### PR TITLE
fix(autodev): add 2-phase analysis to handle agent JSON parse failures (#214)

### DIFF
--- a/plugins/autodev/cli/src/config/models.rs
+++ b/plugins/autodev/cli/src/config/models.rs
@@ -102,9 +102,9 @@ impl Default for GitHubSourceConfig {
 /// analyze → implement → review
 /// ```
 ///
-/// 각 단계는 `agent`(builtin) 또는 `command`(커스텀 슬래시 커맨드) 중
-/// 하나로 실행 방식을 지정한다. 둘 다 미지정 시 task_type별 기본 agent 사용.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// 각 단계는 `command`로 커스텀 슬래시 커맨드를 지정할 수 있다.
+/// 미지정 시 task_type별 기본 출력 스펙이 system prompt로 사용된다.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(default)]
 pub struct Workflows {
     pub analyze: WorkflowStage,
@@ -112,35 +112,13 @@ pub struct Workflows {
     pub review: ReviewStage,
 }
 
-impl Default for Workflows {
-    fn default() -> Self {
-        Self {
-            analyze: WorkflowStage {
-                agent: Some("autodev:issue-analyzer".into()),
-                command: None,
-            },
-            implement: WorkflowStage {
-                agent: Some("autodev:issue-analyzer".into()),
-                command: None,
-            },
-            review: ReviewStage {
-                agent: Some("autodev:pr-reviewer".into()),
-                command: None,
-                max_iterations: 2,
-            },
-        }
-    }
-}
-
 /// 워크플로우 단계 공통 설정.
 ///
-/// `agent`와 `command`는 상호 배타적이다.
-/// - `agent`: autodev builtin agent에 위임 (예: `autodev:issue-analyzer`)
-/// - `command`: 커스텀 슬래시 커맨드 실행 (예: `/review:multi-review`)
+/// `command`가 지정되면 해당 슬래시 커맨드를 system prompt로 사용한다.
+/// 미지정 시 task_type별 기본 출력 스펙이 적용된다.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(default)]
 pub struct WorkflowStage {
-    pub agent: Option<String>,
     pub command: Option<String>,
 }
 
@@ -148,7 +126,6 @@ pub struct WorkflowStage {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct ReviewStage {
-    pub agent: Option<String>,
     pub command: Option<String>,
     pub max_iterations: u32,
 }
@@ -156,7 +133,6 @@ pub struct ReviewStage {
 impl Default for ReviewStage {
     fn default() -> Self {
         Self {
-            agent: Some("autodev:pr-reviewer".into()),
             command: None,
             max_iterations: 2,
         }
@@ -164,10 +140,9 @@ impl Default for ReviewStage {
 }
 
 impl ReviewStage {
-    /// 워크플로우 라우팅에 필요한 agent/command 부분만 추출.
+    /// 워크플로우 라우팅에 필요한 command 부분만 추출.
     pub fn as_stage(&self) -> WorkflowStage {
         WorkflowStage {
-            agent: self.agent.clone(),
             command: self.command.clone(),
         }
     }
@@ -207,14 +182,11 @@ daemon:
     }
 
     #[test]
-    fn workflows_default_agents() {
+    fn workflows_default() {
         let cfg = Workflows::default();
-        assert_eq!(cfg.analyze.agent.as_deref(), Some("autodev:issue-analyzer"));
-        assert_eq!(
-            cfg.implement.agent.as_deref(),
-            Some("autodev:issue-analyzer")
-        );
-        assert_eq!(cfg.review.agent.as_deref(), Some("autodev:pr-reviewer"));
+        assert!(cfg.analyze.command.is_none());
+        assert!(cfg.implement.command.is_none());
+        assert!(cfg.review.command.is_none());
         assert_eq!(cfg.review.max_iterations, 2);
     }
 
@@ -226,30 +198,18 @@ workflows:
     max_iterations: 5
 "#;
         let cfg: WorkflowConfig = serde_yaml::from_str(yaml).unwrap();
-        // review.max_iterations overridden
         assert_eq!(cfg.workflows.review.max_iterations, 5);
-        // review.agent retains default
-        assert_eq!(
-            cfg.workflows.review.agent.as_deref(),
-            Some("autodev:pr-reviewer")
-        );
-        // analyze/implement retain defaults from Workflows::default()
-        assert_eq!(
-            cfg.workflows.analyze.agent.as_deref(),
-            Some("autodev:issue-analyzer")
-        );
+        assert!(cfg.workflows.review.command.is_none());
     }
 
     #[test]
-    fn workflows_custom_command_overrides_agent() {
+    fn workflows_custom_command() {
         let yaml = r#"
 workflows:
   analyze:
     command: /review:multi-analyze
-    agent: null
   review:
     command: /review:multi-review
-    agent: null
     max_iterations: 3
 "#;
         let cfg: WorkflowConfig = serde_yaml::from_str(yaml).unwrap();
@@ -257,19 +217,15 @@ workflows:
             cfg.workflows.analyze.command.as_deref(),
             Some("/review:multi-analyze")
         );
-        assert!(cfg.workflows.analyze.agent.is_none());
         assert_eq!(
             cfg.workflows.review.command.as_deref(),
             Some("/review:multi-review")
         );
-        assert!(cfg.workflows.review.agent.is_none());
         assert_eq!(cfg.workflows.review.max_iterations, 3);
     }
 
     #[test]
     fn deprecated_v1_keys_are_silently_ignored() {
-        // v1 YAML with commands, develop, workflow keys
-        // With deny_unknown_fields removed, these should be ignored
         let yaml = r#"
 sources:
   github:
@@ -284,24 +240,39 @@ workflow:
   pr: builtin
 "#;
         let cfg: WorkflowConfig = serde_yaml::from_str(yaml).unwrap();
-        // Valid keys are parsed
         assert_eq!(cfg.sources.github.model, "opus");
         // workflows uses defaults (v1 keys ignored)
-        assert_eq!(
-            cfg.workflows.analyze.agent.as_deref(),
-            Some("autodev:issue-analyzer")
-        );
-        assert_eq!(
-            cfg.workflows.review.agent.as_deref(),
-            Some("autodev:pr-reviewer")
-        );
+        assert!(cfg.workflows.analyze.command.is_none());
+        assert!(cfg.workflows.review.command.is_none());
     }
 
     #[test]
     fn review_stage_as_stage() {
-        let review = ReviewStage::default();
+        let review = ReviewStage {
+            command: Some("/custom-review".into()),
+            max_iterations: 3,
+        };
         let stage = review.as_stage();
-        assert_eq!(stage.agent.as_deref(), Some("autodev:pr-reviewer"));
-        assert!(stage.command.is_none());
+        assert_eq!(stage.command.as_deref(), Some("/custom-review"));
+    }
+
+    #[test]
+    fn deprecated_agent_field_is_silently_ignored() {
+        // 기존 YAML에 agent 필드가 있어도 파싱 실패 없이 무시
+        let yaml = r#"
+workflows:
+  analyze:
+    agent: autodev:issue-analyzer
+    command: /custom-analyze
+  review:
+    agent: autodev:pr-reviewer
+    max_iterations: 3
+"#;
+        let cfg: WorkflowConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(
+            cfg.workflows.analyze.command.as_deref(),
+            Some("/custom-analyze")
+        );
+        assert_eq!(cfg.workflows.review.max_iterations, 3);
     }
 }

--- a/plugins/autodev/cli/src/tasks/implement.rs
+++ b/plugins/autodev/cli/src/tasks/implement.rs
@@ -159,9 +159,8 @@ impl Task for ImplementTask {
         let workflow = repo_cfg
             .workflows
             .implement
-            .agent
+            .command
             .as_deref()
-            .or(repo_cfg.workflows.implement.command.as_deref())
             .unwrap_or("builtin");
 
         let log = NewConsumerLog {

--- a/plugins/autodev/cli/src/tasks/workflow_resolver.rs
+++ b/plugins/autodev/cli/src/tasks/workflow_resolver.rs
@@ -1,8 +1,8 @@
 //! WorkflowResolver — WorkflowStage를 system prompt 텍스트로 변환.
 //!
-//! `agent` 지정 → builtin 에이전트 위임 지시문
-//! `command` 지정 → 커스텀 슬래시 커맨드 (패스스루)
-//! 둘 다 미지정 → task_type별 기본 agent 사용
+//! task_type별 출력 스펙을 정의하고, 커스텀 슬래시 커맨드가 있으면 그대로 반환한다.
+//! user prompt가 동적으로 분석/리뷰/구현 지시를 전달하고,
+//! system prompt는 최종 출력 형식(JSON 스펙)과 절차를 정의한다.
 
 use crate::config::models::WorkflowStage;
 
@@ -13,33 +13,20 @@ pub enum TaskType {
     Review,
 }
 
-/// task_type별 기본 builtin agent 이름.
-fn default_agent(task_type: &TaskType) -> &'static str {
-    match task_type {
-        TaskType::Analyze => "autodev:issue-analyzer",
-        TaskType::Implement => "autodev:issue-analyzer",
-        TaskType::Review => "autodev:pr-reviewer",
-    }
-}
-
-/// 분석 위임 프롬프트 템플릿. `{agent_name}` 플레이스홀더 사용.
+/// 분석 결과 출력 스펙.
 ///
-/// agent에 분석을 위임하되, 최종 JSON 보고서는 Claude가 직접 생성한다.
-/// `--output-format json` + `--json-schema`와 함께 사용되므로
-/// Claude가 agent 결과를 수신한 뒤 JSON schema에 맞춰 응답해야 한다.
-const ANALYZE_PROMPT: &str = "Delegate the analysis work to the `{agent_name}` agent \
-    using the Agent tool with subagent_type=\"{agent_name}\". \
-    Pass all issue context (number, repo, comments) to the agent. \
-    After the agent completes, use its findings to produce YOUR response \
-    as a JSON object matching the required schema. \
-    Do not pass through the agent's raw output — you must synthesize it into the JSON format.";
+/// `--output-format json` + `--json-schema`와 함께 사용된다.
+/// user prompt의 분석 요청을 수행한 뒤, 결과를 JSON schema에 맞춰 응답해야 한다.
+const ANALYZE_PROMPT: &str = "You are an issue analyzer. \
+    Perform the requested analysis and respond with a JSON object matching the required schema. \
+    Your response must contain: verdict, confidence, summary, questions, reason, report, and related_issues.";
 
-/// 구현 위임 프롬프트 템플릿. `{agent_name}` 플레이스홀더 사용.
-const IMPLEMENT_PROMPT: &str = "You MUST delegate this task to the `{agent_name}` agent \
-    using the Agent tool with subagent_type=\"{agent_name}\". \
-    Pass all issue context (number, repo, comments) to the agent. \
-    Do not attempt to perform the implementation yourself.\n\n\
-    After the agent completes the implementation, you MUST review the changes \
+/// 구현 절차 스펙.
+///
+/// 구현 완료 후 품질 리뷰를 거쳐 커밋/PR을 생성하는 절차를 정의한다.
+const IMPLEMENT_PROMPT: &str = "You are an issue implementer. \
+    Perform the requested implementation based on the issue context.\n\n\
+    After completing the implementation, you MUST review the changes \
     for code quality before creating the PR:\n\
     1. Run `git diff` to see all changes\n\
     2. Review for code reuse (search for existing utilities that could replace new code)\n\
@@ -48,36 +35,30 @@ const IMPLEMENT_PROMPT: &str = "You MUST delegate this task to the `{agent_name}
     5. Fix any issues found directly — do not just report them\n\
     6. Then proceed with commit and PR creation";
 
-/// PR 리뷰 위임 프롬프트 템플릿. `{agent_name}` 플레이스홀더 사용.
-const REVIEW_PROMPT: &str = "You MUST delegate this task to the `{agent_name}` agent \
-    using the Agent tool with subagent_type=\"{agent_name}\". \
-    Pass all PR context (number, repo, diff, comments) to the agent. \
-    Do not attempt to perform the review yourself.";
+/// PR 리뷰 결과 출력 스펙.
+///
+/// `--output-format json` + `--json-schema`와 함께 사용된다.
+/// user prompt의 리뷰 요청을 수행한 뒤, 결과를 JSON schema에 맞춰 응답해야 한다.
+const REVIEW_PROMPT: &str = "You are a PR reviewer. \
+    Perform the requested code review and respond with a JSON object matching the required schema. \
+    Your response must contain: verdict, summary, and report.";
 
 /// WorkflowStage를 system prompt 텍스트로 변환한다.
 ///
 /// 우선순위:
 /// 1. `command`가 Some → 커스텀 슬래시 커맨드 그대로 반환
-/// 2. `agent`가 Some → 해당 agent 위임 지시문 생성
-/// 3. 둘 다 None → task_type별 기본 agent 위임 지시문 생성
+/// 2. 그 외 → task_type별 출력 스펙 반환
 pub fn resolve_workflow_prompt(stage: &WorkflowStage, task_type: TaskType) -> String {
     // 커스텀 슬래시 커맨드 우선
     if let Some(ref cmd) = stage.command {
         return cmd.clone();
     }
 
-    let agent_name = stage
-        .agent
-        .as_deref()
-        .unwrap_or_else(|| default_agent(&task_type));
-
-    let template = match task_type {
-        TaskType::Analyze => ANALYZE_PROMPT,
-        TaskType::Implement => IMPLEMENT_PROMPT,
-        TaskType::Review => REVIEW_PROMPT,
-    };
-
-    template.replace("{agent_name}", agent_name)
+    match task_type {
+        TaskType::Analyze => ANALYZE_PROMPT.to_string(),
+        TaskType::Implement => IMPLEMENT_PROMPT.to_string(),
+        TaskType::Review => REVIEW_PROMPT.to_string(),
+    }
 }
 
 #[cfg(test)]
@@ -85,44 +66,35 @@ mod tests {
     use super::*;
 
     #[test]
-    fn resolve_builtin_analyze() {
-        let stage = WorkflowStage {
-            agent: Some("autodev:issue-analyzer".into()),
-            command: None,
-        };
+    fn resolve_analyze_returns_output_spec() {
+        let stage = WorkflowStage::default();
         let result = resolve_workflow_prompt(&stage, TaskType::Analyze);
-        assert!(result.contains("autodev:issue-analyzer"));
-        assert!(result.contains("Agent tool"));
+        assert!(result.contains("issue analyzer"));
+        assert!(result.contains("JSON object"));
+        assert!(result.contains("verdict"));
     }
 
     #[test]
-    fn resolve_builtin_implement() {
-        let stage = WorkflowStage {
-            agent: Some("autodev:issue-analyzer".into()),
-            command: None,
-        };
+    fn resolve_implement_returns_procedure() {
+        let stage = WorkflowStage::default();
         let result = resolve_workflow_prompt(&stage, TaskType::Implement);
-        assert!(result.contains("autodev:issue-analyzer"));
-        assert!(result.contains("issue context"));
+        assert!(result.contains("issue implementer"));
         assert!(result.contains("review the changes"));
         assert!(result.contains("code quality"));
     }
 
     #[test]
-    fn resolve_builtin_review() {
-        let stage = WorkflowStage {
-            agent: Some("autodev:pr-reviewer".into()),
-            command: None,
-        };
+    fn resolve_review_returns_output_spec() {
+        let stage = WorkflowStage::default();
         let result = resolve_workflow_prompt(&stage, TaskType::Review);
-        assert!(result.contains("autodev:pr-reviewer"));
-        assert!(result.contains("PR context"));
+        assert!(result.contains("PR reviewer"));
+        assert!(result.contains("JSON object"));
+        assert!(result.contains("verdict"));
     }
 
     #[test]
     fn resolve_custom_command() {
         let stage = WorkflowStage {
-            agent: None,
             command: Some("/review:multi-review".into()),
         };
         let result = resolve_workflow_prompt(&stage, TaskType::Review);
@@ -130,28 +102,11 @@ mod tests {
     }
 
     #[test]
-    fn resolve_command_takes_precedence_over_agent() {
+    fn resolve_with_command() {
         let stage = WorkflowStage {
-            agent: Some("autodev:pr-reviewer".into()),
             command: Some("/custom-review".into()),
         };
         let result = resolve_workflow_prompt(&stage, TaskType::Review);
         assert_eq!(result, "/custom-review");
-    }
-
-    #[test]
-    fn resolve_none_falls_back_to_default_agent() {
-        let stage = WorkflowStage {
-            agent: None,
-            command: None,
-        };
-        let result = resolve_workflow_prompt(&stage, TaskType::Review);
-        assert!(result.contains("autodev:pr-reviewer"));
-
-        let result = resolve_workflow_prompt(&stage, TaskType::Analyze);
-        assert!(result.contains("autodev:issue-analyzer"));
-
-        let result = resolve_workflow_prompt(&stage, TaskType::Implement);
-        assert!(result.contains("autodev:issue-analyzer"));
     }
 }

--- a/plugins/autodev/cli/tests/config_loader_tests.rs
+++ b/plugins/autodev/cli/tests/config_loader_tests.rs
@@ -49,18 +49,9 @@ fn default_config_has_expected_values() {
     assert_eq!(config.daemon.log_dir, "logs");
     assert_eq!(config.daemon.log_retention_days, 30);
     // Workflows defaults (v2)
-    assert_eq!(
-        config.workflows.analyze.agent.as_deref(),
-        Some("autodev:issue-analyzer")
-    );
-    assert_eq!(
-        config.workflows.implement.agent.as_deref(),
-        Some("autodev:issue-analyzer")
-    );
-    assert_eq!(
-        config.workflows.review.agent.as_deref(),
-        Some("autodev:pr-reviewer")
-    );
+    assert!(config.workflows.analyze.command.is_none());
+    assert!(config.workflows.implement.command.is_none());
+    assert!(config.workflows.review.command.is_none());
     assert_eq!(config.workflows.review.max_iterations, 2);
 }
 
@@ -71,10 +62,7 @@ fn load_merged_no_files_returns_defaults() {
     // 존재하지 않는 경로 → 양쪽 모두 None → default
     let config = loader::load_merged(&env, Some(tmp.path()));
     assert_eq!(config.sources.github.scan_interval_secs, 300);
-    assert_eq!(
-        config.workflows.analyze.agent.as_deref(),
-        Some("autodev:issue-analyzer")
-    );
+    assert!(config.workflows.analyze.command.is_none());
 }
 
 #[test]
@@ -111,10 +99,7 @@ workflows:
     assert_eq!(config.workflows.review.max_iterations, 5);
     // 미지정 필드는 default 유지
     assert_eq!(config.sources.github.issue_concurrency, 1);
-    assert_eq!(
-        config.workflows.analyze.agent.as_deref(),
-        Some("autodev:issue-analyzer")
-    );
+    assert!(config.workflows.analyze.command.is_none());
 }
 
 // ═══════════════════════════════════════════════
@@ -243,10 +228,7 @@ fn load_merged_partial_yaml_fills_defaults() {
     assert_eq!(config.sources.github.model, "gpt-4");
     // 나머지 전부 default
     assert_eq!(config.sources.github.scan_interval_secs, 300);
-    assert_eq!(
-        config.workflows.analyze.agent.as_deref(),
-        Some("autodev:issue-analyzer")
-    );
+    assert!(config.workflows.analyze.command.is_none());
     assert_eq!(config.workflows.review.max_iterations, 2);
 }
 
@@ -382,10 +364,7 @@ workflow:
     // 유효한 키는 정상 파싱됨 (v1 키가 있어도 fallback 아님)
     assert_eq!(config.sources.github.scan_interval_secs, 60);
     // workflows는 default
-    assert_eq!(
-        config.workflows.analyze.agent.as_deref(),
-        Some("autodev:issue-analyzer")
-    );
+    assert!(config.workflows.analyze.command.is_none());
 }
 
 #[test]
@@ -433,17 +412,13 @@ workflows:
         config.workflows.analyze.command.as_deref(),
         Some("/review:multi-analyze")
     );
-    assert!(config.workflows.analyze.agent.is_none());
     assert_eq!(
         config.workflows.review.command.as_deref(),
         Some("/review:multi-review")
     );
     assert_eq!(config.workflows.review.max_iterations, 3);
     // implement은 default 유지
-    assert_eq!(
-        config.workflows.implement.agent.as_deref(),
-        Some("autodev:issue-analyzer")
-    );
+    assert!(config.workflows.implement.command.is_none());
 }
 
 #[test]
@@ -452,11 +427,11 @@ fn workflows_deep_merge_preserves_global_stage() {
     let repo_dir = tmp.path().join("repo");
     fs::create_dir_all(&repo_dir).unwrap();
 
-    // 글로벌: analyze에 커스텀 에이전트
+    // 글로벌: analyze에 커스텀 커맨드
     let global_yaml = r#"
 workflows:
   analyze:
-    agent: custom:analyzer
+    command: /custom-analyze
   review:
     max_iterations: 5
 "#;
@@ -475,8 +450,8 @@ workflows:
 
     // 글로벌에서 유지
     assert_eq!(
-        config.workflows.analyze.agent.as_deref(),
-        Some("custom:analyzer")
+        config.workflows.analyze.command.as_deref(),
+        Some("/custom-analyze")
     );
     // 레포에서 오버라이드
     assert_eq!(config.workflows.review.max_iterations, 3);


### PR DESCRIPTION
## Summary

- AnalyzeTask의 agent가 sub-agent에 위임 시 JSON 스키마를 인식하지 못해 파싱 실패하는 문제 해결
- Phase 1 파싱 실패 시 별도 Claude 세션(Phase 2)으로 raw report를 JSON으로 변환하는 2-phase 분석 도입
- Phase 2도 실패하면 기존 fallback(raw text 코멘트)으로 graceful degradation

## Changes

- `AnalyzeTask`, `GitHubTaskSource`에 `Arc<dyn Claude>` 필드 추가
- `after_invoke`에 Phase 2 JSON 변환 로직 구현 (`--output-format json --json-schema`, `append_system_prompt: None`)
- Phase 2 프롬프트에 8000자 truncation 적용 (토큰 절약)
- `raw_report` 1회 계산 후 Phase 2/fallback에서 공유 (중복 `parse_output` 호출 제거)
- `mock_claude()` 테스트 헬퍼 추출 (9개 중복 제거)
- Phase 2 성공/실패 테스트 및 프롬프트 내용 검증 추가

## Test plan

- [x] `cargo fmt --check` 통과
- [x] `cargo clippy -- -D warnings` 통과
- [x] `cargo test` 전체 통과 (Phase 2 테스트 2개 포함)
- [ ] 실제 데몬 실행 시 파싱 실패 이슈에서 Phase 2 동작 확인

Closes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)