### PR TITLE
fix(autodev): prevent infinite retry loop for failed knowledge extraction

### DIFF
--- a/plugins/autodev/DESIGN-v2.md
+++ b/plugins/autodev/DESIGN-v2.md
@@ -271,13 +271,13 @@ scan_all():
   issues::scan()            — labels=autodev:analyze → Pending (분석 대기)
   issues::scan_approved()   — labels=autodev:approved-analysis → Ready (구현 대기)
   pulls::scan()             — labels=autodev:wip, state=open → Pending (리뷰 대기)
-  pulls::scan_done_merged() — labels=autodev:done, NOT autodev:extracted, state=merged → Extracting
+  pulls::scan_done_merged() — labels=autodev:done, NOT autodev:extracted/extract-failed, state=merged → Extracting
 ```
 
 - `issues::scan()`: `autodev:analyze` 라벨이 있는 open 이슈만 감지
 - `issues::scan_approved()`: 사람이 승인한 이슈를 감지하여 구현 큐에 적재
 - `pulls::scan()`: `autodev:wip` 라벨이 있는 open PR만 감지
-- `pulls::scan_done_merged()`: `autodev:done` 라벨 + merged 상태 + `autodev:extracted` 라벨이 없는 PR 감지
+- `pulls::scan_done_merged()`: `autodev:done` 라벨 + merged 상태 + `autodev:extracted`/`autodev:extract-failed` 라벨이 없는 PR 감지
 - Safety Valve 불필요: Label-Positive 모델에서는 무한루프 방지 로직이 필요 없음
 
 ---
@@ -310,8 +310,9 @@ scan_all():
   Improved      → 피드백 반영 완료 → autodev:wip + Pending으로 재진입
 
   --- merge 후 ---
-  Extracting    → scan_done_merged에서 감지 (done + merged + NOT extracted)
+  Extracting    → scan_done_merged에서 감지 (done + merged + NOT extracted/extract-failed)
   (exit)        → ExtractTask 완료 → autodev:extracted 추가 + queue 제거
+                → worktree 실패 → autodev:extract-failed 추가 (라벨 제거로 재시도 가능)
 ```
 
 ---
@@ -350,7 +351,7 @@ PR Tasks:
 
 ### Per-Task (PR merge 후)
 
-트리거 조건: `autodev:done` 라벨 + PR merged 상태 + `autodev:extracted` 라벨 없음
+트리거 조건: `autodev:done` 라벨 + PR merged 상태 + `autodev:extracted`/`autodev:extract-failed` 라벨 없음
 
 ```
 ┌─────────────────────────────────────────────────────┐
@@ -366,6 +367,7 @@ PR Tasks:
 │  4. 이슈 코멘트로 게시                                │
 │  5. skill/subagent → PR 생성 (autodev:skip 라벨)     │
 │  6. autodev:extracted 라벨 추가 (중복 방지)           │
+│     └─ worktree 실패 시 autodev:extract-failed 추가  │
 └─────────────────────────────────────────────────────┘
 ```
 
@@ -374,6 +376,8 @@ PR Tasks:
 > merge된 코드만이 실제로 레포에 반영된 확정 지식이다.
 >
 > **중복 방지**: `autodev:extracted` 라벨로 이미 처리된 PR을 scan에서 제외.
+> worktree 생성 실패 등 preflight 오류 시 `autodev:extract-failed` 라벨을 추가하여 무한 재스캔을 방지.
+> 라벨을 수동 제거하면 다음 스캔에서 재시도된다.
 > Label-Positive 모델과 일관되며 GitHub UI에서도 추출 상태를 확인할 수 있다.
 
 ### Daily (일간 집계)
@@ -464,6 +468,7 @@ autodev:implementing 이슈 감지 →
 │  │                                                               │  │
 │  │    Extracting:                                                │  │
 │  │      ExtractTask → 지식 추출 + autodev:extracted → 제거      │  │
+│  │      (worktree 실패 → autodev:extract-failed → 제거)         │  │
 │  │                                                               │  │
 │  └───────────────────────────────────────────────────────────────┘  │
 │                            │                                        │

--- a/plugins/autodev/README.md
+++ b/plugins/autodev/README.md
@@ -173,10 +173,11 @@ scan 감지 (autodev:wip) → queue[Pending]
 ### Knowledge Extraction: merge 후 지식 추출
 
 ```
-scan_done_merged: autodev:done + merged + NOT extracted → queue[Extracting]
+scan_done_merged: autodev:done + merged + NOT extracted/extract-failed → queue[Extracting]
   → ExtractTask → 기존 지식 수집 + suggest-workflow 데이터
   → Claude 분석 → 이슈 코멘트 + knowledge PR 생성 (autodev:skip 라벨)
-  → autodev:extracted 추가 + queue 제거
+  → 성공: autodev:extracted 추가 + queue 제거
+  → worktree 실패: autodev:extract-failed 추가 (라벨 제거로 재시도 가능)
 ```
 
 ### Knowledge Extraction

--- a/plugins/autodev/cli/src/domain/git_repository.rs
+++ b/plugins/autodev/cli/src/domain/git_repository.rs
@@ -393,7 +393,7 @@ impl GitRepository {
                 _ => continue,
             };
 
