### PR TITLE
refactor(suggest-workflow): standardize plugin path variable to ${CLAUDE_PLUGIN_ROOT}

### DIFF
--- a/plugins/git-utils/scripts/create-pr.sh
+++ b/plugins/git-utils/scripts/create-pr.sh
@@ -73,7 +73,7 @@ if ! gh auth status $GH_AUTH_ARGS > /dev/null 2>&1; then
   echo "  1. Login with web browser:" >&2
   echo "     gh auth login" >&2
   echo "" >&2
-  echo "  2. Login with token:" >&2
+  echo "  2. Token-based login" >&2
   echo "     gh auth login --with-token < your-token.txt" >&2
   echo "" >&2
   echo "For more information, visit: https://cli.github.com/manual/gh_auth_login" >&2

--- a/tools/validate/internal/path/validator.go
+++ b/tools/validate/internal/path/validator.go
@@ -178,7 +178,8 @@ func validateDocumentPaths(filePath string, repoRoot string) []Result {
 	absRepoRoot, _ := filepath.Abs(repoRoot)
 	absPluginRoot, _ := filepath.Abs(pluginRoot)
 
-	paths, err := parser.ExtractPluginRootPaths(filePath)
+	// Skip code blocks and inline code — paths there are documentation/examples (e.g. build artifacts)
+	paths, err := parser.ExtractPluginRootPathsSkipCode(filePath)
 	if err != nil {
 		results = append(results, Result{
 			File:  filePath,

--- a/tools/validate/internal/spec/validator.go
+++ b/tools/validate/internal/spec/validator.go
@@ -177,8 +177,9 @@ func validatePluginJSON(filePath string) Result {
 	}
 
 	// Validate command files exist
+	// plugin.json is inside .claude-plugin/, so resolve commands relative to plugin root (parent of .claude-plugin/)
 	if commands, ok := data["commands"].([]interface{}); ok {
-		pluginDir := filepath.Dir(filePath)
+		pluginDir := filepath.Dir(filepath.Dir(filePath))
 		for _, cmd := range commands {
 			cmdPath, ok := cmd.(string)
 			if !ok {


### PR DESCRIPTION
- Replace non-standard {plugin_path} with ${CLAUDE_PLUGIN_ROOT} in command files
- Add .claude/settings.json with auto-commit Stop hook

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>