### PR TITLE
feat(develop-workflow): add gate-based phase enforcement with hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,6 +8,11 @@
             "type": "command",
             "command": "bash ./.claude/hooks/default-branch-guard-hook.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "node ./plugins/develop-workflow/hooks/develop-phase-gate.cjs",
+            "timeout": 5
           }
         ]
       },
@@ -17,6 +22,11 @@
           {
             "type": "command",
             "command": "bash ./.claude/hooks/default-branch-guard-commit-hook.sh",
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "node ./plugins/develop-workflow/hooks/develop-phase-gate.cjs",
             "timeout": 5
           }
         ]

--- a/plugins/develop-workflow/.claude-plugin/plugin.json
+++ b/plugins/develop-workflow/.claude-plugin/plugin.json
@@ -4,7 +4,7 @@
   },
   "description": "통합 개발 워크플로우: 설계 → 리뷰 → 구현 → 머지를 하나의 파이프라인으로",
   "name": "develop-workflow",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "commands": [
     "./commands/setup.md",
     "./commands/outline.md",

--- a/plugins/develop-workflow/commands/implement.md
+++ b/plugins/develop-workflow/commands/implement.md
@@ -51,59 +51,60 @@ Contract(Interface + Test Code)를 기반으로 구현을 실행합니다. 태�
 
 ## 상태 관리
 
-RALPH 루프의 진행 상황을 `.develop-workflow/state.yaml`에 기록합니다.
+RALPH 루프의 진행 상황을 `.develop-workflow/state.json`에 기록합니다.
 compaction이나 세션 재개 시 "어디까지 했는지"를 복원하기 위함입니다.
 
 ### 상태 기록 규칙
 
 ```
 Checkpoint 시작
-    │ → state.yaml: cp-N status를 in_progress로, iteration을 1로
+    │ → state.json: cp-N status를 in_progress로, iteration을 1로
     │
     ▼
 RALPH iteration 실행
     │
     ├── Pass
-    │   → state.yaml: cp-N status를 passed로
+    │   → state.json: cp-N status를 passed로
     │   → 다음 Checkpoint
     │
     └── Fail
-        → state.yaml: cp-N iteration 증가
+        → state.json: cp-N iteration 증가
         │
         ├── iteration < max_retries
         │   → 다음 RALPH iteration
         │
         └── iteration >= max_retries
-            → state.yaml: cp-N status를 escalated로
+            → state.json: cp-N status를 escalated로
             → 사용자에게 에스컬레이션
 ```
 
 ### 기록 예시
 
 Checkpoint 시작 시:
-```yaml
-# Edit .develop-workflow/state.yaml
-checkpoints:
-  cp-1: { status: in_progress, iteration: 1 }
+```json
+// Edit .develop-workflow/state.json
+{ "checkpoints": { "cp-1": { "status": "in_progress", "iteration": 1 } } }
 ```
 
 RALPH 실패 후 재시도:
-```yaml
-checkpoints:
-  cp-1: { status: in_progress, iteration: 2 }
+```json
+{ "checkpoints": { "cp-1": { "status": "in_progress", "iteration": 2 } } }
 ```
 
 Checkpoint 통과:
-```yaml
-checkpoints:
-  cp-1: { status: passed, iteration: 2 }
-  cp-2: { status: in_progress, iteration: 1 }   # 다음 CP 시작
+```json
+{
+  "checkpoints": {
+    "cp-1": { "status": "passed", "iteration": 2 },
+    "cp-2": { "status": "in_progress", "iteration": 1 }
+  }
+}
 ```
 
 ### 세션 재개 시
 
 ```
-state.yaml 읽기
+state.json 읽기
     │
     ├── passed 항목 → 건너뜀
     ├── in_progress 항목 → 해당 iteration부터 RALPH 재개
@@ -124,13 +125,13 @@ state.yaml 읽기
 │   P: Patch    - 구현 코드 작성
 │   H: Halt     - 검증 실행
 │       │
-│       ├── Pass → state.yaml 갱신 (passed) → 다음 Checkpoint
-│       └── Fail → state.yaml 갱신 (iteration++) → 원인 분석
+│       ├── Pass → state.json 갱신 (status: passed) → 다음 Checkpoint
+│       └── Fail → state.json 갱신 (iteration++) → 원인 분석
 │                   │
 └───────────────────┘ (최대 3회)
 ```
 
-최대 재시도(기본 3회) 초과 시 state.yaml에 `escalated` 기록 후 사용자에게 에스컬레이션합니다.
+최대 재시도(기본 3회) 초과 시 state.json에 `escalated` 기록 후 사용자에게 에스컬레이션합니다.
 
 ---
 

--- a/plugins/develop-workflow/commands/setup.md
+++ b/plugins/develop-workflow/commands/setup.md
@@ -86,7 +86,7 @@ hook 설치 범위를 선택하세요.
 | settings.json 위치 | `.claude/settings.json` | `~/.claude/settings.json` |
 | hook 스크립트 경로 | 상대경로 (`./plugins/...`) | 절대경로 bake-in |
 | 팀 공유 | git commit으로 공유 가능 | 불가 (개인 설정) |
-| 적용 범위 | 이 프로젝트만 | 모든 프로젝트 (state.yaml 없으면 자동 스킵) |
+| 적용 범위 | 이 프로젝트만 | 모든 프로젝트 (state.json 없으면 자동 스킵) |
 
 ## Step 4: Hook 등록
 
@@ -125,9 +125,9 @@ develop-workflow hook이 프로젝트에 설정되었습니다!
 └─ .claude/settings.json (hook 등록됨)
 
 SessionStart Hook:
-├─ 세션 시작 시 .develop-workflow/state.yaml 감지
+├─ 세션 시작 시 .develop-workflow/state.json 감지
 ├─ 진행 중인 워크플로우가 있으면 상태를 표시
-└─ state.yaml이 없으면 자동 스킵
+└─ state.json이 없으면 자동 스킵
 
 .claude/ 디렉토리를 git에 커밋하면 팀과 설정을 공유할 수 있습니다.
 ```
@@ -142,9 +142,9 @@ develop-workflow hook이 사용자 설정에 등록되었습니다!
 └─ ~/.claude/settings.json (hook 등록됨)
 
 SessionStart Hook:
-├─ 세션 시작 시 .develop-workflow/state.yaml 감지
+├─ 세션 시작 시 .develop-workflow/state.json 감지
 ├─ 진행 중인 워크플로우가 있으면 상태를 표시
-└─ state.yaml이 없으면 자동 스킵 (git 저장소가 아니어도 안전)
+└─ state.json이 없으면 자동 스킵 (git 저장소가 아니어도 안전)
 ```
 
 ## 예시 실행 흐름

--- a/plugins/develop-workflow/hooks/detect-ralph-state.sh
+++ b/plugins/develop-workflow/hooks/detect-ralph-state.sh
@@ -1,17 +1,44 @@
 #!/usr/bin/env bash
-# SessionStart hook: RALPH 워크플로우 상태 감지
-# state.yaml이 있으면 에이전트에게 현재 상태를 알려줍니다.
+# SessionStart hook: 워크플로우 상태 감지
+# state.json이 있으면 에이전트에게 현재 상태를 알려줍니다.
 
-STATE_FILE=".develop-workflow/state.yaml"
+STATE_FILE=".develop-workflow/state.json"
 
 if [ ! -f "$STATE_FILE" ]; then
   exit 0
 fi
 
-PHASE=$(grep '^phase:' "$STATE_FILE" | sed 's/phase: *//')
-FEATURE=$(grep '^feature:' "$STATE_FILE" | sed 's/feature: *//' | tr -d '"')
-STRATEGY=$(grep '^strategy:' "$STATE_FILE" | sed 's/strategy: *//')
-UPDATED=$(grep '^updated_at:' "$STATE_FILE" | sed 's/updated_at: *//' | tr -d '"')
+# node가 있으면 JSON 파싱, 없으면 grep 폴백
+if command -v node >/dev/null 2>&1; then
+  PARSED=$(node -e "
+    const s = JSON.parse(require('fs').readFileSync('$STATE_FILE','utf8'));
+    console.log('PHASE=' + (s.phase || ''));
+    console.log('FEATURE=' + (s.feature || ''));
+    console.log('STRATEGY=' + (s.strategy || ''));
+    console.log('UPDATED=' + (s.updated_at || ''));
+    console.log('GATE_REVIEW=' + (s.gates && s.gates.review_clean_pass ? 'true' : 'false'));
+    console.log('GATE_ARCHITECT=' + (s.gates && s.gates.architect_verified ? 'true' : 'false'));
+    console.log('GATE_RE_REVIEW=' + (s.gates && s.gates.re_review_clean ? 'true' : 'false'));
+    if (s.checkpoints) {
+      Object.entries(s.checkpoints).forEach(([k,v]) => {
+        console.log('CP=' + k + '|' + (v.status||'pending') + '|' + (v.iteration||0));
+      });
+    }
+  " 2>/dev/null)
+
+  eval "$(echo "$PARSED" | grep -E '^(PHASE|FEATURE|STRATEGY|UPDATED|GATE_)=')"
+  CPS=$(echo "$PARSED" | grep '^CP=')
+else
+  # node 없을 때 grep 폴백 (제한적 파싱)
+  PHASE=$(grep -o '"phase"[[:space:]]*:[[:space:]]*"[^"]*"' "$STATE_FILE" | head -1 | sed 's/.*: *"//;s/"//')
+  FEATURE=$(grep -o '"feature"[[:space:]]*:[[:space:]]*"[^"]*"' "$STATE_FILE" | head -1 | sed 's/.*: *"//;s/"//')
+  STRATEGY=$(grep -o '"strategy"[[:space:]]*:[[:space:]]*"[^"]*"' "$STATE_FILE" | head -1 | sed 's/.*: *"//;s/"//')
+  UPDATED=$(grep -o '"updated_at"[[:space:]]*:[[:space:]]*"[^"]*"' "$STATE_FILE" | head -1 | sed 's/.*: *"//;s/"//')
+  GATE_REVIEW="unknown"
+  GATE_ARCHITECT="unknown"
+  GATE_RE_REVIEW="unknown"
+  CPS=""
+fi
 
 # DONE이면 알림만
 if [ "$PHASE" = "DONE" ]; then
@@ -29,15 +56,20 @@ echo "  Phase   : $PHASE"
 [ -n "$STRATEGY" ] && echo "  Strategy: $STRATEGY"
 echo "  Updated : $UPDATED"
 echo ""
+echo "  Gates:"
+gate_icon() { [ "$1" = "true" ] && echo "PASS" || echo "    "; }
+echo "    [$(gate_icon "$GATE_REVIEW")] review_clean_pass"
+echo "    [$(gate_icon "$GATE_ARCHITECT")] architect_verified"
+echo "    [$(gate_icon "$GATE_RE_REVIEW")] re_review_clean"
+echo ""
 
-# Checkpoint 상태 파싱
-if grep -q 'checkpoints:' "$STATE_FILE"; then
+# Checkpoint 상태 표시
+if [ -n "$CPS" ]; then
   echo "  Checkpoints:"
-  # YAML의 checkpoint 라인들 추출
-  grep -E '^\s+cp-' "$STATE_FILE" | while IFS= read -r line; do
-    CP_ID=$(echo "$line" | sed 's/:.*//' | tr -d ' ')
-    STATUS=$(echo "$line" | grep -o 'status: [a-z_]*' | sed 's/status: //')
-    ITER=$(echo "$line" | grep -o 'iteration: [0-9]*' | sed 's/iteration: //')
+  echo "$CPS" | while IFS= read -r line; do
+    CP_ID=$(echo "$line" | cut -d'|' -f1 | sed 's/^CP=//')
+    STATUS=$(echo "$line" | cut -d'|' -f2)
+    ITER=$(echo "$line" | cut -d'|' -f3)
     case "$STATUS" in
       passed)      ICON="PASS" ;;
       in_progress) ICON=">>  " ;;
@@ -50,6 +82,6 @@ if grep -q 'checkpoints:' "$STATE_FILE"; then
   echo ""
 fi
 
-echo "  .develop-workflow/state.yaml 을 Read tool로 읽어 상세 상태를 확인하세요."
+echo "  .develop-workflow/state.json 을 Read tool로 읽어 상세 상태를 확인하세요."
 echo "  사용자에게 이어서 진행할지 물어보세요."
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/plugins/develop-workflow/hooks/develop-phase-gate.cjs
+++ b/plugins/develop-workflow/hooks/develop-phase-gate.cjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+/**
+ * develop-phase-gate.cjs
+ *
+ * PreToolUse hook: state.json의 gate 조건이 미충족이면 Write/Edit/Bash를 차단합니다.
+ *
+ * Matcher별 동작:
+ *   Write|Edit → phase 진입 gate 검증
+ *   Bash       → 종료 명령(git push, gh pr create, git commit) gate 검증
+ *
+ * state.json이 없으면 워크플로우 비활성 상태로 간주하여 통과(exit 0).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const STATE_PATH = path.join(process.cwd(), '.develop-workflow', 'state.json');
+
+// ── 1. 워크플로우 비활성이면 통과 ──────────────────────────────
+if (!fs.existsSync(STATE_PATH)) {
+  process.exit(0);
+}
+
+let state;
+try {
+  state = JSON.parse(fs.readFileSync(STATE_PATH, 'utf8'));
+} catch {
+  // 파싱 실패 시 차단하지 않음 (state.json이 깨진 경우 워크플로우 외부에서 수정 가능)
+  process.exit(0);
+}
+
+const { phase, gates } = state;
+if (!phase || !gates) {
+  process.exit(0);
+}
+
+// ── 2. stdin에서 tool_input 읽기 ──────────────────────────────
+let input = '';
+try {
+  input = fs.readFileSync('/dev/stdin', 'utf8');
+} catch {
+  // stdin 읽기 실패 시 통과
+  process.exit(0);
+}
+
+let toolInput;
+try {
+  toolInput = JSON.parse(input);
+} catch {
+  process.exit(0);
+}
+
+const toolName = toolInput.tool_name || '';
+const command = (toolInput.tool_input && toolInput.tool_input.command) || '';
+
+// ── 3. Phase 진입 gate 규칙 ──────────────────────────────────
+const ENTRY_RULES = {
+  IMPLEMENT: ['review_clean_pass'],
+  MERGE: ['review_clean_pass', 'architect_verified'],
+};
+
+// ── 4. 종료 명령 gate 규칙 ──────────────────────────────────
+const EXIT_COMMANDS = /\b(git\s+push|gh\s+pr\s+create|git\s+commit)\b/;
+
+const EXIT_RULES = {
+  MERGE: ['re_review_clean'],
+};
+
+// ── 5. Write|Edit 차단 로직 ──────────────────────────────────
+if (toolName === 'Write' || toolName === 'Edit') {
+  const required = ENTRY_RULES[phase] || [];
+  const blocked = required.filter(g => !gates[g]);
+
+  if (blocked.length > 0) {
+    process.stderr.write(
+      `\n[PHASE GATE] ${phase} phase에서 파일 수정이 차단되었습니다.\n` +
+      `미충족 gate: ${blocked.join(', ')}\n` +
+      `state.json의 해당 gate를 true로 업데이트한 후 다시 시도하세요.\n\n`
+    );
+    process.exit(1);
+  }
+}
+
+// ── 6. Bash 종료 명령 차단 로직 ──────────────────────────────
+if (toolName === 'Bash' && EXIT_COMMANDS.test(command)) {
+  const required = EXIT_RULES[phase] || [];
+  const entryRequired = ENTRY_RULES[phase] || [];
+  const allRequired = [...new Set([...entryRequired, ...required])];
+  const blocked = allRequired.filter(g => !gates[g]);
+
+  if (blocked.length > 0) {
+    process.stderr.write(
+      `\n[PHASE GATE] ${phase} phase에서 종료 명령이 차단되었습니다.\n` +
+      `차단된 명령: ${command.substring(0, 80)}\n` +
+      `미충족 gate: ${blocked.join(', ')}\n` +
+      `모든 gate를 통과한 후 다시 시도하세요.\n\n`
+    );
+    process.exit(1);
+  }
+}
+
+// ── 7. 통과 ──────────────────────────────────────────────────
+process.exit(0);

--- a/plugins/develop-workflow/skills/feature-workflow/SKILL.md
+++ b/plugins/develop-workflow/skills/feature-workflow/SKILL.md
@@ -15,7 +15,7 @@ version: 1.0.0
 세션 시작/재개 시 `detect-ralph-state.sh` 훅이 자동 실행됩니다.
 훅 출력에 "진행 중인 워크플로우 감지"가 포함되면:
 
-1. `.develop-workflow/state.yaml`을 Read tool로 읽기
+1. `.develop-workflow/state.json`을 Read tool로 읽기
 2. 사용자에게 현재 상태 보고
 3. 이어서 진행할지 `AskUserQuestion`으로 확인
 
@@ -23,11 +23,11 @@ version: 1.0.0
 
 컨텍스트 압축 후 RALPH 워크플로우 진행 상황이 불명확해지면:
 
-1. **즉시** `.develop-workflow/state.yaml`을 Read tool로 읽기
+1. **즉시** `.develop-workflow/state.json`을 Read tool로 읽기
 2. 현재 Phase, Checkpoint 상태, iteration 확인
 3. passed는 건너뛰고 in_progress부터 재개
 
-**감지 신호**: 다음 중 하나라도 해당하면 state.yaml을 재확인합니다:
+**감지 신호**: 다음 중 하나라도 해당하면 state.json을 재확인합니다:
 - RALPH 워크플로우를 실행 중이었는데 현재 Phase/Checkpoint가 기억나지 않을 때
 - Checkpoint 번호나 iteration 횟수가 불확실할 때
 - "이전 컨텍스트가 요약되었습니다" 류의 메시지가 보일 때

--- a/plugins/develop-workflow/templates/state-management.md
+++ b/plugins/develop-workflow/templates/state-management.md
@@ -1,30 +1,36 @@
 # 상태 관리 가이드
 
-`.develop-workflow/state.yaml` 1개 파일로 워크플로우 상태를 추적합니다.
+`.develop-workflow/state.json` 1개 파일로 워크플로우 상태를 추적합니다.
 compaction이나 세션 재개 시 "어디까지 했는지"를 복원하기 위한 최소 정보만 기록합니다.
 
 ## 설계 원칙
 
-1. **파일 1개만**: `.develop-workflow/state.yaml`이 유일한 상태 파일
+1. **파일 1개만**: `.develop-workflow/state.json`이 유일한 상태 파일
 2. **최소 기록**: "어디까지 했는지"만 기록. 피드백 상세, 설계 내용은 기록하지 않음
 3. **재분석 가능**: 실패 원인 등은 다시 분석하면 되므로 결과만 기록
 4. **Phase 전환 + RALPH iteration 경계에서만 갱신**: 불필요한 I/O 최소화
+5. **Gate 기반 Phase 차단**: `gates` 필드로 다음 Phase 진입을 물리적으로 제어
 
-## state.yaml 스키마
+## state.json 스키마
 
-```yaml
-# .develop-workflow/state.yaml
-
-phase: IMPLEMENT              # DESIGN | REVIEW | IMPLEMENT | MERGE | DONE
-strategy: subagent            # direct | subagent | agent-teams (Phase 3 전용)
-feature: "실시간 채팅 기능"     # 사용자 요청 요약 (세션 재개 시 컨텍스트)
-started_at: "2026-02-16T10:00:00"
-updated_at: "2026-02-16T11:30:00"
-
-checkpoints:                  # Phase 2에서 Checkpoint 정의 후 초기화
-  cp-1: { status: passed, iteration: 2 }
-  cp-2: { status: in_progress, iteration: 1 }
-  cp-3: { status: pending, iteration: 0 }
+```json
+{
+  "phase": "IMPLEMENT",
+  "strategy": "subagent",
+  "feature": "실시간 채팅 기능",
+  "started_at": "2026-02-16T10:00:00",
+  "updated_at": "2026-02-16T11:30:00",
+  "gates": {
+    "review_clean_pass": true,
+    "architect_verified": false,
+    "re_review_clean": false
+  },
+  "checkpoints": {
+    "cp-1": { "status": "passed", "iteration": 2 },
+    "cp-2": { "status": "in_progress", "iteration": 1 },
+    "cp-3": { "status": "pending", "iteration": 0 }
+  }
+}
 ```
 
 ### 필드 설명
@@ -36,7 +42,27 @@ checkpoints:                  # Phase 2에서 Checkpoint 정의 후 초기화
 | `feature` | string | 사용자 요청 요약 (재개 시 컨텍스트) |
 | `started_at` | ISO 8601 | 워크플로우 시작 시각 |
 | `updated_at` | ISO 8601 | 마지막 갱신 시각 |
+| `gates` | object | Phase Gate 조건 (Hook이 검증) |
 | `checkpoints` | map | Checkpoint별 상태 |
+
+### Gates 필드
+
+Phase 간 전환을 물리적으로 제어하는 조건입니다.
+`develop-phase-gate.cjs` hook이 PreToolUse 시점에 검증합니다.
+
+| Gate | 설정 시점 | 용도 |
+|------|----------|------|
+| `review_clean_pass` | Phase 2 리뷰에서 Blocking 이슈 0개 | Phase 3 IMPLEMENT 진입 허용 |
+| `architect_verified` | Phase 3 Architect 검증 통과 | Phase 4 MERGE 진입 허용 |
+| `re_review_clean` | Phase 4 코드 리뷰 clean pass | PR 생성/push 허용 |
+
+### Gate 검증 매트릭스
+
+| Phase | Matcher | 필수 Gate | 차단 대상 |
+|-------|---------|-----------|----------|
+| IMPLEMENT | Write\|Edit | `review_clean_pass` | 파일 수정 |
+| MERGE | Write\|Edit | `review_clean_pass` + `architect_verified` | 파일 수정 |
+| MERGE | Bash (git push/gh pr/git commit) | `re_review_clean` | 종료 명령 |
 
 ### Checkpoint 상태
 
@@ -57,20 +83,23 @@ checkpoints:                  # Phase 2에서 Checkpoint 정의 후 초기화
 ### Phase 전환 시
 
 ```
-Phase 1 시작 → Write state.yaml (phase: DESIGN, feature 기록)
-Phase 2 진입 → Edit state.yaml (phase: REVIEW, checkpoints 초기화)
-Phase 3 진입 → Edit state.yaml (phase: IMPLEMENT, strategy 기록)
-Phase 4 진입 → Edit state.yaml (phase: MERGE)
-완료          → Edit state.yaml (phase: DONE)
+Phase 1 시작 → Write state.json (phase: DESIGN, feature, gates 초기화)
+Phase 2 진입 → Edit state.json (phase: REVIEW, checkpoints 초기화)
+Phase 2 통과 → Edit state.json (gates.review_clean_pass: true)
+Phase 3 진입 → Edit state.json (phase: IMPLEMENT, strategy 기록)
+Phase 3 통과 → Edit state.json (gates.architect_verified: true)
+Phase 4 진입 → Edit state.json (phase: MERGE)
+Phase 4 통과 → Edit state.json (gates.re_review_clean: true)
+완료          → Edit state.json (phase: DONE)
 ```
 
 ### RALPH iteration 경계에서
 
 ```
-CP 시작     → Edit state.yaml (cp-N: in_progress, iteration: 1)
-검증 통과   → Edit state.yaml (cp-N: passed)
-검증 실패   → Edit state.yaml (cp-N: iteration 증가)
-재시도 초과 → Edit state.yaml (cp-N: escalated)
+CP 시작     → Edit state.json (cp-N: in_progress, iteration: 1)
+검증 통과   → Edit state.json (cp-N: passed)
+검증 실패   → Edit state.json (cp-N: iteration 증가)
+재시도 초과 → Edit state.json (cp-N: escalated)
 ```
 
 ## 세션 재개 흐름
@@ -78,19 +107,20 @@ CP 시작     → Edit state.yaml (cp-N: in_progress, iteration: 1)
 ```
 /develop 실행
     │
-    ├── state.yaml 없음 → 새 워크플로우
+    ├── state.json 없음 → 새 워크플로우
     │
-    ├── phase: DONE → "이전 완료. 새로 시작합니다." → state.yaml 삭제 → 새 워크플로우
+    ├── phase: DONE → "이전 완료. 새로 시작합니다." → state.json 삭제 → 새 워크플로우
     │
     └── phase: DESIGN | REVIEW | IMPLEMENT | MERGE
         │
         ▼
         사용자에게 보고:
         "이전 세션: '{feature}', Phase {phase}"
+        "Gates: review_clean_pass={}, architect_verified={}, re_review_clean={}"
         "Checkpoints: cp-1 passed, cp-2 in_progress (iter 1/3), cp-3 pending"
         │
         ├── AskUserQuestion: "이어서 진행" → 해당 지점부터 재개
-        └── AskUserQuestion: "처음부터"   → state.yaml 삭제 → 새 워크플로우
+        └── AskUserQuestion: "처음부터"   → state.json 삭제 → 새 워크플로우
 ```
 
 ### 재개 시 Phase별 동작
@@ -109,8 +139,8 @@ CP 시작     → Edit state.yaml (cp-N: in_progress, iteration: 1)
 
 Claude Code가 컨텍스트를 압축할 때:
 1. 대화 히스토리의 상세 내용이 요약됨
-2. **state.yaml은 파일이므로 영향 없음**
-3. 압축 후 state.yaml을 읽으면 "어디까지 했는지" 복원 가능
+2. **state.json은 파일이므로 영향 없음**
+3. 압축 후 state.json을 읽으면 "어디까지 했는지" 복원 가능
 4. 피드백 상세는 유실되지만, 다시 분석하면 됨
 
 ```
@@ -120,7 +150,7 @@ Compaction 발생
 컨텍스트 요약됨 (피드백 상세 유실)
     │
     ▼
-state.yaml 읽기 → "cp-2가 iteration 1에서 in_progress"
+state.json 읽기 → "cp-2가 iteration 1에서 in_progress"
     │
     ▼
 cp-2의 현재 코드와 테스트를 다시 읽음
@@ -134,7 +164,7 @@ RALPH 계속 (피드백은 재분석)
 ```
 프로젝트 루트/
 └── .develop-workflow/
-    └── state.yaml        ← 이것만
+    └── state.json        ← 이것만
 ```
 
 > `.gitignore`에 `.develop-workflow/` 추가를 권장합니다.


### PR DESCRIPTION
- Add develop-phase-gate.cjs PreToolUse hook that physically blocks
  Write/Edit/Bash based on state.json gates (review_clean_pass,
  architect_verified, re_review_clean)
- Register phase gate hook in .claude/settings.json for Write|Edit
  and Bash matchers
- Migrate state.yaml to state.json with gates field for machine-
  readable phase control
- Update develop.md with gate logic, Blocking/Warning/Info review
  classification, and Phase 4 review loop with re_review_clean gate
- Update detect-ralph-state.sh to parse state.json with node (grep
  fallback) and display gates status
- Update implement.md, setup.md, SKILL.md references from state.yaml
  to state.json
- Bump plugin version to 0.3.0

https://claude.ai/code/session_018SaaDqcxL51To8ypHNp4JT