### PR TITLE
refactor(autodev): rename config file from .develop-workflow.yaml to .autodev.yaml

### DIFF
--- a/plugins/autodev/CONFIG-SCHEMA-v2.md
+++ b/plugins/autodev/CONFIG-SCHEMA-v2.md
@@ -1,4 +1,4 @@
-# Config Schema v2: `.develop-workflow.yaml`
+# Config Schema v2: `.autodev.yaml`
 
 > **Date**: 2026-03-02
 > **Status**: Draft
@@ -48,8 +48,8 @@ workflows:    # autodev 파이프라인 단계별 실행 방식
 `.claude/` 설정과 동일한 패턴으로, 글로벌 기본값 위에 레포별 오버라이드를 deep merge한다:
 
 ```
-~/.develop-workflow.yaml              ← 글로벌 기본값
-  └── <repo>/.develop-workflow.yaml   ← 레포별 오버라이드 (deep merge)
+~/.autodev.yaml              ← 글로벌 기본값
+  └── <repo>/.autodev.yaml   ← 레포별 오버라이드 (deep merge)
 ```
 
 레포 설정에서 명시한 필드만 글로벌 값을 덮어쓴다. 명시하지 않은 필드는 글로벌 → default 순으로 적용된다.
@@ -184,7 +184,7 @@ workflows:
 
 ## 6. 레포별 오버라이드 예시
 
-### 글로벌 설정 (`~/.develop-workflow.yaml`)
+### 글로벌 설정 (`~/.autodev.yaml`)
 
 ```yaml
 daemon:
@@ -206,7 +206,7 @@ workflows:
     max_iterations: 2
 ```
 
-### Frontend 레포 오버라이드 (`frontend-app/.develop-workflow.yaml`)
+### Frontend 레포 오버라이드 (`frontend-app/.autodev.yaml`)
 
 ```yaml
 sources:
@@ -218,7 +218,7 @@ workflows:
     max_iterations: 3     # UI 리뷰는 반복 횟수를 늘림
 ```
 
