### PR TITLE
feat(autodev): add DEBUG logging for config loading path and gh_host resolution

### DIFF
--- a/plugins/autodev/cli/src/domain/git_repository_factory.rs
+++ b/plugins/autodev/cli/src/domain/git_repository_factory.rs
@@ -40,6 +40,10 @@ fn resolve_gh_host(env: &dyn Env, repo_name: &str) -> Option<String> {
         if let Some(ref cache) = *guard {
             if let Some(entry) = cache.get(repo_name) {
                 if entry.mtime == current_mtime {
+                    tracing::debug!(
+                        "[config] resolve_gh_host({repo_name}): cache hit → {:?}",
+                        entry.value
+                    );
                     return entry.value.clone();
                 }
             }
@@ -56,6 +60,7 @@ fn resolve_gh_host(env: &dyn Env, repo_name: &str) -> Option<String> {
         },
     );
     let value = cfg.consumer.gh_host;
+    tracing::debug!("[config] resolve_gh_host({repo_name}): loaded → {value:?}");
 
     // 캐시 갱신
     {


### PR DESCRIPTION
config/loader.rs의 load_merged()에 글로벌/레포별 config 경로와
로드 결과를 DEBUG 로깅하고, git_repository_factory.rs의
resolve_gh_host()에 캐시 히트/미스와 최종 값을 DEBUG 로깅한다.

#142 같은 gh_host 누락 문제를 로그만으로 즉시 진단할 수 있게 한다.

Closes #143

https://claude.ai/code/session_01EYJjxMAG82rMwDjHRXNcwo