### PR TITLE
fix(codex): add --skip-git-repo-check option for non-repo environments

### DIFF
--- a/common/scripts/call-codex.sh
+++ b/common/scripts/call-codex.sh
@@ -61,7 +61,7 @@ fi
 
 # Codex CLI 호출
 echo "OpenAI Codex 호출 중..." >&2
-echo "$FULL_PROMPT" | codex exec - > "$OUTPUT_FILE" 2>&1
+echo "$FULL_PROMPT" | codex exec --skip-git-repo-check - > "$OUTPUT_FILE" 2>&1
 
 # 파일 경로 반환 (stdout)
 echo "$OUTPUT_FILE"


### PR DESCRIPTION
## Summary
- Codex CLI가 기본적으로 git repository 내에서만 실행되도록 설계되어 있어 non-repo 환경에서 오류 발생
- `--skip-git-repo-check` 옵션을 추가하여 git repo가 아닌 환경에서도 Codex 실행 가능
- sandbox에서 읽기 전용 작업만 수행하므로 안전하게 적용 가능

## Test plan
- [ ] git repo가 아닌 디렉토리에서 Codex 호출 테스트
- [ ] 기존 git repo 내 Codex 호출이 정상 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)