-### OSS 레포 오버라이드 (`oss-lib/.develop-workflow.yaml`)
+### OSS 레포 오버라이드 (`oss-lib/.autodev.yaml`)
 
 ```yaml
 workflows:

--- a/plugins/autodev/cli/src/client/mod.rs
+++ b/plugins/autodev/cli/src/client/mod.rs
@@ -80,15 +80,15 @@ pub fn repo_add(
         let ws_dir = config::workspaces_path(env).join(config::sanitize_repo_name(&name));
         std::fs::create_dir_all(&ws_dir)?;
         let yaml = serde_yaml::to_string(&value)?;
-        std::fs::write(ws_dir.join(".develop-workflow.yaml"), yaml)?;
+        std::fs::write(ws_dir.join(config::CONFIG_FILENAME), yaml)?;
         println!("registered: {name} ({url})");
         println!(
             "config: written to {}",
-            ws_dir.join(".develop-workflow.yaml").display()
+            ws_dir.join(config::CONFIG_FILENAME).display()
         );
     } else {
         println!("registered: {name} ({url})");
-        println!("config: edit ~/.develop-workflow.yaml (global) or <repo>/.develop-workflow.yaml (per-repo)");
+        println!("config: edit ~/.autodev.yaml (global) or <repo>/.autodev.yaml (per-repo)");
     }
 
     Ok(())
@@ -125,7 +125,7 @@ pub fn repo_config(env: &dyn Env, name: &str) -> Result<()> {
 
     // 워크스페이스에서 레포별 설정 탐색
     let ws = config::workspaces_path(env).join(config::sanitize_repo_name(name));
-    let repo_config_path = ws.join(".develop-workflow.yaml");
+    let repo_config_path = ws.join(config::CONFIG_FILENAME);
     println!("\nRepo config: {}", repo_config_path.display());
 
     if repo_config_path.exists() {

--- a/plugins/autodev/cli/src/config/loader.rs
+++ b/plugins/autodev/cli/src/config/loader.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use super::models::WorkflowConfig;
 use super::Env;
 
-const CONFIG_FILENAME: &str = ".develop-workflow.yaml";
+pub const CONFIG_FILENAME: &str = ".autodev.yaml";
 
 /// 글로벌(~/) + 레포별 YAML을 머지하여 최종 설정 반환
 /// Raw YAML Value 단계에서 딥머지 → 최종 역직렬화

--- a/plugins/autodev/cli/src/config/mod.rs
+++ b/plugins/autodev/cli/src/config/mod.rs
@@ -1,6 +1,8 @@
 pub mod loader;
 pub mod models;
 
+pub use loader::CONFIG_FILENAME;
+
 use std::path::{Path, PathBuf};
 
 use self::models::WorkflowConfig;

--- a/plugins/autodev/cli/src/config/models.rs
+++ b/plugins/autodev/cli/src/config/models.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-/// .develop-workflow.yaml의 전체 스키마 (v2)
+/// .autodev.yaml의 전체 스키마 (v2)
 /// 글로벌(~/) + 레포별 오버라이드를 딥머지하여 최종 설정 생성
 ///
 /// v2에서 `commands`, `develop`, `workflow` 섹션을 제거하고

--- a/plugins/autodev/cli/src/domain/git_repository_factory.rs
+++ b/plugins/autodev/cli/src/domain/git_repository_factory.rs
@@ -31,7 +31,7 @@ fn config_mtime(path: &std::path::Path) -> Option<SystemTime> {
 /// 매 tick마다 불필요한 디스크 I/O를 회피한다.
 pub(crate) fn resolve_gh_host(env: &dyn Env, repo_name: &str) -> Option<String> {
     let ws_path = config::workspaces_path(env).join(config::sanitize_repo_name(repo_name));
-    let config_path = ws_path.join(".develop-workflow.yaml");
+    let config_path = ws_path.join(config::CONFIG_FILENAME);
     let current_mtime = config_mtime(&config_path);
 
     // 캐시 조회: mtime 일치하면 재사용

--- a/plugins/autodev/cli/src/knowledge/extractor.rs
+++ b/plugins/autodev/cli/src/knowledge/extractor.rs
@@ -92,11 +92,11 @@ pub fn collect_existing_knowledge(wt_path: &Path) -> String {
         }
     }
 
-    // .develop-workflow.yaml (워크플로우 설정)
-    let workflow_yaml = wt_path.join(".develop-workflow.yaml");
+    // .autodev.yaml (워크플로우 설정)
+    let workflow_yaml = wt_path.join(".autodev.yaml");
     if workflow_yaml.exists() {
         if let Ok(content) = std::fs::read_to_string(&workflow_yaml) {
-            knowledge.push_str("--- .develop-workflow.yaml ---\n");
+            knowledge.push_str("--- .autodev.yaml ---\n");
             knowledge.push_str(&content);
             knowledge.push_str("\n\n");
         }
@@ -384,15 +384,15 @@ mod tests {
         )
         .unwrap();
 
-        // .develop-workflow.yaml
-        std::fs::write(base.join(".develop-workflow.yaml"), "workflow: test").unwrap();
+        // .autodev.yaml
+        std::fs::write(base.join(".autodev.yaml"), "workflow: test").unwrap();
 
         let knowledge = collect_existing_knowledge(base);
         assert!(knowledge.contains(".claude/hooks.json"));
         assert!(knowledge.contains(r#"{"hooks":[]}"#));
         assert!(knowledge.contains(".claude-plugin/plugin.json"));
         assert!(knowledge.contains("workflow: test"));
-        assert!(knowledge.contains(".develop-workflow.yaml"));
+        assert!(knowledge.contains(".autodev.yaml"));
     }
 
     #[test]

--- a/plugins/autodev/cli/tests/cli_tests.rs
+++ b/plugins/autodev/cli/tests/cli_tests.rs
@@ -111,7 +111,7 @@ fn repo_add_with_config_writes_yaml() {
 
     // Verify YAML file was created in workspace
     let ws_dir = home.path().join("workspaces").join("org-myrepo");
-    let yaml_path = ws_dir.join(".develop-workflow.yaml");
+    let yaml_path = ws_dir.join(".autodev.yaml");
     assert!(yaml_path.exists(), "config YAML should be created");
 
     let content = std::fs::read_to_string(&yaml_path).unwrap();

--- a/plugins/autodev/cli/tests/config_loader_tests.rs
+++ b/plugins/autodev/cli/tests/config_loader_tests.rs
@@ -102,7 +102,7 @@ workflows:
   review:
     max_iterations: 5
 "#;
-    fs::write(tmp.path().join(".develop-workflow.yaml"), yaml).unwrap();
+    fs::write(tmp.path().join(".autodev.yaml"), yaml).unwrap();
     let env = TestEnv::new().with_home(tmp.path().to_str().unwrap());
 
     let config = loader::load_merged(&env, None);
@@ -138,7 +138,7 @@ sources:
       - bot1
       - bot2
 "#;
-    fs::write(repo_dir.join(".develop-workflow.yaml"), yaml).unwrap();
+    fs::write(repo_dir.join(".autodev.yaml"), yaml).unwrap();
 
     let config = loader::load_merged(&env, Some(&repo_dir));
     assert_eq!(config.sources.github.scan_interval_secs, 120);
@@ -168,7 +168,7 @@ workflows:
   review:
     max_iterations: 5
 "#;
-    fs::write(tmp.path().join(".develop-workflow.yaml"), global_yaml).unwrap();
+    fs::write(tmp.path().join(".autodev.yaml"), global_yaml).unwrap();
     let env = TestEnv::new().with_home(tmp.path().to_str().unwrap());
 
     // 레포 오버라이드 — model과 max_iterations만 덮어씀
@@ -180,7 +180,7 @@ workflows:
   review:
     max_iterations: 3
 "#;
-    fs::write(repo_dir.join(".develop-workflow.yaml"), repo_yaml).unwrap();
+    fs::write(repo_dir.join(".autodev.yaml"), repo_yaml).unwrap();
 
     let config = loader::load_merged(&env, Some(&repo_dir));
 
@@ -209,7 +209,7 @@ fn load_merged_ignores_malformed_yaml() {
     let env = TestEnv::new().with_home(tmp.path().to_str().unwrap());
 
     // 잘못된 YAML
-    fs::write(repo_dir.join(".develop-workflow.yaml"), "{{invalid yaml!!!").unwrap();
+    fs::write(repo_dir.join(".autodev.yaml"), "{{invalid yaml!!!").unwrap();
 
     // 파싱 실패 시 기본값 반환 (패닉하지 않음)
     let config = loader::load_merged(&env, Some(&repo_dir));
@@ -225,7 +225,7 @@ fn load_merged_empty_yaml_returns_defaults() {
     let env = TestEnv::new().with_home(tmp.path().to_str().unwrap());
 
     // 빈 파일
-    fs::write(repo_dir.join(".develop-workflow.yaml"), "").unwrap();
+    fs::write(repo_dir.join(".autodev.yaml"), "").unwrap();
 
     let config = loader::load_merged(&env, Some(&repo_dir));
     assert_eq!(config.sources.github.scan_interval_secs, 300);
@@ -236,7 +236,7 @@ fn load_merged_partial_yaml_fills_defaults() {
     let tmp = TempDir::new().unwrap();
 
     let yaml = "sources:\n  github:\n    model: gpt-4\n";
-    fs::write(tmp.path().join(".develop-workflow.yaml"), yaml).unwrap();
+    fs::write(tmp.path().join(".autodev.yaml"), yaml).unwrap();
     let env = TestEnv::new().with_home(tmp.path().to_str().unwrap());
 
     let config = loader::load_merged(&env, None);
@@ -263,7 +263,7 @@ daemon:
   tick_interval_secs: 30
   daily_report_hour: 9
 "#;
-    fs::write(tmp.path().join(".develop-workflow.yaml"), yaml).unwrap();
+    fs::write(tmp.path().join(".autodev.yaml"), yaml).unwrap();
     let env = TestEnv::new().with_home(tmp.path().to_str().unwrap());
 
     let config = loader::load_merged(&env, None);
@@ -282,7 +282,7 @@ sources:
     scan_interval_secs: 60
     model: opus
 "#;
-    fs::write(tmp.path().join(".develop-workflow.yaml"), yaml).unwrap();
+    fs::write(tmp.path().join(".autodev.yaml"), yaml).unwrap();
     let env = TestEnv::new().with_home(tmp.path().to_str().unwrap());
 
     let config = loader::load_merged(&env, None);
@@ -302,7 +302,7 @@ fn daemon_config_partial_override() {
 daemon:
   daily_report_hour: 12
 "#;
-    fs::write(tmp.path().join(".develop-workflow.yaml"), yaml).unwrap();
+    fs::write(tmp.path().join(".autodev.yaml"), yaml).unwrap();
     let env = TestEnv::new().with_home(tmp.path().to_str().unwrap());
 
     let config = loader::load_merged(&env, None);
@@ -324,7 +324,7 @@ sources:
   github:
     scan_interval_secs: "oops"
 "#;
-    fs::write(tmp.path().join(".develop-workflow.yaml"), yaml).unwrap();
+    fs::write(tmp.path().join(".autodev.yaml"), yaml).unwrap();
     let env = TestEnv::new().with_home(tmp.path().to_str().unwrap());
 
     // 타입 오류 시에도 패닉 없이 default 반환
@@ -343,7 +343,7 @@ workflows:
   review:
     max_iterations: "not_a_number"
 "#;
-    fs::write(tmp.path().join(".develop-workflow.yaml"), yaml).unwrap();
+    fs::write(tmp.path().join(".autodev.yaml"), yaml).unwrap();
     let env = TestEnv::new().with_home(tmp.path().to_str().unwrap());
 
     let config = loader::load_merged(&env, None);
@@ -375,7 +375,7 @@ workflow:
   issue: builtin
   pr: builtin
 "#;
-    fs::write(tmp.path().join(".develop-workflow.yaml"), yaml).unwrap();
+    fs::write(tmp.path().join(".autodev.yaml"), yaml).unwrap();
     let env = TestEnv::new().with_home(tmp.path().to_str().unwrap());
 
     let config = loader::load_merged(&env, None);
@@ -399,7 +399,7 @@ sources:
     scan_interval_secs: 60
 totally_unknown_field: 42
 "#;
-    fs::write(tmp.path().join(".develop-workflow.yaml"), yaml).unwrap();
+    fs::write(tmp.path().join(".autodev.yaml"), yaml).unwrap();
     let env = TestEnv::new().with_home(tmp.path().to_str().unwrap());
 
     let config = loader::load_merged(&env, None);
@@ -425,7 +425,7 @@ workflows:
     agent: null
     max_iterations: 3
 "#;
-    fs::write(tmp.path().join(".develop-workflow.yaml"), yaml).unwrap();
+    fs::write(tmp.path().join(".autodev.yaml"), yaml).unwrap();
     let env = TestEnv::new().with_home(tmp.path().to_str().unwrap());
 
     let config = loader::load_merged(&env, None);
@@ -460,7 +460,7 @@ workflows:
   review:
     max_iterations: 5
 "#;
-    fs::write(tmp.path().join(".develop-workflow.yaml"), global_yaml).unwrap();
+    fs::write(tmp.path().join(".autodev.yaml"), global_yaml).unwrap();
     let env = TestEnv::new().with_home(tmp.path().to_str().unwrap());
 
     // 레포: review만 오버라이드
@@ -469,7 +469,7 @@ workflows:
   review:
     max_iterations: 3
 "#;
-    fs::write(repo_dir.join(".develop-workflow.yaml"), repo_yaml).unwrap();
+    fs::write(repo_dir.join(".autodev.yaml"), repo_yaml).unwrap();
 
     let config = loader::load_merged(&env, Some(&repo_dir));
 

--- a/plugins/autodev/commands/auto-setup.md
+++ b/plugins/autodev/commands/auto-setup.md
@@ -227,7 +227,7 @@ autodev repo add <url> --config '{"sources":{"github":{"scan_interval_secs":<ste
 autodev repo add <url> --config '{"sources":{"github":{"gh_host":"<detected_host>","scan_interval_secs":<step5>,"issue_concurrency":<step6_issue>,"pr_concurrency":<step6_pr>,"scan_targets":[<step4>]}},"workflows":{"analyze":{"agent":"<step7_analyze_agent>","command":<step7_analyze_cmd>},"review":{"agent":"<step7_review_agent>","command":<step7_review_cmd>}}}'
 ```
 
