### PR TITLE
fix(autodev): use gh api for issue_comment and pr_review to support GHE

### DIFF
--- a/plugins/autodev/cli/src/infrastructure/gh/mod.rs
+++ b/plugins/autodev/cli/src/infrastructure/gh/mod.rs
@@ -29,7 +29,7 @@ pub trait Gh: Send + Sync {
         host: Option<&str>,
     ) -> Result<Vec<u8>>;
 
-    /// `gh issue comment {number} --repo {repo} --body {body}`
+    /// `gh api repos/{repo}/issues/{number}/comments --method POST -f body={body}`
     /// 실패해도 계속 진행 (best effort)
     async fn issue_comment(
         &self,
@@ -82,7 +82,7 @@ pub trait Gh: Send + Sync {
         host: Option<&str>,
     ) -> Option<i64>;
 
-    /// `gh pr review {number}` — PR 리뷰 제출
+    /// `gh api repos/{repo}/pulls/{number}/reviews --method POST -f event={event}`
     /// event: `"APPROVE"` | `"REQUEST_CHANGES"` | `"COMMENT"`
     /// GitHub PR UI에서 Approved / Changes Requested 상태를 설정한다.
     async fn pr_review(

--- a/plugins/autodev/cli/src/infrastructure/gh/real.rs
+++ b/plugins/autodev/cli/src/infrastructure/gh/real.rs
@@ -121,13 +121,13 @@ impl Gh for RealGh {
         host: Option<&str>,
     ) -> bool {
         let mut args = vec![
-            "issue".to_string(),
-            "comment".to_string(),
-            number.to_string(),
-            "--repo".to_string(),
-            repo_name.to_string(),
-            "--body".to_string(),
-            body.to_string(),
+            "api".to_string(),
+            format!("repos/{repo_name}/issues/{number}/comments"),
+            "--method".to_string(),
+            "POST".to_string(),
+            "--silent".to_string(),
+            "-f".to_string(),
+            format!("body={body}"),
         ];
 
         if let Some(h) = host {
@@ -136,9 +136,7 @@ impl Gh for RealGh {
         }
 
         tracing::debug!(
-            "[gh:issue_comment] >>> gh issue comment {} --repo {} (body={} bytes)",
-            number,
-            repo_name,
+            "[gh:issue_comment] >>> gh api repos/{repo_name}/issues/{number}/comments (body={} bytes)",
             body.len()
         );
         let start = Instant::now();
@@ -339,66 +337,30 @@ impl Gh for RealGh {
         body: &str,
         host: Option<&str>,
     ) -> bool {
-        let args = match event {
-            "APPROVE" => {
-                let mut a = vec![
-                    "pr".to_string(),
-                    "review".to_string(),
-                    number.to_string(),
-                    "--repo".to_string(),
-                    repo_name.to_string(),
-                    "--approve".to_string(),
-                ];
-                if !body.is_empty() {
-                    a.push("--body".to_string());
-                    a.push(body.to_string());
-                }
-                if let Some(h) = host {
-                    a.push("--hostname".to_string());
-                    a.push(h.to_string());
-                }
-                a
-            }
-            "REQUEST_CHANGES" => {
-                let mut a = vec![
-                    "pr".to_string(),
-                    "review".to_string(),
-                    number.to_string(),
-                    "--repo".to_string(),
-                    repo_name.to_string(),
-                    "--request-changes".to_string(),
-                    "--body".to_string(),
-                    if body.is_empty() {
-                        "Changes requested".to_string()
-                    } else {
-                        body.to_string()
-                    },
-                ];
-                if let Some(h) = host {
-                    a.push("--hostname".to_string());
-                    a.push(h.to_string());
-                }
-                a
-            }
-            _ => {
-                // COMMENT
-                let mut a = vec![
-                    "pr".to_string(),
-                    "review".to_string(),
-                    number.to_string(),
-                    "--repo".to_string(),
-                    repo_name.to_string(),
-                    "--comment".to_string(),
-                    "--body".to_string(),
-                    body.to_string(),
-                ];
-                if let Some(h) = host {
-                    a.push("--hostname".to_string());
-                    a.push(h.to_string());
-                }
-                a
-            }
+        let review_body = match event {
+            "REQUEST_CHANGES" if body.is_empty() => "Changes requested",
+            _ => body,
         };
+
+        let mut args = vec![
+            "api".to_string(),
+            format!("repos/{repo_name}/pulls/{number}/reviews"),
+            "--method".to_string(),
+            "POST".to_string(),
+            "--silent".to_string(),
+            "-f".to_string(),
+            format!("event={event}"),
+        ];
+
+        if !review_body.is_empty() {
+            args.push("-f".to_string());
+            args.push(format!("body={review_body}"));
+        }
+
+        if let Some(h) = host {
+            args.push("--hostname".to_string());
+            args.push(h.to_string());
+        }
 
         tracing::debug!("[gh:pr_review] >>> {repo_name}#{number} event={event}");
         let start = Instant::now();


### PR DESCRIPTION
## Summary

- `gh issue comment` and `gh pr review` do not support the `--hostname` flag, causing **all comment/review posts to silently fail** in GitHub Enterprise environments
- Switched both `issue_comment()` and `pr_review()` in `RealGh` to use `gh api` REST endpoints, which properly support `--hostname`
- This is consistent with all other methods in the file (`label_add`, `label_remove`, `create_issue`, `create_pr`) which already use `gh api`

## Changes

| Method | Before | After |
|--------|--------|-------|
| `issue_comment()` | `gh issue comment --hostname` (unsupported) | `gh api repos/{repo}/issues/{number}/comments --method POST --hostname` |
| `pr_review()` | `gh pr review --hostname` (unsupported) | `gh api repos/{repo}/pulls/{number}/reviews --method POST --hostname` |

## Test plan

- [x] `cargo check` — compiles clean
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] `cargo test` — all 278 tests pass (179 unit + 99 integration)
- [ ] Manual verification on GHE environment

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)