### PR TITLE
fix(cli): improve bun detection in tc doctor

### DIFF
--- a/plugins/team-claude/cli/src/commands/doctor.ts
+++ b/plugins/team-claude/cli/src/commands/doctor.ts
@@ -75,6 +75,25 @@ function checkCommandWithWhich(cmd: string): boolean {
   }
 }
 
+function checkBunAtCommonPaths(): boolean {
+  const homedir = process.env.HOME || "";
+  const commonPaths = [
+    `${homedir}/.bun/bin/bun`,
+    "/usr/local/bin/bun",
+    "/opt/homebrew/bin/bun",
+  ];
+
+  for (const path of commonPaths) {
+    try {
+      const result = Bun.spawnSync([path, "--version"]);
+      if (result.exitCode === 0) return true;
+    } catch {
+      continue;
+    }
+  }
+  return false;
+}
+
 /**
  * 인프라 검사: yq, jq, git, bun, curl 설치 여부
  */
@@ -83,7 +102,10 @@ export function checkInfrastructure(): DiagnosticCheck[] {
   const commands = ["yq", "jq", "git", "bun", "curl"];
 
   for (const cmd of commands) {
-    const installed = checkCommand(cmd) || checkCommandWithWhich(cmd);
+    const installed =
+      checkCommand(cmd) ||
+      checkCommandWithWhich(cmd) ||
+      (cmd === "bun" && checkBunAtCommonPaths());
     checks.push({
       category: "infrastructure",
       name: cmd,


### PR DESCRIPTION
## Summary
- bun이 PATH에 없을 때도 일반적인 설치 경로에서 감지하도록 개선
- 확인 경로: `~/.bun/bin/bun`, `/usr/local/bin/bun`, `/opt/homebrew/bin/bun`

## Problem
컴파일된 tc 바이너리가 `~/.zshrc`를 로드하지 않아 bun PATH를 상속받지 못함
→ bun이 설치되어 있어도 `tc doctor`에서 "미설치"로 표시

## Test plan
- [x] `tc doctor`에서 bun이 ✓로 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)