### PR TITLE
fix(autodev): add IMPROVE_FAILED label and failure comment on ImproveTask agent failure

### DIFF
--- a/plugins/autodev/cli/src/domain/labels.rs
+++ b/plugins/autodev/cli/src/domain/labels.rs
@@ -15,8 +15,9 @@ pub const CHANGES_REQUESTED: &str = "autodev:changes-requested";
 pub const EXTRACTED: &str = "autodev:extracted";
 pub const EXTRACT_FAILED: &str = "autodev:extract-failed";
 
-// v2.2: 구현 실패 라벨
+// v2.2: 실패 라벨
 pub const IMPL_FAILED: &str = "autodev:impl-failed";
+pub const IMPROVE_FAILED: &str = "autodev:improve-failed";
 
 // v2: 리뷰 반복 횟수 라벨 (예: "autodev:iteration/1")
 pub const ITERATION_PREFIX: &str = "autodev:iteration/";

--- a/plugins/autodev/cli/src/tasks/improve.rs
+++ b/plugins/autodev/cli/src/tasks/improve.rs
@@ -183,6 +183,15 @@ impl Task for ImproveTask {
                 item: Box::new(next_item),
             });
         } else {
+            // 실패 라벨 추가 (add-first) → changes-requested 제거
+            self.gh
+                .label_add(
+                    &self.item.repo_name,
+                    self.item.github_number,
+                    labels::IMPROVE_FAILED,
+                    gh_host,
+                )
+                .await;
             self.gh
                 .label_remove(
                     &self.item.repo_name,
@@ -191,6 +200,23 @@ impl Task for ImproveTask {
                     gh_host,
                 )
                 .await;
+
+            let fail_comment = format!(
+                "<!-- autodev:improve-failed -->\n\
+                 ⚠️ Improve agent failed (exit_code={}).\n\n\
+                 **Branch**: `{}`\n\
+                 Check the agent logs for details.",
+                response.exit_code, self.item.head_branch
+            );
+            self.gh
+                .issue_comment(
+                    &self.item.repo_name,
+                    self.item.github_number,
+                    &fail_comment,
+                    gh_host,
+                )
+                .await;
+
             ops.push(QueueOp::Remove);
         }
 
@@ -358,7 +384,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn after_nonzero_exit_removes() {
+    async fn after_nonzero_exit_removes_and_adds_improve_failed() {
         let gh = Arc::new(MockGh::new());
         let mut task = make_task(gh.clone());
         let _ = task.before_invoke().await;
@@ -378,9 +404,39 @@ mod tests {
             .iter()
             .any(|op| matches!(op, QueueOp::PushPr { .. })));
 
+        // IMPROVE_FAILED 라벨 추가
+        let added = gh.added_labels.lock().unwrap();
+        assert!(added
+            .iter()
+            .any(|(_, n, l)| *n == 10 && l == labels::IMPROVE_FAILED));
+
+        // CHANGES_REQUESTED 라벨 제거
         let removed = gh.removed_labels.lock().unwrap();
         assert!(removed
             .iter()
             .any(|(_, n, l)| *n == 10 && l == labels::CHANGES_REQUESTED));
+
+        // 실패 코멘트 작성
+        let comments = gh.posted_comments.lock().unwrap();
+        assert!(comments
+            .iter()
+            .any(|(_, n, body)| *n == 10 && body.contains("Improve agent failed")));
+    }
+
+    #[tokio::test]
+    async fn after_nonzero_exit_adds_improve_failed_before_removing_changes_requested() {
+        let gh = Arc::new(MockGh::new());
+        let mut task = make_task(gh.clone());
+        let _ = task.before_invoke().await;
+
+        let response = AgentResponse {
+            exit_code: 1,
+            stdout: String::new(),
+            stderr: "error".to_string(),
+            duration: Duration::from_secs(5),
+        };
+        let _ = task.after_invoke(response).await;
+
+        gh.assert_add_before_remove(10, labels::IMPROVE_FAILED, labels::CHANGES_REQUESTED);
     }
 }

--- a/plugins/autodev/skills/label-setup/SKILL.md
+++ b/plugins/autodev/skills/label-setup/SKILL.md
@@ -24,6 +24,7 @@ GitHub 레포에 autodev 워크플로우에서 사용하는 라벨을 생성/업
 | `autodev:extracted` | `D4C5F9` (purple) | Knowledge extracted |
 | `autodev:extract-failed` | `B60205` (dark red) | Extraction failed |
 | `autodev:impl-failed` | `B60205` (dark red) | Implementation failed |
+| `autodev:improve-failed` | `B60205` (dark red) | Improve feedback failed |
 
 ## 입력 변수
 
@@ -47,6 +48,7 @@ declare -A LABEL_COLORS=(
   ["autodev:extracted"]="D4C5F9"
   ["autodev:extract-failed"]="B60205"
   ["autodev:impl-failed"]="B60205"
+  ["autodev:improve-failed"]="B60205"
 )
 
 declare -A LABEL_DESCS=(
@@ -61,6 +63,7 @@ declare -A LABEL_DESCS=(
   ["autodev:extracted"]="Knowledge extracted"
   ["autodev:extract-failed"]="Extraction failed"
   ["autodev:impl-failed"]="Implementation failed"
+  ["autodev:improve-failed"]="Improve feedback failed"
 )
 
 created=0


### PR DESCRIPTION
## Summary
- Add `IMPROVE_FAILED` (`autodev:improve-failed`) label constant to `labels.rs`
- Modify `ImproveTask` failure path to add `IMPROVE_FAILED` label (add-first pattern) and post a failure comment with exit code and branch info, matching `ImplementTask` behavior
- Update `label-setup` skill to include the new label for automatic GitHub registration

## Test plan
- [x] `after_nonzero_exit_removes_and_adds_improve_failed` — verifies IMPROVE_FAILED label added, CHANGES_REQUESTED removed, and failure comment posted
- [x] `after_nonzero_exit_adds_improve_failed_before_removing_changes_requested` — verifies add-first ordering
- [x] All existing tests pass (`cargo test`)
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --check` passes

Closes #224