### PR TITLE
fix(autodev): add failure label and comment on AnalyzeTask agent failure

### DIFF
--- a/plugins/autodev/cli/src/domain/labels.rs
+++ b/plugins/autodev/cli/src/domain/labels.rs
@@ -15,8 +15,9 @@ pub const CHANGES_REQUESTED: &str = "autodev:changes-requested";
 pub const EXTRACTED: &str = "autodev:extracted";
 pub const EXTRACT_FAILED: &str = "autodev:extract-failed";
 
-// v2.2: 구현 실패 라벨
+// v2.2: 실패 라벨
 pub const IMPL_FAILED: &str = "autodev:impl-failed";
+pub const ANALYZE_FAILED: &str = "autodev:analyze-failed";
 
 // v2: 리뷰 반복 횟수 라벨 (예: "autodev:iteration/1")
 pub const ITERATION_PREFIX: &str = "autodev:iteration/";

--- a/plugins/autodev/cli/src/tasks/analyze.rs
+++ b/plugins/autodev/cli/src/tasks/analyze.rs
@@ -423,6 +423,15 @@ impl Task for AnalyzeTask {
 
         // Agent 호출 실패 (exit_code != 0)
         if response.exit_code != 0 {
+            // add-first: 새 라벨 추가 → 이전 라벨 제거 (크래시 안전)
+            self.gh
+                .label_add(
+                    &self.item.repo_name,
+                    self.item.github_number,
+                    labels::ANALYZE_FAILED,
+                    gh_host,
+                )
+                .await;
             self.gh
                 .label_remove(
                     &self.item.repo_name,
@@ -431,6 +440,22 @@ impl Task for AnalyzeTask {
                     gh_host,
                 )
                 .await;
+
+            let fail_comment = format!(
+                "<!-- autodev:analyze-failed -->\n\
+                 ⚠️ Analysis agent failed (exit_code={}).\n\n\
+                 Check the agent logs for details.",
+                response.exit_code
+            );
+            self.gh
+                .issue_comment(
+                    &self.item.repo_name,
+                    self.item.github_number,
+                    &fail_comment,
+                    gh_host,
+                )
+                .await;
+
             self.cleanup_worktree().await;
             return TaskResult {
                 work_id: self.item.work_id.clone(),
@@ -831,6 +856,89 @@ mod tests {
 
         let removed = gh.removed_labels.lock().unwrap();
         assert!(removed.iter().any(|(_, _, l)| l == labels::WIP));
+
+        let added = gh.added_labels.lock().unwrap();
+        assert!(added.iter().any(|(_, _, l)| l == labels::ANALYZE_FAILED));
+
+        let comments = gh.posted_comments.lock().unwrap();
+        assert!(comments
+            .iter()
+            .any(|(_, _, body)| body.contains("<!-- autodev:analyze-failed -->")));
+    }
+
+    // ═══════════════════════════════════════════════
+    // after_invoke: agent failure (exit_code != 0) detailed tests
+    // ═══════════════════════════════════════════════
+
+    #[tokio::test]
+    async fn after_nonzero_exit_adds_analyze_failed_label() {
+        let gh = Arc::new(MockGh::new());
+        gh.set_field("org/repo", "issues/42", ".state", "open");
+
+        let mut task = make_task(gh.clone());
+        let _ = task.before_invoke().await;
+
+        let response = AgentResponse {
+            exit_code: 1,
+            stdout: String::new(),
+            stderr: "error".to_string(),
+            duration: Duration::from_secs(10),
+        };
+        let result = task.after_invoke(response).await;
+
+        assert!(matches!(result.status, TaskStatus::Failed(_)));
+
+        let added = gh.added_labels.lock().unwrap();
+        assert!(
+            added
+                .iter()
+                .any(|(_, n, l)| *n == 42 && l == labels::ANALYZE_FAILED),
+            "should add analyze-failed label on agent failure"
+        );
+    }
+
+    #[tokio::test]
+    async fn after_nonzero_exit_posts_failure_comment() {
+        let gh = Arc::new(MockGh::new());
+        gh.set_field("org/repo", "issues/42", ".state", "open");
+
+        let mut task = make_task(gh.clone());
+        let _ = task.before_invoke().await;
+
+        let response = AgentResponse {
+            exit_code: 1,
+            stdout: String::new(),
+            stderr: "crash".to_string(),
+            duration: Duration::from_secs(10),
+        };
+        let _ = task.after_invoke(response).await;
+
+        let comments = gh.posted_comments.lock().unwrap();
+        assert!(
+            comments
+                .iter()
+                .any(|(_, n, body)| *n == 42 && body.contains("<!-- autodev:analyze-failed -->")),
+            "should post failure comment with autodev:analyze-failed marker"
+        );
+    }
+
+    #[tokio::test]
+    async fn after_nonzero_exit_uses_add_first_ordering() {
+        let gh = Arc::new(MockGh::new());
+        gh.set_field("org/repo", "issues/42", ".state", "open");
+
+        let mut task = make_task(gh.clone());
+        let _ = task.before_invoke().await;
+
+        let response = AgentResponse {
+            exit_code: 1,
+            stdout: String::new(),
+            stderr: "error".to_string(),
+            duration: Duration::from_secs(10),
+        };
+        let _ = task.after_invoke(response).await;
+
+        gh.assert_add_before_remove(42, labels::ANALYZE_FAILED, labels::WIP);
     }
 
     // ─── auto-approve tests ───

--- a/plugins/autodev/skills/label-setup/SKILL.md
+++ b/plugins/autodev/skills/label-setup/SKILL.md
@@ -24,6 +24,7 @@ GitHub 레포에 autodev 워크플로우에서 사용하는 라벨을 생성/업
 | `autodev:extracted` | `D4C5F9` (purple) | Knowledge extracted |
 | `autodev:extract-failed` | `B60205` (dark red) | Extraction failed |
 | `autodev:impl-failed` | `B60205` (dark red) | Implementation failed |
+| `autodev:analyze-failed` | `B60205` (dark red) | Analysis failed |
 
 ## 입력 변수
 
@@ -47,6 +48,7 @@ declare -A LABEL_COLORS=(
   ["autodev:extracted"]="D4C5F9"
   ["autodev:extract-failed"]="B60205"
   ["autodev:impl-failed"]="B60205"
+  ["autodev:analyze-failed"]="B60205"
 )
 
 declare -A LABEL_DESCS=(
@@ -61,6 +63,7 @@ declare -A LABEL_DESCS=(
   ["autodev:extracted"]="Knowledge extracted"
   ["autodev:extract-failed"]="Extraction failed"
   ["autodev:impl-failed"]="Implementation failed"
+  ["autodev:analyze-failed"]="Analysis failed"
 )
 
 created=0


### PR DESCRIPTION
## Summary

- When `AnalyzeTask` agent fails (exit_code != 0), adds `autodev:analyze-failed` label and posts a failure comment instead of silently dropping the issue from the pipeline
- Uses add-first label ordering (add `analyze-failed` before removing `wip`) for crash safety
- Registers the new `autodev:analyze-failed` label in the label-setup skill

## Test plan

- [x] `cargo test --lib tasks::analyze` — all 22 tests pass (3 new tests added)
- [x] `cargo clippy -- -D warnings` — clean
- [ ] Verify `autodev:analyze-failed` label is created on target repo via `/label-setup`

Closes #223