### PR TITLE
feat(autodev): inject existing issue context into analysis prompt

### DIFF
--- a/plugins/autodev/cli/src/components/verdict.rs
+++ b/plugins/autodev/cli/src/components/verdict.rs
@@ -72,10 +72,24 @@ pub fn format_analysis_comment(a: &AnalysisResult) -> String {
     comment
 }
 
+/// 파싱 실패 시 raw report를 분석 코멘트로 포맷
+///
+/// `format_analysis_comment`와 동일한 마커/헤더/푸터를 사용하여 일관성을 유지한다.
+pub fn format_raw_analysis_comment(report: &str) -> String {
+    format!(
+        "<!-- autodev:analysis -->\n\
+         ## Autodev Analysis Report\n\n\
+         {report}\n\n\
+         ---\n\
+         > 이 분석을 승인하려면 `autodev:approved-analysis` 라벨을 추가하세요.\n\
+         > 수정이 필요하면 코멘트로 피드백을 남기고 `autodev:analyzed` 라벨을 제거하세요."
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::infrastructure::claude::output::{AnalysisResult, RelatedIssue, Verdict};
+    use crate::infrastructure::claude::output::{AnalysisResult, RelatedIssue, Relation, Verdict};
 
     #[test]
     fn format_analysis_comment_contains_marker_and_fields() {
@@ -141,13 +155,13 @@ mod tests {
             related_issues: vec![
                 RelatedIssue {
                     number: 10,
-                    relation: "related".to_string(),
+                    relation: Relation::Related,
                     confidence: 0.7,
                     summary: "Similar auth issue".to_string(),
                 },
                 RelatedIssue {
                     number: 15,
-                    relation: "duplicate".to_string(),
+                    relation: Relation::Duplicate,
                     confidence: 0.9,
                     summary: "Same bug reported".to_string(),
                 },

--- a/plugins/autodev/cli/src/infrastructure/claude/output.rs
+++ b/plugins/autodev/cli/src/infrastructure/claude/output.rs
@@ -64,12 +64,32 @@ impl fmt::Display for Verdict {
     }
 }
 
+/// 관련 이슈 관계 타입
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum Relation {
+    Duplicate,
+    Related,
+    Blocks,
+    BlockedBy,
+}
+
+impl fmt::Display for Relation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Relation::Duplicate => write!(f, "duplicate"),
+            Relation::Related => write!(f, "related"),
+            Relation::Blocks => write!(f, "blocks"),
+            Relation::BlockedBy => write!(f, "blocked_by"),
+        }
+    }
+}
+
 /// 관련 이슈 정보
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 pub struct RelatedIssue {
     pub number: i64,
-    /// "duplicate" | "related" | "blocks" | "blocked_by"
-    pub relation: String,
+    pub relation: Relation,
     /// 0.0 ~ 1.0
     pub confidence: f64,
     pub summary: String,

--- a/plugins/autodev/cli/src/tasks/analyze.rs
+++ b/plugins/autodev/cli/src/tasks/analyze.rs
@@ -250,14 +250,7 @@ impl AnalyzeTask {
     async fn handle_fallback(&self, stdout: &str) -> Vec<QueueOp> {
         let gh_host = self.gh_host();
         let report = output::parse_output(stdout);
-        let comment = format!(
-            "<!-- autodev:analysis -->\n\
-             ## Autodev Analysis Report\n\n\
-             {report}\n\n\
-             ---\n\
-             > 이 분석을 승인하려면 `autodev:approved-analysis` 라벨을 추가하세요.\n\
-             > 수정이 필요하면 코멘트로 피드백을 남기고 `autodev:analyzed` 라벨을 제거하세요."
-        );
+        let comment = verdict::format_raw_analysis_comment(&report);
         self.gh
             .issue_comment(
                 &self.item.repo_name,


### PR DESCRIPTION
## Summary

- 이슈 분석 시 에이전트가 `gh issue list`로 기존 이슈를 조회하여 중복/관련성을 분석하도록 프롬프트 개선
- `RelatedIssue` 구조체 추가 — relation, confidence, summary 포함
- 분석 코멘트에 관련 이슈 테이블 자동 렌더링
- 높은 confidence의 duplicate 발견 시 wontfix verdict 유도

Closes #188

## Test plan

- [x] `AnalysisResult` 역직렬화 — `related_issues` 없는 기존 응답과 호환 (`#[serde(default)]`)
- [x] `format_analysis_comment` — related issues 있을 때 테이블 렌더링
- [x] `format_analysis_comment` — related issues 없을 때 테이블 생략
- [x] 기존 205개 테스트 전부 통과
- [x] clippy, fmt 클린

🤖 Generated with [Claude Code](https://claude.com/claude-code)