### PR TITLE
fix(team-claude): remove invalid keys from plugin.json manifest

### DIFF
--- a/plugins/team-claude/plugin.json
+++ b/plugins/team-claude/plugin.json
@@ -2,41 +2,7 @@
   "name": "team-claude",
   "version": "0.2.0",
   "description": "팀 클루드: Contract 기반 설계, Worker 자율 RALPH, Semi-Auto 머지",
-  "commands": [
-    "commands/setup.md",
-    "commands/architect.md",
-    "commands/delegate.md",
-    "commands/merge.md",
-    "commands/checkpoint.md",
-    "commands/loop-status.md"
-  ],
-  "configFile": ".claude/team-claude.yaml",
-  "agents": [
-    "agents/spec-validator.md",
-    "agents/test-oracle.md",
-    "agents/impl-reviewer.md",
-    "agents/conflict-analyzer.md"
-  ],
-  "hooks": "hooks/hooks.json",
-  "skills": [
-    "skills/feedback-routing/SKILL.md"
-  ],
-  "dependencies": [],
-  "config": {
-    "autoFeedbackLoop": {
-      "enabled": true,
-      "maxIterations": 5,
-      "checkpointValidation": true,
-      "autoRouteOnComplete": true
-    },
-    "architectLoop": {
-      "requireHumanApproval": ["architecture", "contracts", "checkpoints"],
-      "autoProgress": ["implementation", "test"]
-    },
-    "delegation": {
-      "autoValidateOnComplete": true,
-      "autoRetryOnFail": true,
-      "maxRetries": 3
-    }
+  "author": {
+    "name": "kys0213"
   }
 }


### PR DESCRIPTION
## Summary
- team-claude 플러그인 설치 시 발생하는 manifest 유효성 검사 오류 수정
- Claude Code 플러그인 스키마에서 지원하지 않는 필드들 제거
- 제거된 필드: `commands`, `agents`, `skills`, `hooks` (자동 검색됨), `configFile`, `dependencies`, `config` (미지원)

## Test plan
- [ ] `claude plugin install plugins/team-claude` 명령으로 설치 테스트
- [ ] 플러그인 설치 후 commands, agents, skills, hooks가 정상적으로 자동 검색되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)