### PR TITLE
fix(autodev): close design-v2 implementation gaps

### DIFF
--- a/plugins/autodev/cli/src/components/workspace.rs
+++ b/plugins/autodev/cli/src/components/workspace.rs
@@ -16,6 +16,11 @@ impl<'a> Workspace<'a> {
         Self { git, env }
     }
 
+    /// 내부 Git 인프라 참조 반환
+    pub fn git(&self) -> &'a dyn Git {
+        self.git
+    }
+
     /// 레포의 base clone 경로
     pub fn repo_base_path(&self, repo_name: &str) -> PathBuf {
         let sanitized = config::sanitize_repo_name(repo_name);

--- a/plugins/autodev/cli/src/daemon/recovery.rs
+++ b/plugins/autodev/cli/src/daemon/recovery.rs
@@ -62,3 +62,126 @@ pub async fn recover_orphan_wip(
 
     Ok(recovered)
 }
+
+/// Orphan `autodev:implementing` 이슈 복구
+///
+/// 크래시로 인해 `autodev:implementing` 라벨이 남아있지만 연결된 PR이 이미
+/// merged/closed인 이슈를 찾아 `autodev:done`으로 전이한다.
+/// 연결 PR 마커(`<!-- autodev:pr-link:{N} -->`)가 없는 경우 implementing 라벨을 제거하여
+/// 다음 scan에서 재시도하도록 한다.
+pub async fn recover_orphan_implementing(
+    repos: &[EnabledRepo],
+    gh: &dyn Gh,
+    queues: &TaskQueues,
+    gh_host: Option<&str>,
+) -> Result<u64> {
+    let mut recovered = 0u64;
+
+    for repo in repos {
+        let params = &[
+            ("labels", labels::IMPLEMENTING),
+            ("state", "open"),
+            ("per_page", "100"),
+        ];
+
+        let data = match gh.api_paginate(&repo.name, "issues", params, gh_host).await {
+            Ok(d) => d,
+            Err(e) => {
+                tracing::warn!("implementing recovery scan failed for {}: {e}", repo.name);
+                continue;
+            }
+        };
+
+        let items: Vec<serde_json::Value> = serde_json::from_slice(&data).unwrap_or_default();
+
+        for item in items {
+            if item.get("pull_request").is_some() {
+                continue; // PR 제외
+            }
+
+            let number = match item["number"].as_i64() {
+                Some(n) if n > 0 => n,
+                _ => continue,
+            };
+
+            let work_id = make_work_id("issue", &repo.name, number);
+            if queues.contains(&work_id) {
+                continue; // 큐에 있으면 skip
+            }
+
+            // 이슈 코멘트에서 pr-link 마커 추출
+            match extract_pr_link_from_comments(gh, &repo.name, number, gh_host).await {
+                Some(pr_num) => {
+                    // 연결 PR 상태 확인
+                    let pr_state = get_pr_state(gh, &repo.name, pr_num, gh_host).await;
+                    match pr_state.as_deref() {
+                        Some("closed") | Some("merged") => {
+                            gh.label_remove(&repo.name, number, labels::IMPLEMENTING, gh_host)
+                                .await;
+                            gh.label_add(&repo.name, number, labels::DONE, gh_host)
+                                .await;
+                            recovered += 1;
+                            tracing::info!(
+                                "recovered implementing issue #{number} in {} (PR #{pr_num} {})",
+                                repo.name,
+                                pr_state.as_deref().unwrap_or("unknown")
+                            );
+                        }
+                        _ => {
+                            // PR이 아직 open → skip (PR pipeline이 처리)
+                        }
+                    }
+                }
+                None => {
+                    // pr-link 마커 없음 → implementing 제거 (다음 scan에서 재시도)
+                    gh.label_remove(&repo.name, number, labels::IMPLEMENTING, gh_host)
+                        .await;
+                    recovered += 1;
+                    tracing::info!(
+                        "recovered orphan implementing issue #{number} in {} (no pr-link marker)",
+                        repo.name
+                    );
+                }
+            }
+        }
+    }
+
+    Ok(recovered)
+}
+
+/// 이슈 코멘트에서 `<!-- autodev:pr-link:{N} -->` 마커를 추출하여 PR 번호 반환
+async fn extract_pr_link_from_comments(
+    gh: &dyn Gh,
+    repo_name: &str,
+    number: i64,
+    gh_host: Option<&str>,
+) -> Option<i64> {
+    let jq = r#"[.[] | select(.body | contains("<!-- autodev:pr-link:")) | .body] | last"#;
+    let body = gh
+        .api_get_field(repo_name, &format!("issues/{number}/comments"), jq, gh_host)
+        .await?;
+    // <!-- autodev:pr-link:42 --> 에서 42 추출
+    let start = body.find("<!-- autodev:pr-link:")? + "<!-- autodev:pr-link:".len();
+    let end = body[start..].find(" -->").map(|i| start + i)?;
+    body[start..end].trim().parse().ok()
+}
+
+/// PR의 state를 조회 ("open", "closed", "merged" 등)
+async fn get_pr_state(
+    gh: &dyn Gh,
+    repo_name: &str,
+    pr_number: i64,
+    gh_host: Option<&str>,
+) -> Option<String> {
+    // merged 여부를 먼저 확인
+    let merged = gh
+        .api_get_field(repo_name, &format!("pulls/{pr_number}"), ".merged", gh_host)
+        .await;
+    if merged.as_deref() == Some("true") {
+        return Some("merged".to_string());
+    }
+
+    // state 필드 조회
+    gh.api_get_field(repo_name, &format!("pulls/{pr_number}"), ".state", gh_host)
+        .await
+}

--- a/plugins/autodev/cli/src/knowledge/daily.rs
+++ b/plugins/autodev/cli/src/knowledge/daily.rs
@@ -364,7 +364,6 @@ pub async fn create_knowledge_prs(
 ///
 /// 당일 knowledge 코멘트들에서 target_file 기준으로 그룹핑하여
 /// 2회 이상 등장하는 패턴을 감지한다.
-#[allow(dead_code)]
 pub fn detect_cross_task_patterns(suggestions: &[super::models::Suggestion]) -> Vec<Pattern> {
     let mut file_counts: std::collections::HashMap<&str, Vec<&str>> =
         std::collections::HashMap::new();

--- a/plugins/autodev/cli/src/pipeline/mod.rs
+++ b/plugins/autodev/cli/src/pipeline/mod.rs
@@ -27,7 +27,7 @@ pub async fn process_all(
 ) -> Result<()> {
     // Issue: Phase 1 (분석) → Phase 2 (구현)
     issue::process_pending(db, env, workspace, notifier, gh, claude, queues).await?;
-    issue::process_ready(db, env, workspace, gh, claude, sw, queues).await?;
+    issue::process_ready(db, env, workspace, notifier, gh, claude, sw, queues).await?;
 
     // PR: 리뷰 → 개선 → 재리뷰 사이클
     pr::process_pending(db, env, workspace, notifier, gh, claude, sw, queues).await?;

--- a/plugins/autodev/cli/src/pipeline/pr.rs
+++ b/plugins/autodev/cli/src/pipeline/pr.rs
@@ -165,6 +165,7 @@ pub async fn process_pending(
                                 let _ = crate::knowledge::extractor::extract_task_knowledge(
                                     claude,
                                     gh,
+                                    workspace.git(),
                                     sw,
                                     &item.repo_name,
                                     item.github_number,
@@ -464,6 +465,7 @@ pub async fn process_improved(
                             let _ = crate::knowledge::extractor::extract_task_knowledge(
                                 claude,
                                 gh,
+                                workspace.git(),
                                 sw,
                                 &item.repo_name,
                                 item.github_number,

--- a/plugins/autodev/cli/tests/resource_cleanup_tests.rs
+++ b/plugins/autodev/cli/tests/resource_cleanup_tests.rs
@@ -518,15 +518,25 @@ async fn issue_ready_cleans_up_worktree() {
     claude.enqueue_response(r#"{"suggestions":[]}"#, 0);
 
     let workspace = Workspace::new(&git, &env);
+    let notifier = Notifier::new(&gh);
     let sw = MockSuggestWorkflow::new();
     let mut queues = TaskQueues::new();
     queues
         .issues
         .push(issue_phase::READY, make_issue_item(&repo_id, 90));
 
-    autodev::pipeline::issue::process_ready(&db, &env, &workspace, &gh, &claude, &sw, &mut queues)
-        .await
-        .unwrap();
+    autodev::pipeline::issue::process_ready(
+        &db,
+        &env,
+        &workspace,
+        &notifier,
+        &gh,
+        &claude,
+        &sw,
+        &mut queues,
+    )
+    .await
+    .unwrap();
 
     // Issue pipeline은 항상 worktree 정리 수행 (올바른 동작)
     assert!(


### PR DESCRIPTION
Phase 1: process_ready() keeps implementing label on issue until PR
approve instead of immediately transitioning to done. Adds pr-link
comment for recovery tracking and find_existing_pr() API fallback.

Phase 2: recover_orphan_implementing() detects issues stuck in
implementing state with merged/closed PRs and transitions them to done.

Phase 3: extract_pr_number() gains JSON pr_number field fallback
pattern for when URL pattern is absent from Claude output.

Phase 4: collect_existing_knowledge() extended to read hooks.json,
.claude-plugin/ configs, and .develop-workflow.yaml. Empty suggestions
now return None to skip unnecessary comment posting.

Phase 5: Per-task actionable PR creation from knowledge suggestions.
detect_cross_task_patterns() wired into daily report flow.

https://claude.ai/code/session_016inTaih89zvMWpbSsu9fpt