-등록 성공 시 CLI가 자동으로 워크스페이스 디렉토리(`~/.autodev/workspaces/<org-repo>/`)에 `.develop-workflow.yaml`을 생성합니다.
+등록 성공 시 CLI가 자동으로 워크스페이스 디렉토리(`~/.autodev/workspaces/<org-repo>/`)에 `.autodev.yaml`을 생성합니다.
 
 `--config` 없이 등록한 경우에도 이후 `autodev repo config <name>`으로 설정을 확인하고 수동 편집할 수 있습니다.
 

--- a/plugins/autodev/commands/update.md
+++ b/plugins/autodev/commands/update.md
@@ -24,7 +24,7 @@ bash ${CLAUDE_PLUGIN_ROOT}/scripts/ensure-binary.sh
 
 #### 2-1. 글로벌 설정 점검
 
-`~/.develop-workflow.yaml`이 있으면 읽어서 deprecated 키를 점검합니다.
+`~/.autodev.yaml`이 있으면 읽어서 deprecated 키를 점검합니다.
 
 #### 2-2. 등록된 레포별 설정 점검
 
@@ -36,7 +36,7 @@ autodev repo list
 
 ```bash
 # 각 레포의 워크스페이스 경로
-ls ~/.autodev/workspaces/*/. develop-workflow.yaml 2>/dev/null
+ls ~/.autodev/workspaces/*/.autodev.yaml 2>/dev/null
 ```
 
 #### 2-3. 마이그레이션 규칙 적용


