### PR TITLE
feat(autodev): implement cron expression parsing for scheduled jobs

### DIFF
--- a/plugins/autodev/cli/Cargo.lock
+++ b/plugins/autodev/cli/Cargo.lock
@@ -128,13 +128,14 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autodev"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
  "async-trait",
  "chrono",
  "clap",
+ "cron",
  "crossterm",
  "libc",
  "predicates",
@@ -292,6 +293,17 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cron"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5877d3fbf742507b66bc2a1945106bd30dd8504019d596901ddd012a4dd01740"
+dependencies = [
+ "chrono",
+ "once_cell",
+ "winnow",
+]
 
 [[package]]
 name = "crossbeam-channel"
@@ -1862,6 +1874,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.6.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/plugins/autodev/cli/Cargo.toml
+++ b/plugins/autodev/cli/Cargo.toml
@@ -43,6 +43,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-appender = "0.2"
 uuid = { version = "1", features = ["v4"] }
+cron = "0.15.0"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/plugins/autodev/cli/src/infra/db/repository.rs
+++ b/plugins/autodev/cli/src/infra/db/repository.rs
@@ -1089,9 +1089,33 @@ impl CronRepository for Database {
                         due_jobs.push(job);
                     }
                 }
-                CronSchedule::Expression { .. } => {
-                    // For now, return all active expression jobs
-                    due_jobs.push(job);
+                CronSchedule::Expression { ref cron } => {
+                    use cron::Schedule;
+                    use std::str::FromStr;
+
+                    let Ok(schedule) = Schedule::from_str(cron) else {
+                        // Skip jobs with invalid cron expressions
+                        continue;
+                    };
+
+                    let is_due = if let Some(ref last) = job.last_run_at {
+                        if let Ok(last_time) = chrono::DateTime::parse_from_rfc3339(last) {
+                            // Check if there's a scheduled time between last_run and now
+                            schedule
+                                .after(&last_time.with_timezone(&chrono::Utc))
+                                .next()
+                                .map(|next| next <= now)
+                                .unwrap_or(false)
+                        } else {
+                            true // Can't parse last_run → treat as due
+                        }
+                    } else {
+                        true // Never run → due
+                    };
+
+                    if is_due {
+                        due_jobs.push(job);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- `cron` 크레이트(v0.15.0) 추가
- `cron_find_due()`의 `CronSchedule::Expression` stub을 실제 파싱으로 교체
- 엣지 케이스 처리: 잘못된 표현식(skip), 미실행 job(due), 파싱 불가 last_run_at(due)

## Test plan
- [x] `cargo fmt --check` 통과
- [x] `cargo clippy -- -D warnings` 통과
- [x] `cargo test` 전체 통과

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)