### PR TITLE
fix(autodev): remove obsolete merge concurrency from auto-setup wizard

### DIFF
--- a/plugins/autodev/commands/auto-setup.md
+++ b/plugins/autodev/commands/auto-setup.md
@@ -165,7 +165,6 @@ AskUserQuestion으로 질문:
 AskUserQuestion으로 질문:
 - Issue 동시 처리 수 (1~3)
 - PR 동시 처리 수 (1~3)
-- Merge 동시 처리 수 (1~2)
 
 ### Step 7: 워크플로우 선택
 


### PR DESCRIPTION
## Summary
- Remove obsolete "Merge 동시 처리 수 (1~2)" question from Step 6 of the auto-setup wizard
- `GitHubSourceConfig` in `cli/src/config/models.rs` only has `issue_concurrency` and `pr_concurrency` fields — there is no `merge_concurrency` field, so the wizard question was stale

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)