### PR TITLE
fix(autodev): use add-first label ordering in ImplementTask agent failure path

### DIFF
--- a/plugins/autodev/cli/src/tasks/implement.rs
+++ b/plugins/autodev/cli/src/tasks/implement.rs
@@ -247,18 +247,18 @@ impl Task for ImplementTask {
         // Agent 호출 실패
         if response.exit_code != 0 {
             self.gh
-                .label_remove(
-                    &self.item.repo_name,
-                    self.item.github_number,
-                    labels::IMPLEMENTING,
-                    gh_host,
-                )
-                .await;
-            self.gh
                 .label_add(
                     &self.item.repo_name,
                     self.item.github_number,
                     labels::IMPL_FAILED,
+                    gh_host,
+                )
+                .await;
+            self.gh
+                .label_remove(
+                    &self.item.repo_name,
+                    self.item.github_number,
+                    labels::IMPLEMENTING,
                     gh_host,
                 )
                 .await;
@@ -1096,6 +1096,25 @@ mod tests {
             stdout: "Done but no PR URL".to_string(),
             stderr: String::new(),
             duration: Duration::from_secs(30),
+        };
+        let _ = task.after_invoke(response).await;
+
+        gh.assert_add_before_remove(42, labels::IMPL_FAILED, labels::IMPLEMENTING);
+    }
+
+    #[tokio::test]
+    async fn after_nonzero_exit_adds_impl_failed_before_removing_implementing() {
+        let gh = Arc::new(MockGh::new());
+        let ws = Arc::new(MockWorkspace::new());
+        let cfg = Arc::new(MockConfigLoader);
+        let mut task = ImplementTask::new(ws, gh.clone(), cfg, make_test_issue());
+        let _ = task.before_invoke().await;
+
+        let response = AgentResponse {
+            exit_code: 1,
+            stdout: String::new(),
+            stderr: "agent crashed".to_string(),
+            duration: Duration::from_secs(5),
         };
         let _ = task.after_invoke(response).await;
 


### PR DESCRIPTION
## Summary

- Swap `label_remove`/`label_add` order in `ImplementTask::after_invoke()` when `exit_code != 0` so `IMPL_FAILED` is added **before** `IMPLEMENTING` is removed
- Prevents the issue from losing both labels if the process crashes between the two calls (becoming invisible to the scanner)
- Add `after_nonzero_exit_adds_impl_failed_before_removing_implementing` test

## Test plan

- [x] `cargo test` — all implement tests pass including new test
- [x] `cargo clippy -- -D warnings` — no warnings

Closes #221