### PR TITLE
feat(team-claude): add project-level hooks configuration to setup

### DIFF
--- a/plugins/team-claude/skills/setup/init-mode.md
+++ b/plugins/team-claude/skills/setup/init-mode.md
@@ -141,6 +141,111 @@ cp -r ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/* .team-claude/hooks/
 chmod +x .team-claude/hooks/*.sh
 ```
 
+### 프로젝트 hooks 설정
+
+`.claude/settings.local.json`에 hooks 설정을 추가합니다:
+
+```bash
+# .claude 디렉토리 생성
+mkdir -p .claude
+
+# 기존 settings.local.json이 있으면 병합, 없으면 생성
+if [ -f .claude/settings.local.json ]; then
+  # 기존 파일에 hooks 병합
+  jq '.hooks = {
+    "Stop": [
+      {
+        "type": "command",
+        "command": ".team-claude/hooks/on-worker-complete.sh"
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "AskUserQuestion",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".team-claude/hooks/on-worker-question.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".team-claude/hooks/on-validation-complete.sh",
+            "condition": "tool_input.command.includes('\''test'\'')"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "matcher": "idle_prompt",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".team-claude/hooks/on-worker-idle.sh"
+          }
+        ]
+      }
+    ]
+  }' .claude/settings.local.json > .claude/settings.local.json.tmp
+  mv .claude/settings.local.json.tmp .claude/settings.local.json
+else
+  # 새로 생성
+  cat > .claude/settings.local.json << 'EOF'
+{
+  "hooks": {
+    "Stop": [
+      {
+        "type": "command",
+        "command": ".team-claude/hooks/on-worker-complete.sh"
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "AskUserQuestion",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".team-claude/hooks/on-worker-question.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".team-claude/hooks/on-validation-complete.sh",
+            "condition": "tool_input.command.includes('test')"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "matcher": "idle_prompt",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".team-claude/hooks/on-worker-idle.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+EOF
+fi
+```
+
 ---
 
 ## 완료 메시지
@@ -157,7 +262,8 @@ chmod +x .team-claude/hooks/*.sh
   └── agents/
 
   .claude/
-  └── team-claude.yaml
+  ├── team-claude.yaml
+  └── settings.local.json (hooks 설정)
 
 📊 감지된 프로젝트 정보:
   • 언어: {language}


### PR DESCRIPTION
## Summary

- 프로젝트 레벨 hooks 설정을 `.claude/settings.local.json`에 생성하도록 init-mode 수정
- 기존 settings.local.json이 있으면 `jq`로 병합, 없으면 새로 생성
- 완료 메시지에 settings.local.json 파일 추가 표시

## 변경 사항

### Step 4: Hook 설정
- `.claude/settings.local.json`에 hooks 설정 추가
- Stop, PreToolUse, PostToolUse, Notification 이벤트에 대한 hook 구성

### hooks 설정 내용
| Event | Matcher | Script |
|-------|---------|--------|
| Stop | - | on-worker-complete.sh |
| PreToolUse | AskUserQuestion | on-worker-question.sh |
| PostToolUse | Bash (test) | on-validation-complete.sh |
| Notification | idle_prompt | on-worker-idle.sh |

## 배경

기존에는 hooks.json이 플러그인 레벨에서만 정의되어 실제 프로젝트의 .claude 폴더에 설정이 적용되지 않았습니다. 이 변경으로 `/team-claude:setup` 실행 시 프로젝트에 hooks 설정이 직접 생성됩니다.

## Test plan

- [ ] `/team-claude:setup` 실행
- [ ] `cat .claude/settings.local.json` 으로 hooks 설정 확인
- [ ] hook 이벤트 발생 시 스크립트 실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)