### PR TITLE
fix(bumpversion): update plugin.json for all plugins regardless of strict flag

### DIFF
--- a/tools/bumpversion/internal/bumper/bumper.go
+++ b/tools/bumpversion/internal/bumper/bumper.go
@@ -84,28 +84,27 @@ func (b *Bumper) bumpPlugin(pkg changes.Package, bumpType BumpType, marketplace 
 		Plugin: pkg.Name,
 	}
 
-	// Check if plugin has strict: false in marketplace.json
-	isStrictFalse := b.isPluginStrictFalse(marketplace, pkg.Name)
-
 	// Find plugin.json path
 	pluginJSONPath := filepath.Join(b.RepoRoot, pkg.Path, ".claude-plugin", "plugin.json")
 	result.PluginJSON = pluginJSONPath
 
 	var currentVersion string
 	var pluginData map[string]interface{}
+	pluginJSONExists := false
 
-	if isStrictFalse {
-		// For strict: false plugins, read version from marketplace.json
-		currentVersion = b.getMarketplacePluginVersion(marketplace, pkg.Name)
-		result.PluginJSON = "(managed by marketplace.json)"
-	} else {
-		// Read current version from plugin.json
-		var err error
+	// Try to read plugin.json if it exists
+	if _, err := os.Stat(pluginJSONPath); err == nil {
+		pluginJSONExists = true
 		pluginData, err = b.loadJSON(pluginJSONPath)
 		if err != nil {
 			return result, fmt.Errorf("failed to load plugin.json: %w", err)
 		}
 		currentVersion, _ = pluginData["version"].(string)
+	}
+
+	// If plugin.json doesn't exist or has no version, try marketplace.json
+	if currentVersion == "" {
+		currentVersion = b.getMarketplacePluginVersion(marketplace, pkg.Name)
 	}
 
 	if currentVersion == "" {
@@ -121,8 +120,8 @@ func (b *Bumper) bumpPlugin(pkg changes.Package, bumpType BumpType, marketplace 
 	result.NewVersion = newVersion
 
 	if !b.DryRun {
-		// Update plugin.json only if not strict: false
-		if !isStrictFalse {
+		// Update plugin.json if it exists
+		if pluginJSONExists {
 			pluginData["version"] = newVersion
 			if err := b.saveJSON(pluginJSONPath, pluginData); err != nil {
 				return result, fmt.Errorf("failed to save plugin.json: %w", err)
@@ -139,29 +138,6 @@ func (b *Bumper) bumpPlugin(pkg changes.Package, bumpType BumpType, marketplace 
 	return result, nil
 }
 
-// isPluginStrictFalse checks if a plugin has strict: false in marketplace.json
-func (b *Bumper) isPluginStrictFalse(marketplace map[string]interface{}, pluginName string) bool {
-	plugins, ok := marketplace["plugins"].([]interface{})
-	if !ok {
-		return false
-	}
-
-	for _, p := range plugins {
-		plugin, ok := p.(map[string]interface{})
-		if !ok {
-			continue
-		}
-
-		name, _ := plugin["name"].(string)
-		if name == pluginName {
-			strict, ok := plugin["strict"].(bool)
-			// strict defaults to true, so only return true if explicitly set to false
-			return ok && !strict
-		}
-	}
-
-	return false
-}
 
 // getMarketplacePluginVersion gets the version of a plugin from marketplace.json
 func (b *Bumper) getMarketplacePluginVersion(marketplace map[string]interface{}, pluginName string) string {


### PR DESCRIPTION
Previously, plugins with strict: false in marketplace.json were not
getting their plugin.json updated during version bumps. This caused
version consistency validation failures in CI because marketplace.json
and plugin.json had different versions.

Now bumpversion updates plugin.json whenever it exists, ensuring
version consistency across both files.