### PR TITLE
fix(autodev): improve /auto-setup wizard (repo add --config, duplicate error, GHE detection)

### DIFF
--- a/plugins/autodev/cli/src/main.rs
+++ b/plugins/autodev/cli/src/main.rs
@@ -82,6 +82,9 @@ enum RepoAction {
     Add {
         /// 레포 URL
         url: String,
+        /// 초기 설정 JSON (WorkflowConfig 형식)
+        #[arg(long)]
+        config: Option<String>,
     },
     /// 등록된 레포 목록
     List,
@@ -167,8 +170,8 @@ async fn main() -> Result<()> {
         }
         Commands::Dashboard => tui::run(&db).await?,
         Commands::Repo { action } => match action {
-            RepoAction::Add { url } => {
-                client::repo_add(&db, &url)?;
+            RepoAction::Add { url, config } => {
+                client::repo_add(&db, &env, &url, config.as_deref())?;
             }
             RepoAction::List => {
                 let list = client::repo_list(&db)?;


### PR DESCRIPTION
- Add --config flag to `repo add` for initial setup JSON, writes
  .develop-workflow.yaml to workspace directory automatically
- Replace raw SQLite UNIQUE constraint error with friendly message
  on duplicate repo registration
- Improve GHE host detection: use `gh auth status` to match
  authenticated hosts instead of string-matching "github"
- Update auto-setup Step 9 to use --config with WorkflowConfig
  structure so gh_host is properly persisted

Closes #90

https://claude.ai/code/session_01UgVGfiwBYgjSkkQyB7rjvY