### PR TITLE
fix(autodev): validate knowledge PR target_file to prevent path traversal

### DIFF
--- a/plugins/autodev/cli/src/knowledge/extractor.rs
+++ b/plugins/autodev/cli/src/knowledge/extractor.rs
@@ -332,7 +332,16 @@ async fn create_task_knowledge_prs(
             continue;
         }
 
-        let file_path = kn_wt_path.join(target);
+        let file_path = match crate::config::safe_join(&kn_wt_path, target) {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::warn!("task knowledge PR: unsafe target_file '{target}': {e}");
+                let _ = workspace
+                    .remove_worktree(repo_name, &knowledge_task_id)
+                    .await;
+                continue;
+            }
+        };
         if let Some(parent) = file_path.parent() {
             let _ = std::fs::create_dir_all(parent);
         }


### PR DESCRIPTION
Add safe_join() utility that rejects absolute paths, `..` components,
and any path escaping the worktree base directory. Apply to both
daily and per-task knowledge PR creation paths.

Closes #128

https://claude.ai/code/session_01Nb5DrvtK6HY9BZZYHtMwao