### PR TITLE
fix(autodev): add review-failed label and comment on review agent failure

### DIFF
--- a/plugins/autodev/cli/src/domain/labels.rs
+++ b/plugins/autodev/cli/src/domain/labels.rs
@@ -15,8 +15,9 @@ pub const CHANGES_REQUESTED: &str = "autodev:changes-requested";
 pub const EXTRACTED: &str = "autodev:extracted";
 pub const EXTRACT_FAILED: &str = "autodev:extract-failed";
 
-// v2.2: 구현 실패 라벨
+// v2.2: 실패 라벨
 pub const IMPL_FAILED: &str = "autodev:impl-failed";
+pub const REVIEW_FAILED: &str = "autodev:review-failed";
 
 // v2: 리뷰 반복 횟수 라벨 (예: "autodev:iteration/1")
 pub const ITERATION_PREFIX: &str = "autodev:iteration/";

--- a/plugins/autodev/cli/src/tasks/review.rs
+++ b/plugins/autodev/cli/src/tasks/review.rs
@@ -219,6 +219,15 @@ impl Task for ReviewTask {
 
         // Agent 호출 실패
         if response.exit_code != 0 {
+            // add-first: REVIEW_FAILED 추가 후 WIP 제거
+            self.gh
+                .label_add(
+                    &self.item.repo_name,
+                    self.item.github_number,
+                    labels::REVIEW_FAILED,
+                    gh_host,
+                )
+                .await;
             self.gh
                 .label_remove(
                     &self.item.repo_name,
@@ -227,6 +236,22 @@ impl Task for ReviewTask {
                     gh_host,
                 )
                 .await;
+
+            let fail_comment = format!(
+                "<!-- autodev:review-failed -->\n\
+                 ⚠️ Review agent failed (exit_code={}).\n\n\
+                 Check the agent logs for details.",
+                response.exit_code
+            );
+            self.gh
+                .issue_comment(
+                    &self.item.repo_name,
+                    self.item.github_number,
+                    &fail_comment,
+                    gh_host,
+                )
+                .await;
+
             self.cleanup_worktree().await;
             return TaskResult {
                 work_id: self.item.work_id.clone(),
@@ -787,5 +812,76 @@ mod tests {
         assert!(matches!(result.status, TaskStatus::Failed(_)));
         let removed = gh.removed_labels.lock().unwrap();
         assert!(removed.iter().any(|(_, n, l)| *n == 10 && l == labels::WIP));
+    }
+
+    #[tokio::test]
+    async fn after_nonzero_exit_adds_review_failed_label() {
+        let gh = Arc::new(MockGh::new());
+        gh.set_field("org/repo", "pulls/10", ".state", "open");
+
+        let mut task = make_task(gh.clone(), None);
+        let _ = task.before_invoke().await;
+
+        let response = AgentResponse {
+            exit_code: 1,
+            stdout: String::new(),
+            stderr: "error".to_string(),
+            duration: Duration::from_secs(5),
+        };
+        let result = task.after_invoke(response).await;
+
+        assert!(matches!(result.status, TaskStatus::Failed(_)));
+
+        let added = gh.added_labels.lock().unwrap();
+        assert!(
+            added
+                .iter()
+                .any(|(_, n, l)| *n == 10 && l == labels::REVIEW_FAILED),
+            "should add review-failed label on agent failure"
+        );
+    }
+
+    #[tokio::test]
+    async fn after_nonzero_exit_adds_review_failed_before_removing_wip() {
+        let gh = Arc::new(MockGh::new());
+        gh.set_field("org/repo", "pulls/10", ".state", "open");
+
+        let mut task = make_task(gh.clone(), None);
+        let _ = task.before_invoke().await;
+
+        let response = AgentResponse {
+            exit_code: 1,
+            stdout: String::new(),
+            stderr: "error".to_string(),
+            duration: Duration::from_secs(5),
+        };
+        let _ = task.after_invoke(response).await;
+
+        gh.assert_add_before_remove(10, labels::REVIEW_FAILED, labels::WIP);
+    }
+
+    #[tokio::test]
+    async fn after_nonzero_exit_posts_failure_comment() {
+        let gh = Arc::new(MockGh::new());
+        gh.set_field("org/repo", "pulls/10", ".state", "open");
+
+        let mut task = make_task(gh.clone(), None);
+        let _ = task.before_invoke().await;
+
+        let response = AgentResponse {
+            exit_code: 1,
+            stdout: String::new(),
+            stderr: "crash".to_string(),
+            duration: Duration::from_secs(5),
+        };
+        let _ = task.after_invoke(response).await;
+
+        let comments = gh.posted_comments.lock().unwrap();
+        assert!(
+            comments
+                .iter()
+                .any(|(_, n, body)| *n == 10 && body.contains("autodev:review-failed")),
+            "should post failure comment on agent failure"
+        );
     }
 }

--- a/plugins/autodev/skills/label-setup/SKILL.md
+++ b/plugins/autodev/skills/label-setup/SKILL.md
@@ -24,6 +24,7 @@ GitHub 레포에 autodev 워크플로우에서 사용하는 라벨을 생성/업
 | `autodev:extracted` | `D4C5F9` (purple) | Knowledge extracted |
 | `autodev:extract-failed` | `B60205` (dark red) | Extraction failed |
 | `autodev:impl-failed` | `B60205` (dark red) | Implementation failed |
+| `autodev:review-failed` | `B60205` (dark red) | Review failed |
 
 ## 입력 변수
 
@@ -47,6 +48,7 @@ declare -A LABEL_COLORS=(
   ["autodev:extracted"]="D4C5F9"
   ["autodev:extract-failed"]="B60205"
   ["autodev:impl-failed"]="B60205"
+  ["autodev:review-failed"]="B60205"
 )
 
 declare -A LABEL_DESCS=(
@@ -61,6 +63,7 @@ declare -A LABEL_DESCS=(
   ["autodev:extracted"]="Knowledge extracted"
   ["autodev:extract-failed"]="Extraction failed"
   ["autodev:impl-failed"]="Implementation failed"
+  ["autodev:review-failed"]="Review failed"
 )
 
 created=0


### PR DESCRIPTION
## Summary
- Add `REVIEW_FAILED` label constant (`autodev:review-failed`) to `labels.rs`
- Fix `ReviewTask::after_invoke()` failure path to add `REVIEW_FAILED` label (add-first) and post a failure comment before removing `WIP`, preventing PRs from disappearing from the pipeline
- Register `autodev:review-failed` label in `label-setup` skill

## Test plan
- [x] `after_nonzero_exit_adds_review_failed_label` — verifies label is added on failure
- [x] `after_nonzero_exit_adds_review_failed_before_removing_wip` — verifies add-first ordering
- [x] `after_nonzero_exit_posts_failure_comment` — verifies failure comment is posted
- [x] All 15 review task tests pass
- [x] `cargo clippy` clean
- [x] `cargo fmt --check` clean

Closes #222