### PR TITLE
fix(autonomous): resolve gh api, UTF-8 panic, env leak, and stuck recovery

### DIFF
--- a/plugins/autonomous/cli/Cargo.lock
+++ b/plugins/autonomous/cli/Cargo.lock
@@ -117,7 +117,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autodev"
-version = "0.1.0"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/plugins/autonomous/cli/Cargo.toml
+++ b/plugins/autonomous/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "autodev"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 
 [lib]

--- a/plugins/autonomous/cli/src/queue/schema.rs
+++ b/plugins/autonomous/cli/src/queue/schema.rs
@@ -51,6 +51,7 @@ pub fn create_tables(conn: &Connection) -> Result<()> {
             branch_name     TEXT,
             pr_number       INTEGER,
             error_message   TEXT,
+            retry_count     INTEGER NOT NULL DEFAULT 0,
             created_at      TEXT NOT NULL,
             updated_at      TEXT NOT NULL
         );
@@ -68,6 +69,7 @@ pub fn create_tables(conn: &Connection) -> Result<()> {
             status          TEXT NOT NULL DEFAULT 'pending',
             worker_id       TEXT,
             error_message   TEXT,
+            retry_count     INTEGER NOT NULL DEFAULT 0,
             created_at      TEXT NOT NULL,
             updated_at      TEXT NOT NULL
         );
@@ -83,6 +85,7 @@ pub fn create_tables(conn: &Connection) -> Result<()> {
             conflict_files  TEXT,
             worker_id       TEXT,
             error_message   TEXT,
+            retry_count     INTEGER NOT NULL DEFAULT 0,
             created_at      TEXT NOT NULL,
             updated_at      TEXT NOT NULL
         );

--- a/plugins/autonomous/cli/src/scanner/issues.rs
+++ b/plugins/autonomous/cli/src/scanner/issues.rs
@@ -42,6 +42,7 @@ pub async fn scan(
         "api".to_string(),
         format!("repos/{repo_name}/issues"),
         "--paginate".to_string(),
+        "--method".to_string(), "GET".to_string(),
         "-f".to_string(), "state=open".to_string(),
         "-f".to_string(), "sort=updated".to_string(),
         "-f".to_string(), "direction=desc".to_string(),

--- a/plugins/autonomous/cli/src/scanner/pulls.rs
+++ b/plugins/autonomous/cli/src/scanner/pulls.rs
@@ -41,6 +41,7 @@ pub async fn scan(
         "api".to_string(),
         format!("repos/{repo_name}/pulls"),
         "--paginate".to_string(),
+        "--method".to_string(), "GET".to_string(),
         "-f".to_string(), "state=open".to_string(),
         "-f".to_string(), "sort=updated".to_string(),
         "-f".to_string(), "direction=desc".to_string(),

--- a/plugins/autonomous/cli/src/session/mod.rs
+++ b/plugins/autonomous/cli/src/session/mod.rs
@@ -22,6 +22,7 @@ pub async fn run_claude(
     let result = tokio::process::Command::new("claude")
         .args(&args)
         .current_dir(cwd)
+        .env_remove("CLAUDECODE")
         .output()
         .await?;
 
@@ -51,6 +52,10 @@ fn truncate(s: &str, max: usize) -> &str {
     if s.len() <= max {
         s
     } else {
-        &s[..max]
+        let mut end = max;
+        while end > 0 && !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        &s[..end]
     }
 }


### PR DESCRIPTION
- Add --method GET to gh api calls to prevent HTTP 422 (#62)
- Fix UTF-8 truncate panic on multi-byte chars (#62)
- Add missing fields to repo_update_config: gh_host, scan_targets,
  filter_labels, ignore_authors (#62)
- Remove CLAUDECODE env var from child claude -p processes (#63)
- Add stuck state recovery on daemon startup (#64)
- Add auto-retry for failed items with retry_count (max 3) (#64)
- Add retry_count column to all queue tables schema (#64)
- Bump CLI version to 0.2.3

Closes #62
Closes #63
Closes #64

https://claude.ai/code/session_01NYhsY5eaQfqBy78arsHW2Q