### PR TITLE
fix(team-claude): add missing 'hooks' wrapper key in hooks.json

### DIFF
--- a/plugins/team-claude/hooks/hooks.json
+++ b/plugins/team-claude/hooks/hooks.json
@@ -1,55 +1,55 @@
 {
-  "description": "Team Claude 이벤트 훅",
+  "hooks": {
+    "Stop": [
+      {
+        "description": "Worker 완료 시 자동 검증 트리거",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".team-claude/hooks/on-worker-complete.sh"
+          }
+        ]
+      }
+    ],
 
-  "Stop": [
-    {
-      "description": "Worker 완료 시 자동 검증 트리거",
-      "hooks": [
-        {
-          "type": "command",
-          "command": ".team-claude/hooks/on-worker-complete.sh"
-        }
-      ]
-    }
-  ],
+    "PreToolUse": [
+      {
+        "matcher": "AskUserQuestion",
+        "description": "Worker 질문 시 에스컬레이션",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".team-claude/hooks/on-worker-question.sh"
+          }
+        ]
+      }
+    ],
 
-  "PreToolUse": [
-    {
-      "matcher": "AskUserQuestion",
-      "description": "Worker 질문 시 에스컬레이션",
-      "hooks": [
-        {
-          "type": "command",
-          "command": ".team-claude/hooks/on-worker-question.sh"
-        }
-      ]
-    }
-  ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "description": "검증 명령어 실행 후 결과 분석",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".team-claude/hooks/on-validation-complete.sh",
+            "condition": "tool_input.command.includes('test')"
+          }
+        ]
+      }
+    ],
 
-  "PostToolUse": [
-    {
-      "matcher": "Bash",
-      "description": "검증 명령어 실행 후 결과 분석",
-      "hooks": [
-        {
-          "type": "command",
-          "command": ".team-claude/hooks/on-validation-complete.sh",
-          "condition": "tool_input.command.includes('test')"
-        }
-      ]
-    }
-  ],
-
-  "Notification": [
-    {
-      "matcher": "idle_prompt",
-      "description": "Worker 대기 상태 감지",
-      "hooks": [
-        {
-          "type": "command",
-          "command": ".team-claude/hooks/on-worker-idle.sh"
-        }
-      ]
-    }
-  ]
+    "Notification": [
+      {
+        "matcher": "idle_prompt",
+        "description": "Worker 대기 상태 감지",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".team-claude/hooks/on-worker-idle.sh"
+          }
+        ]
+      }
+    ]
+  }
 }


### PR DESCRIPTION
Claude Code requires hooks.json to have a top-level 'hooks' key that
wraps all event types. The previous structure caused a validation error:
"expected record, received undefined" when loading hooks.