### PR TITLE
fix(ci): add refactor to patch bump and validate version prefix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
             BUMP_TYPE="major"
           elif echo "$PR_TITLE" | grep -qE '^feat(\(.+\))?:'; then
             BUMP_TYPE="minor"
-          elif echo "$PR_TITLE" | grep -qE '^fix(\(.+\))?:'; then
+          elif echo "$PR_TITLE" | grep -qE '^(fix|refactor)(\(.+\))?:'; then
             BUMP_TYPE="patch"
           else
             BUMP_TYPE="none"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -53,3 +53,44 @@ jobs:
           fi
 
           echo "✓ PR title format is valid"
+
+      - name: Check version bump prefix for code changes
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # plugins 또는 common 디렉토리에 변경이 있는지 확인
+          CHANGED_FILES=$(gh pr diff ${{ github.event.pull_request.number }} --name-only)
+
+          HAS_CODE_CHANGES=false
+          if echo "$CHANGED_FILES" | grep -qE '^(plugins/|common/)'; then
+            HAS_CODE_CHANGES=true
+          fi
+
+          echo "Changed files:"
+          echo "$CHANGED_FILES"
+          echo ""
+          echo "Has code changes in plugins/ or common/: $HAS_CODE_CHANGES"
+
+          if [ "$HAS_CODE_CHANGES" = "true" ]; then
+            # 버전업을 트리거하는 prefix인지 확인 (feat, fix, refactor, major)
+            if ! echo "$PR_TITLE" | grep -qE '^(feat|fix|refactor|major)(\(.+\))?:'; then
+              echo ""
+              echo "::error::Code changes in plugins/ or common/ require a version bump prefix"
+              echo ""
+              echo "Your PR title: $PR_TITLE"
+              echo ""
+              echo "Version bump prefixes:"
+              echo "  major: breaking changes (bumps major version)"
+              echo "  feat:  new features (bumps minor version)"
+              echo "  fix:   bug fixes (bumps patch version)"
+              echo "  refactor: code refactoring (bumps patch version)"
+              echo ""
+              echo "Non-version prefixes (docs, style, test, ci, chore, etc.) are only"
+              echo "allowed for changes that don't affect plugins/ or common/ directories."
+              exit 1
+            fi
+            echo "✓ Version bump prefix is valid for code changes"
+          else
+            echo "✓ No code changes in plugins/ or common/, any prefix is allowed"
+          fi


### PR DESCRIPTION
## Summary
- `refactor` prefix를 patch 버전업 트리거로 추가
- `plugins/` 또는 `common/` 디렉토리 변경 시 버전업 prefix 필수 검증 추가

## Changes
### release.yml
- `refactor` prefix가 patch 버전업을 트리거하도록 수정

### validate.yml  
- PR에서 코드 변경(`plugins/`, `common/`)이 있을 때 버전업 prefix(`feat`, `fix`, `refactor`, `major`) 필수
- 잘못된 prefix 사용 시 명확한 에러 메시지 출력

## Test plan
- [ ] `refactor:` prefix PR이 patch 버전업 트리거하는지 확인
- [ ] `docs:` prefix로 plugins/ 변경 시 PR 실패하는지 확인
- [ ] `feat:` prefix로 plugins/ 변경 시 PR 통과하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)