### PR TITLE
docs(autodev): fix ImplementTask Err handling description in queue summary

### DIFF
--- a/plugins/autodev/DESIGN-v3.md
+++ b/plugins/autodev/DESIGN-v3.md
@@ -523,7 +523,7 @@ autodev:changes-requested (orphan PR) 감지 →
 │  │    Ready → Implementing:                                      │  │
 │  │      OK + PR 생성 → PR에 autodev:wip + PR queue push         │  │
 │  │      OK + PR 감지 실패 → autodev:impl-failed (worktree 보존) │  │
-│  │      Err → 라벨 제거 + 재시도                                  │  │
+│  │      Err → autodev:impl-failed (라벨 추가 + 실패 코멘트)       │  │
 │  │                                                               │  │
 │  │  PRs:                                                         │  │
 │  │    Pending → Reviewing:                                       │  │


### PR DESCRIPTION
## Summary

- DESIGN-v3.md line 526의 큐 단계 요약에서 `Ready → Implementing` Err 처리 설명을 실제 코드 동작에 맞게 수정
  - Before: `Err → 라벨 제거 + 재시도`
  - After: `Err → autodev:impl-failed (라벨 추가 + 실패 코멘트)`
- 실제 코드(`implement.rs` lines 248-293)는 `autodev:impl-failed` 라벨 추가 + 실패 코멘트 게시를 수행

Closes #225

## Test plan

- [x] 문서 내 다른 impl-failed 관련 설명(lines 27, 37, 56, 164-166, 275-277)과 일관성 확인
- [x] 실제 코드 동작과 일치 여부 확인