### PR TITLE
feat(autodev): implement agent headless mode and cron engine internal lock

### DIFF
--- a/plugins/autodev/cli/Cargo.lock
+++ b/plugins/autodev/cli/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autodev"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/plugins/autodev/cli/src/cli/queue.rs
+++ b/plugins/autodev/cli/src/cli/queue.rs
@@ -30,8 +30,26 @@ pub fn queue_skip(db: &Database, work_id: &str, reason: Option<&str>) -> Result<
 }
 
 /// DB 기반 큐 아이템 목록 조회
-pub fn queue_list_db(db: &Database, repo: Option<&str>, json: bool) -> Result<String> {
-    let items = db.queue_list_items(repo)?;
+pub fn queue_list_db(
+    db: &Database,
+    repo: Option<&str>,
+    json: bool,
+    state: Option<&str>,
+    unextracted: bool,
+) -> Result<String> {
+    let mut items = db.queue_list_items(repo)?;
+
+    // Apply --state filter
+    if let Some(phase_filter) = state {
+        items.retain(|item| item.phase == phase_filter);
+    }
+
+    // Apply --unextracted filter: done + pr type + no skip_reason
+    if unextracted {
+        items.retain(|item| {
+            item.phase == "done" && item.queue_type == "pr" && item.skip_reason.is_none()
+        });
+    }
 
     if json {
         return Ok(serde_json::to_string_pretty(&items)?);

--- a/plugins/autodev/cli/src/daemon/cron/engine.rs
+++ b/plugins/autodev/cli/src/daemon/cron/engine.rs
@@ -1,5 +1,7 @@
+use std::collections::HashMap;
 use std::path::PathBuf;
 
+use tokio::task::JoinHandle;
 use tracing::{info, warn};
 
 use crate::core::models::RepoInfo;
@@ -12,21 +14,35 @@ use super::runner::{CronExecResult, ScriptRunner};
 ///
 /// Called from the daemon tick loop. On each tick it:
 /// 1. Queries the DB for due cron jobs (active + interval elapsed)
-/// 2. Resolves repo info for per-repo jobs
-/// 3. Builds env vars and executes each script
-/// 4. Updates last_run_at after execution
+/// 2. Checks in-memory running map to prevent duplicate execution
+/// 3. Resolves repo info for per-repo jobs
+/// 4. Builds env vars and executes each script
+/// 5. Updates last_run_at after execution
 pub struct CronEngine {
     db: Database,
     home: PathBuf,
+    /// In-memory tracking of running jobs to prevent duplicate execution.
+    /// Key = job ID, Value = JoinHandle of the spawned task.
+    running: HashMap<String, JoinHandle<()>>,
 }
 
 impl CronEngine {
     pub fn new(db: Database, home: PathBuf) -> Self {
-        Self { db, home }
+        Self {
+            db,
+            home,
+            running: HashMap::new(),
+        }
     }
 
     /// Check for due cron jobs and execute them.
-    pub async fn tick(&self) -> Vec<CronExecResult> {
+    ///
+    /// Jobs that are still running from a previous tick are skipped.
+    /// Finished jobs are cleaned up before processing new ones.
+    pub async fn tick(&mut self) -> Vec<CronExecResult> {
+        // Clean up finished jobs
+        self.running.retain(|_id, handle| !handle.is_finished());
+
         let due_jobs = match self.db.cron_find_due() {
             Ok(jobs) => jobs,
             Err(e) => {
@@ -47,6 +63,15 @@ impl CronEngine {
         let mut results = Vec::new();
 
         for job in &due_jobs {
+            // Skip if this job is still running from a previous tick
+            if self.running.contains_key(&job.id) {
+                info!(
+                    "cron: skipping '{}' (still running from previous tick)",
+                    job.name
+                );
+                continue;
+            }
+
             let repo_info = job.repo_id.as_ref().and_then(|rid| {
                 enabled_repos
                     .iter()
@@ -71,6 +96,24 @@ impl CronEngine {
 
         results
     }
+
+    /// Spawn a long-running job and track it in the running map.
+    /// Returns true if the job was spawned, false if it was already running.
+    pub fn spawn_job(&mut self, job_id: String, job_name: String, future: JoinHandle<()>) -> bool {
+        if let Some(handle) = self.running.get(&job_id) {
+            if !handle.is_finished() {
+                info!("cron: cannot spawn '{}': already running", job_name);
+                return false;
+            }
+        }
+        self.running.insert(job_id, future);
+        true
+    }
+
+    /// Check if a specific job is currently running.
+    pub fn is_running(&self, job_id: &str) -> bool {
+        self.running.get(job_id).is_some_and(|h| !h.is_finished())
+    }
 }
 
 #[cfg(test)]
@@ -91,7 +134,7 @@ mod tests {
     #[tokio::test]
     async fn tick_returns_empty_when_no_due_jobs() {
         let (dir, db) = setup_db();
-        let engine = CronEngine::new(db, dir.path().to_path_buf());
+        let mut engine = CronEngine::new(db, dir.path().to_path_buf());
 
         let results = engine.tick().await;
         assert!(results.is_empty());
@@ -111,7 +154,7 @@ mod tests {
         })
         .unwrap();
 
-        let engine = CronEngine::new(db, dir.path().to_path_buf());
+        let mut engine = CronEngine::new(db, dir.path().to_path_buf());
 
         let results = engine.tick().await;
         assert_eq!(results.len(), 1);
@@ -136,7 +179,7 @@ mod tests {
         db.cron_set_status("paused-job", None, CronStatus::Paused)
             .unwrap();
 
-        let engine = CronEngine::new(db, dir.path().to_path_buf());
+        let mut engine = CronEngine::new(db, dir.path().to_path_buf());
 
         let results = engine.tick().await;
         assert!(results.is_empty());
@@ -158,7 +201,7 @@ mod tests {
         // Open a separate DB connection to verify the update
         let verify_db = Database::open(&dir.path().join("test.db")).unwrap();
 
-        let engine = CronEngine::new(db, dir.path().to_path_buf());
+        let mut engine = CronEngine::new(db, dir.path().to_path_buf());
         let results = engine.tick().await;
         assert_eq!(results.len(), 1);
 
@@ -180,7 +223,7 @@ mod tests {
         })
         .unwrap();
 
-        let engine = CronEngine::new(db, dir.path().to_path_buf());
+        let mut engine = CronEngine::new(db, dir.path().to_path_buf());
 
         let results = engine.tick().await;
         assert_eq!(results.len(), 1);
@@ -200,7 +243,7 @@ mod tests {
         })
         .unwrap();
 
-        let engine = CronEngine::new(db, dir.path().to_path_buf());
+        let mut engine = CronEngine::new(db, dir.path().to_path_buf());
 
         // First tick should execute
         let results = engine.tick().await;
@@ -209,5 +252,33 @@ mod tests {
         // Second tick should NOT execute (interval not elapsed)
         let results = engine.tick().await;
         assert!(results.is_empty());
+    }
+
+    #[tokio::test]
+    async fn is_running_returns_false_when_no_job() {
+        let (dir, db) = setup_db();
+        let engine = CronEngine::new(db, dir.path().to_path_buf());
+
+        assert!(!engine.is_running("nonexistent"));
+    }
+
+    #[tokio::test]
+    async fn spawn_job_tracks_running_job() {
+        let (dir, db) = setup_db();
+        let mut engine = CronEngine::new(db, dir.path().to_path_buf());
+
+        // Spawn a job that sleeps briefly
+        let handle = tokio::spawn(async {
+            tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+        });
+
+        let spawned = engine.spawn_job("job-1".to_string(), "test-job".to_string(), handle);
+        assert!(spawned);
+        assert!(engine.is_running("job-1"));
+
+        // Trying to spawn the same job should fail
+        let handle2 = tokio::spawn(async {});
+        let spawned2 = engine.spawn_job("job-1".to_string(), "test-job".to_string(), handle2);
+        assert!(!spawned2);
     }
 }

--- a/plugins/autodev/cli/src/daemon/mod.rs
+++ b/plugins/autodev/cli/src/daemon/mod.rs
@@ -194,7 +194,7 @@ impl Daemon {
                     self.reporter.maybe_run().await;
 
                     // Execute due cron jobs
-                    if let Some(ref cron) = self.cron_engine {
+                    if let Some(ref mut cron) = self.cron_engine {
                         let results = cron.tick().await;
                         for r in &results {
                             info!("cron '{}' completed: exit_code={}", r.job_name, r.exit_code);

--- a/plugins/autodev/cli/src/main.rs
+++ b/plugins/autodev/cli/src/main.rs
@@ -4,6 +4,8 @@ use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 
 use autodev::core::config;
+use autodev::core::models::NewConsumerLog;
+use autodev::core::repository::{ConsumerLogRepository, RepoRepository};
 use autodev::{cli as client, daemon, infra, tui};
 
 use infra::claude::RealClaude;
@@ -108,7 +110,14 @@ enum Commands {
         json: bool,
     },
     /// Claw 에이전트 세션 시작 (claude --cwd ~/.autodev/claw-workspace)
-    Agent,
+    Agent {
+        /// Headless 모드 프롬프트 (지정 시 비대화형 실행)
+        #[arg(short = 'p', long)]
+        prompt: Option<String>,
+        /// 대상 레포 이름 (org/repo)
+        #[arg(long)]
+        repo: Option<String>,
+    },
     /// Convention bootstrap — detect tech stack and generate .claude/rules/
     Convention {
         #[command(subcommand)]
@@ -159,6 +168,12 @@ enum QueueAction {
         /// JSON 출력
         #[arg(long)]
         json: bool,
+        /// phase 필터 (pending, ready, running, done, skipped)
+        #[arg(long)]
+        state: Option<String>,
+        /// 미추출 항목만 (done 상태, queue_type=pr, skip_reason 없음)
+        #[arg(long)]
+        unextracted: bool,
     },
     /// 큐 아이템을 다음 phase로 전이
     Advance {
@@ -559,9 +574,30 @@ async fn main() -> Result<()> {
             }
         },
         Commands::Queue { action } => match action {
-            QueueAction::List { repo, json } => {
+            QueueAction::List {
+                repo,
+                json,
+                state,
+                unextracted,
+            } => {
                 if json {
-                    let output = client::queue::queue_list_db(&db, repo.as_deref(), true)?;
+                    let output = client::queue::queue_list_db(
+                        &db,
+                        repo.as_deref(),
+                        true,
+                        state.as_deref(),
+                        unextracted,
+                    )?;
+                    println!("{output}");
+                } else if state.is_some() || unextracted {
+                    // Filters require DB-based query
+                    let output = client::queue::queue_list_db(
+                        &db,
+                        repo.as_deref(),
+                        false,
+                        state.as_deref(),
+                        unextracted,
+                    )?;
                     println!("{output}");
                 } else {
                     let output = client::queue_list(&env, repo.as_deref())?;
@@ -744,18 +780,100 @@ async fn main() -> Result<()> {
                 print!("{output}");
             }
         }
-        Commands::Agent => {
+        Commands::Agent { prompt, repo } => {
             let ws = client::claw::claw_workspace_path(&home);
             if !ws.exists() {
                 anyhow::bail!("Claw workspace not initialized. Run 'autodev claw init' first.");
             }
-            let status = std::process::Command::new("claude")
-                .arg("--cwd")
-                .arg(&ws)
-                .status()
-                .context("failed to launch claude. Is it installed?")?;
-            if !status.success() {
-                std::process::exit(status.code().unwrap_or(1));
+
+            // Resolve repo context if --repo is provided
+            let mut extra_env: Vec<(String, String)> = Vec::new();
+            if let Some(ref repo_name) = repo {
+                let enabled = db.repo_find_enabled()?;
+                let repo_entry = enabled
+                    .iter()
+                    .find(|r| r.name == *repo_name)
+                    .ok_or_else(|| anyhow::anyhow!("repository not found: {repo_name}"))?;
+                extra_env.push(("AUTODEV_REPO_NAME".to_string(), repo_entry.name.clone()));
+                extra_env.push(("AUTODEV_REPO_ROOT".to_string(), {
+                    let ws_dir = config::workspaces_path(&env)
+                        .join(config::sanitize_repo_name(&repo_entry.name));
+                    ws_dir.to_string_lossy().to_string()
+                }));
+                extra_env.push(("AUTODEV_REPO_ID".to_string(), repo_entry.id.clone()));
+            }
+
+            if let Some(ref prompt_text) = prompt {
+                // Headless mode: run claude non-interactively with --print
+                let started_at = chrono::Utc::now();
+                let start_instant = std::time::Instant::now();
+                let output = std::process::Command::new("claude")
+                    .arg("--print")
+                    .arg("-p")
+                    .arg(prompt_text)
+                    .arg("--cwd")
+                    .arg(&ws)
+                    .envs(extra_env.iter().map(|(k, v)| (k.as_str(), v.as_str())))
+                    .output()
+                    .context("failed to launch claude. Is it installed?")?;
+
+                let duration_ms = start_instant.elapsed().as_millis() as i64;
+                let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+                let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+                let exit_code = output.status.code().unwrap_or(-1);
+
+                // Print output
+                if !stdout.is_empty() {
+                    print!("{stdout}");
+                }
+                if !stderr.is_empty() {
+                    eprint!("{stderr}");
+                }
+
+                // Log to DB
+                let repo_id = repo
+                    .as_ref()
+                    .and_then(|name| {
+                        db.repo_find_enabled()
+                            .ok()?
+                            .iter()
+                            .find(|r| r.name == *name)
+                            .map(|r| r.id.clone())
+                    })
+                    .unwrap_or_else(|| "global".to_string());
+                let log = NewConsumerLog {
+                    repo_id,
+                    queue_type: "agent".to_string(),
+                    queue_item_id: "headless".to_string(),
+                    worker_id: "agent-cli".to_string(),
+                    command: format!("claude --print -p \"{}\"", prompt_text),
+                    stdout: stdout.chars().take(10000).collect(),
+                    stderr: stderr.chars().take(5000).collect(),
+                    exit_code,
+                    started_at: started_at.to_rfc3339(),
+                    finished_at: chrono::Utc::now().to_rfc3339(),
+                    duration_ms,
+                };
+                if let Err(e) = db.log_insert(&log) {
+                    eprintln!("warning: failed to log agent execution: {e}");
+                }
+
+                if !output.status.success() {
+                    std::process::exit(exit_code);
+                }
+            } else {
+                // Interactive mode (existing behavior)
+                let mut cmd = std::process::Command::new("claude");
+                cmd.arg("--cwd").arg(&ws);
+                for (k, v) in &extra_env {
+                    cmd.env(k, v);
+                }
+                let status = cmd
+                    .status()
+                    .context("failed to launch claude. Is it installed?")?;
+                if !status.success() {
+                    std::process::exit(status.code().unwrap_or(1));
+                }
             }
         }
         Commands::Convention { action } => match action {

--- a/plugins/autodev/cli/tests/queue_advance_tests.rs
+++ b/plugins/autodev/cli/tests/queue_advance_tests.rs
@@ -250,7 +250,7 @@ fn cli_queue_list_db_json_output() {
     let repo_id = add_test_repo(&db);
     insert_queue_item(&db, &repo_id, "work-cli-3", "pending");
 
-    let output = autodev::cli::queue::queue_list_db(&db, None, true).unwrap();
+    let output = autodev::cli::queue::queue_list_db(&db, None, true, None, false).unwrap();
     let parsed: Vec<autodev::core::models::QueueItem> =
         serde_json::from_str(&output).expect("valid JSON");
     assert_eq!(parsed.len(), 1);
@@ -261,6 +261,6 @@ fn cli_queue_list_db_json_output() {
 fn cli_queue_list_db_empty() {
     let db = open_memory_db();
 
-    let output = autodev::cli::queue::queue_list_db(&db, None, false).unwrap();
+    let output = autodev::cli::queue::queue_list_db(&db, None, false, None, false).unwrap();
     assert!(output.contains("no queue items"));
 }

--- a/plugins/autodev/templates/crons/knowledge-extract.sh
+++ b/plugins/autodev/templates/crons/knowledge-extract.sh
@@ -8,8 +8,8 @@
 set -euo pipefail
 
 # Guard: 미추출 merged PR이 있는지 확인
-UNEXTRACTED=$(autodev queue list --json --repo "$AUTODEV_REPO_NAME" \
-  | jq '[.[] | select(.state == "done" and .extracted == false)] | length')
+UNEXTRACTED=$(autodev queue list --json --repo "$AUTODEV_REPO_NAME" --unextracted \
+  | jq 'length')
 
 if [ "$UNEXTRACTED" = "0" ]; then
   echo "skip: $AUTODEV_REPO_NAME 미추출 merged PR 없음"


### PR DESCRIPTION
## Summary
- **agent headless mode**: `autodev agent -p "<prompt>"` (global) / `autodev agent --repo <name> -p "<prompt>"` (repo context) 지원. --repo 시 AUTODEV_REPO_NAME/ROOT/ID 환경변수 자동 주입, 실행 결과 DB 로깅
- **cron engine lock**: `HashMap<String, JoinHandle<()>>` 기반 in-memory 중복 실행 방지. tick마다 finished job 정리, 실행 중인 job skip
- **queue list filters**: `--state <phase>`, `--unextracted` 플래그 추가. knowledge-extract.sh에서 jq 대신 CLI 필터 사용

## Test plan
- [x] `cargo fmt --check` 통과
- [x] `cargo clippy -- -D warnings` 통과
- [x] `cargo test` 전체 통과 (500+ tests)

Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)