-            // extracted 라벨이 있으면 이미 처리됨
+            // extracted 또는 extract-failed 라벨이 있으면 스킵
             let item_labels: Vec<&str> = item["labels"]
                 .as_array()
                 .map(|arr| {
@@ -402,7 +402,9 @@ impl GitRepository {
                         .collect::<Vec<_>>()
                 })
                 .unwrap_or_default();
-            if item_labels.contains(&labels::EXTRACTED) {
+            if item_labels.contains(&labels::EXTRACTED)
+                || item_labels.contains(&labels::EXTRACT_FAILED)
+            {
                 continue;
             }
 

--- a/plugins/autodev/cli/src/domain/labels.rs
+++ b/plugins/autodev/cli/src/domain/labels.rs
@@ -13,6 +13,7 @@ pub const IMPLEMENTING: &str = "autodev:implementing";
 // v2.1: PR 전용 라벨
 pub const CHANGES_REQUESTED: &str = "autodev:changes-requested";
 pub const EXTRACTED: &str = "autodev:extracted";
+pub const EXTRACT_FAILED: &str = "autodev:extract-failed";
 
 // v2: 리뷰 반복 횟수 라벨 (예: "autodev:iteration/1")
 pub const ITERATION_PREFIX: &str = "autodev:iteration/";

--- a/plugins/autodev/cli/src/tasks/extract.rs
+++ b/plugins/autodev/cli/src/tasks/extract.rs
@@ -109,16 +109,40 @@ impl Task for ExtractTask {
         } else {
             Some(self.item.head_branch.as_str())
         };
-        let wt_path = self
+
+        // 이전 시도에서 남은 worktree 정리 후 재생성
+        let _ = self
+            .workspace
+            .remove_worktree(&self.item.repo_name, &self.task_id)
+            .await;
+
+        let wt_path = match self
             .workspace
             .create_worktree(&self.item.repo_name, &self.task_id, branch)
             .await
-            .map_err(|e| {
-                SkipReason::PreflightFailed(format!(
+        {
+            Ok(path) => path,
+            Err(e) => {
+                // worktree 생성 실패 시 extract-failed 라벨을 추가하여 무한 재스캔 방지.
+                // extracted와 구분하여 수동 라벨 제거로 재시도 가능.
+                tracing::warn!(
+                    "worktree creation failed for PR #{}, marking as extract-failed to prevent retry loop: {e}",
+                    self.item.github_number
+                );
+                self.gh
+                    .label_add(
+                        &self.item.repo_name,
+                        self.item.github_number,
+                        labels::EXTRACT_FAILED,
+                        self.item.gh_host.as_deref(),
+                    )
+                    .await;
+                return Err(SkipReason::PreflightFailed(format!(
                     "worktree failed for PR #{}: {e}",
                     self.item.github_number
-                ))
-            })?;
+                )));
+            }
+        };
         self.wt_path = Some(wt_path.clone());
 
         let task_type = "pr";
@@ -529,5 +553,55 @@ mod tests {
         assert!(result.logs[0]
             .command
             .contains("knowledge: per-task pr #10"));
+    }
+
+    // ─── Worktree Failure Mock ───
+
+    struct FailingWorkspace;
+
+    #[async_trait]
+    impl WorkspaceOps for FailingWorkspace {
+        async fn ensure_cloned(&self, _: &str, _: &str) -> anyhow::Result<PathBuf> {
+            Ok(PathBuf::from("/mock/main"))
+        }
+        async fn create_worktree(
+            &self,
+            _: &str,
+            _: &str,
+            _: Option<&str>,
+        ) -> anyhow::Result<PathBuf> {
+            anyhow::bail!("git worktree add failed: path already exists")
+        }
+        async fn remove_worktree(&self, _: &str, _: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn before_invoke_worktree_failure_adds_extract_failed_label() {
+        let gh = Arc::new(MockGh::new());
+        let sw: Arc<dyn SuggestWorkflow> = Arc::new(MockSuggestWorkflow::empty());
+
+        let mut task = ExtractTask::new(
+            Arc::new(FailingWorkspace),
+            gh.clone(),
+            sw,
+            Arc::new(MockGit),
+            Arc::new(MockEnv),
+            make_test_pr(),
+        );
+
+        let result = task.before_invoke().await;
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            SkipReason::PreflightFailed(_)
+        ));
+
+        // extract-failed 라벨이 추가되어 무한 재스캔 방지 (수동 제거로 재시도 가능)
+        let labels = gh.added_labels.lock().unwrap();
+        assert!(labels.iter().any(|(repo, n, label)| repo == "org/repo"
+            && *n == 10
+            && label == labels::EXTRACT_FAILED));
     }
 }


### PR DESCRIPTION
## Summary

- When worktree creation fails during knowledge extraction, `after_invoke()` is never called, so no label is added
- `scan_done_merged()` re-discovers the same PR every 5-minute scan cycle → **infinite retry loop**
- Fix: clean up leftover worktree, add `autodev:extract-failed` label on persistent failure

## Root Cause

| Scenario | before_invoke | after_invoke | Label Added | Next Scan |
|----------|---------------|-------------|-------------|-----------|
| Success | OK | Called | `extracted` | Skipped |
| Agent failure | OK | Called | `extracted` | Skipped |
| **Worktree failure** | **Err** | **Skipped** | **None** | **Re-scanned (infinite)** |

## Changes

1. **`labels.rs`**: Add `EXTRACT_FAILED` constant (`autodev:extract-failed`)
2. **`extract.rs`**: Clean up leftover worktree before retry; add `extract-failed` label on failure
3. **`git_repository.rs`**: `scan_done_merged()` excludes both `extracted` and `extract-failed` labels
4. New test `before_invoke_worktree_failure_adds_extract_failed_label`

### Why `extract-failed` instead of `extracted`?

- Distinguishes successful extraction from failed — visible on GitHub
- User can remove `extract-failed` label to trigger a manual retry
- `extracted` label is reserved for actual completion (success or agent failure)

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] `cargo test` — all 280 tests pass
- [ ] Manual verification: create a scenario where worktree fails, confirm no retry loop

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)