### PR DESCRIPTION
## Summary

- Rename config filename from `.develop-workflow.yaml` to `.autodev.yaml` to align with the independent plugin identity
- Centralize filename as `pub const CONFIG_FILENAME` in `config::loader` and re-export via `config` module to eliminate hardcoded strings
- Update all references across Rust source (6 files), tests (3 files), and documentation (3 files)

## Changed files

**Rust source**: `loader.rs`, `mod.rs`, `models.rs`, `client/mod.rs`, `git_repository_factory.rs`, `extractor.rs`
**Tests**: `config_loader_tests.rs`, `cli_tests.rs`, `extractor.rs` inline tests
**Docs**: `auto-setup.md`, `update.md`, `CONFIG-SCHEMA-v2.md`

## Not changed

- `archive/` directory (historical references)
- Slash command references (`/develop-workflow:*`) — external plugin
- `workflow_resolver.rs` test slash command strings

## Manual migration

```bash
mv ~/.develop-workflow.yaml ~/.autodev.yaml 2>/dev/null
for f in ~/.autodev/workspaces/*/.develop-workflow.yaml; do
  mv "$f" "$(dirname "$f")/.autodev.yaml" 2>/dev/null
done
```

## Test plan

- [x] `cargo test` — 289 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] No remaining `.develop-workflow.yaml` references outside `archive/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)