### PR TITLE
fix(autodev): warn on config type errors and auto-detect review plugins

### DIFF
--- a/plugins/autodev/cli/src/config/loader.rs
+++ b/plugins/autodev/cli/src/config/loader.rs
@@ -19,7 +19,13 @@ pub fn load_merged(env: &dyn Env, repo_path: Option<&Path>) -> WorkflowConfig {
     };
 
     // 머지된 YAML Value → WorkflowConfig (serde(default)가 미지정 필드 채움)
-    serde_json::from_value(merged).unwrap_or_default()
+    match serde_json::from_value::<WorkflowConfig>(merged) {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            tracing::warn!("config deserialization failed, falling back to defaults: {e}");
+            WorkflowConfig::default()
+        }
+    }
 }
 
 /// 글로벌 YAML을 raw JSON Value로 로드


### PR DESCRIPTION
- Replace unwrap_or_default() with explicit match + tracing::warn
  in config loader to surface deserialization errors (#131)
- Add tests for type mismatch, nested field errors, and unknown fields
- Restructure auto-setup Step 2 to auto-detect installed review
  plugins by scanning plugin cache directory (#114)
- Make Step 7 workflow selection dynamic based on detected plugins
- Include workflow/develop config in Step 9 registration command

Closes #131
Closes #114

https://claude.ai/code/session_01TnBX7hQahwuq4SG4PRh5GR