### PR TITLE
chore: add .omc and tsbuildinfo to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 # Output directories
 .review-output/
 .team-claude/
+.omc/
+
+# Build artifacts
+tsconfig.tsbuildinfo
+*.tsbuildinfo
 
 # Local settings
 *.local.md


### PR DESCRIPTION
## Summary
- `.omc/` 디렉토리 gitignore 추가 (OMC 상태 파일)
- `*.tsbuildinfo` gitignore 추가 (TypeScript 빌드 아티팩트)

## Test plan
- [ ] `git status`에서 해당 파일들이 untracked로 표시되지 않음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)