### PR TITLE
feat(autodev): add simplify review step to implement workflow

### DIFF
--- a/plugins/autodev/cli/Cargo.lock
+++ b/plugins/autodev/cli/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autodev"
-version = "0.9.13"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/plugins/autodev/cli/src/tasks/workflow_resolver.rs
+++ b/plugins/autodev/cli/src/tasks/workflow_resolver.rs
@@ -22,11 +22,25 @@ fn default_agent(task_type: &TaskType) -> &'static str {
     }
 }
 
-/// 이슈 분석/구현 위임 프롬프트 템플릿. `{agent_name}` 플레이스홀더 사용.
-const ISSUE_PROMPT: &str = "You MUST delegate this task to the `{agent_name}` agent \
+/// 분석 위임 프롬프트 템플릿. `{agent_name}` 플레이스홀더 사용.
+const ANALYZE_PROMPT: &str = "You MUST delegate this task to the `{agent_name}` agent \
     using the Agent tool with subagent_type=\"{agent_name}\". \
     Pass all issue context (number, repo, comments) to the agent. \
     Do not attempt to perform the analysis yourself.";
+
+/// 구현 위임 프롬프트 템플릿. `{agent_name}` 플레이스홀더 사용.
+const IMPLEMENT_PROMPT: &str = "You MUST delegate this task to the `{agent_name}` agent \
+    using the Agent tool with subagent_type=\"{agent_name}\". \
+    Pass all issue context (number, repo, comments) to the agent. \
+    Do not attempt to perform the implementation yourself.\n\n\
+    After the agent completes the implementation, you MUST review the changes \
+    for code quality before creating the PR:\n\
+    1. Run `git diff` to see all changes\n\
+    2. Review for code reuse (search for existing utilities that could replace new code)\n\
+    3. Review for code quality (redundant state, copy-paste, stringly-typed code)\n\
+    4. Review for efficiency (unnecessary work, missed concurrency, unbounded data)\n\
+    5. Fix any issues found directly — do not just report them\n\
+    6. Then proceed with commit and PR creation";
 
 /// PR 리뷰 위임 프롬프트 템플릿. `{agent_name}` 플레이스홀더 사용.
 const REVIEW_PROMPT: &str = "You MUST delegate this task to the `{agent_name}` agent \
@@ -52,7 +66,8 @@ pub fn resolve_workflow_prompt(stage: &WorkflowStage, task_type: TaskType) -> St
         .unwrap_or_else(|| default_agent(&task_type));
 
     let template = match task_type {
-        TaskType::Analyze | TaskType::Implement => ISSUE_PROMPT,
+        TaskType::Analyze => ANALYZE_PROMPT,
+        TaskType::Implement => IMPLEMENT_PROMPT,
         TaskType::Review => REVIEW_PROMPT,
     };
 
@@ -83,6 +98,8 @@ mod tests {
         let result = resolve_workflow_prompt(&stage, TaskType::Implement);
         assert!(result.contains("autodev:issue-analyzer"));
         assert!(result.contains("issue context"));
+        assert!(result.contains("review the changes"));
+        assert!(result.contains("code quality"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- 구현 완료 후 자동 simplify 리뷰 단계 추가 (코드 재사용, 품질, 효율성)
- Implement 프롬프트를 Analyze에서 분리하여 각각 고유 템플릿 사용
- 커스텀 command 사용 시 영향 없음 (command 우선 적용)

Closes #193

## Test plan

- [x] `resolve_builtin_implement` — simplify 지시문 포함 검증
- [x] `resolve_builtin_analyze` — 기존 동작 유지 확인
- [x] 전체 315개 테스트 통과
- [x] clippy, fmt 클린

🤖 Generated with [Claude Code](https://claude.com/claude-code)