### PR TITLE
refactor(validation): make name field optional for commands and agents

### DIFF
--- a/tools/validate/internal/spec/validator.go
+++ b/tools/validate/internal/spec/validator.go
@@ -302,7 +302,7 @@ func validateAgentMD(filePath string) Result {
 		return result
 	}
 
-	errors := parser.ValidateFrontmatter(parsed.Frontmatter, []string{"name", "description"})
+	errors := parser.ValidateFrontmatter(parsed.Frontmatter, []string{"description"})
 	result.Errors = append(result.Errors, errors...)
 
 	// tools must be array
@@ -342,7 +342,7 @@ func validateCommandMD(filePath string) Result {
 		return result
 	}
 
-	errors := parser.ValidateFrontmatter(parsed.Frontmatter, []string{"name", "description"})
+	errors := parser.ValidateFrontmatter(parsed.Frontmatter, []string{"description"})
 	result.Errors = append(result.Errors, errors...)
 
 	// allowed-tools must be array


### PR DESCRIPTION
## Summary

- Remove `name` from required frontmatter fields for agent and command `.md` files in the Go validator
- Claude Code infers names from filenames automatically, making the `name` field redundant
- Skills and hooks retain `name` as a required field (no change)
- Add test cases: agent without name, command without name, command with qualified name, and skill-without-name regression test

## Test plan

- [x] `make build` passes
- [x] `make test` passes — all new and existing tests green
- [ ] Merge this PR before PR#2 (`refactor/remove-name-frontmatter`) so `make validate` passes when name fields are removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)