### PR TITLE
refactor(autodev): implement DB SSOT for queue system

### DIFF
--- a/plugins/autodev/cli/Cargo.lock
+++ b/plugins/autodev/cli/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autodev"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/plugins/autodev/cli/src/cli/queue.rs
+++ b/plugins/autodev/cli/src/cli/queue.rs
@@ -75,8 +75,14 @@ pub fn queue_list_db(
             .map(|r| format!(" [reason: {r}]"))
             .unwrap_or_default();
         output.push_str(&format!(
-            "  [{}] {} — {} ({}){}\n",
-            item.queue_type, item.work_id, item.phase, title, skip
+            "  [{}] {} — {} ({}) [{}/#{}]{}\n",
+            item.queue_type,
+            item.work_id,
+            item.phase,
+            title,
+            item.task_kind,
+            item.github_number,
+            skip
         ));
     }
     Ok(output)

--- a/plugins/autodev/cli/src/core/models.rs
+++ b/plugins/autodev/cli/src/core/models.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use serde::{Deserialize, Serialize};
 
 use super::labels;
+use super::phase::TaskKind;
 
 // ─── Label trait ───
 
@@ -370,6 +371,9 @@ pub struct QueueItemRow {
     pub skip_reason: Option<String>,
     pub created_at: String,
     pub updated_at: String,
+    pub task_kind: TaskKind,
+    pub github_number: i64,
+    pub metadata_json: Option<String>,
 }
 
 // ─── Spec models ───

--- a/plugins/autodev/cli/src/core/queue_item.rs
+++ b/plugins/autodev/cli/src/core/queue_item.rs
@@ -1,4 +1,6 @@
-use super::models::{QueueType, RepoIssue, RepoPull};
+use serde::{Deserialize, Serialize};
+
+use super::models::{QueueItemRow, QueuePhase, QueueType, RepoIssue, RepoPull};
 use super::phase::TaskKind;
 use super::state_queue::HasWorkId;
 use super::task_queues::make_work_id;
@@ -22,7 +24,7 @@ pub struct RepoRef {
 ///
 /// `ItemMetadata::Pr`와 1:1 대응하지만, 독립 struct로 분리하여
 /// `new_pr` 호출부에서 Issue 메타데이터를 실수로 전달할 수 없도록 한다.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PrMetadata {
     pub head_branch: String,
     pub base_branch: String,
@@ -34,7 +36,7 @@ pub struct PrMetadata {
 // ─── Internal Metadata Enum ───
 
 /// QueueItem 내부 메타데이터. 외부에서 직접 생성하지 않는다.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) enum ItemMetadata {
     Issue {
         body: Option<String>,
@@ -253,6 +255,76 @@ impl QueueItem {
         )
     }
 
+    /// 메타데이터를 JSON 문자열로 직렬화한다.
+    pub fn metadata_json(&self) -> Option<String> {
+        serde_json::to_string(&self.metadata).ok()
+    }
+
+    /// JSON 문자열에서 ItemMetadata를 역직렬화한다.
+    pub(crate) fn metadata_from_json(json: &str) -> Option<ItemMetadata> {
+        serde_json::from_str(json).ok()
+    }
+
+    /// QueueItem을 DB 행으로 변환한다.
+    pub fn to_row(&self, phase: QueuePhase) -> QueueItemRow {
+        let now = chrono::Utc::now().to_rfc3339();
+        QueueItemRow {
+            work_id: self.work_id.clone(),
+            repo_id: self.repo_id.clone(),
+            queue_type: self.queue_type.clone(),
+            phase,
+            title: Some(self.title.clone()),
+            skip_reason: None,
+            created_at: now.clone(),
+            updated_at: now,
+            task_kind: self.task_kind,
+            github_number: self.github_number,
+            metadata_json: self.metadata_json(),
+        }
+    }
+
+    /// DB 행에서 QueueItem을 복원한다.
+    pub fn from_row(
+        row: &QueueItemRow,
+        repo_name: &str,
+        repo_url: &str,
+        gh_host: Option<&str>,
+    ) -> Option<Self> {
+        let metadata = match &row.metadata_json {
+            Some(json) => Self::metadata_from_json(json)?,
+            None => match row.queue_type {
+                QueueType::Issue => ItemMetadata::Issue {
+                    body: None,
+                    labels: vec![],
+                    author: String::new(),
+                    analysis_report: None,
+                },
+                QueueType::Pr | QueueType::Knowledge | QueueType::Agent => {
+                    ItemMetadata::Pr(PrMetadata {
+                        head_branch: String::new(),
+                        base_branch: String::new(),
+                        review_comment: None,
+                        source_issue_number: None,
+                        review_iteration: 0,
+                    })
+                }
+            },
+        };
+
+        Some(Self {
+            work_id: row.work_id.clone(),
+            repo_id: row.repo_id.clone(),
+            repo_name: repo_name.to_string(),
+            repo_url: repo_url.to_string(),
+            github_number: row.github_number,
+            queue_type: row.queue_type.clone(),
+            task_kind: row.task_kind,
+            title: row.title.clone().unwrap_or_default(),
+            metadata,
+            gh_host: gh_host.map(|s| s.to_string()),
+        })
+    }
+
     /// PR QueueItem 생성
     pub fn new_pr(
         repo: &RepoRef,
@@ -459,5 +531,67 @@ mod tests {
         );
         assert_eq!(item.head_branch(), None);
         assert_eq!(item.base_branch(), None);
+    }
+
+    #[test]
+    fn metadata_json_roundtrip_issue() {
+        let item = test_issue(42, TaskKind::Analyze);
+        let json = item.metadata_json().unwrap();
+        let meta = QueueItem::metadata_from_json(&json).unwrap();
+        match meta {
+            ItemMetadata::Issue { body, author, .. } => {
+                assert_eq!(body.as_deref(), Some("test body"));
+                assert_eq!(author, "user");
+            }
+            _ => panic!("expected Issue metadata"),
+        }
+    }
+
+    #[test]
+    fn metadata_json_roundtrip_pr() {
+        let item = test_pr_with_source(10, TaskKind::Review, Some(42), 3);
+        let json = item.metadata_json().unwrap();
+        let meta = QueueItem::metadata_from_json(&json).unwrap();
+        match meta {
+            ItemMetadata::Pr(pr) => {
+                assert_eq!(pr.head_branch, "autodev/issue-42");
+                assert_eq!(pr.base_branch, "main");
+                assert_eq!(pr.source_issue_number, Some(42));
+                assert_eq!(pr.review_iteration, 3);
+            }
+            _ => panic!("expected Pr metadata"),
+        }
+    }
+
+    #[test]
+    fn queue_item_to_row_roundtrip() {
+        let item = test_issue(42, TaskKind::Analyze);
+        let row = item.to_row(QueuePhase::Pending);
+
+        assert_eq!(row.work_id, "issue:org/repo:42");
+        assert_eq!(row.task_kind, TaskKind::Analyze);
+        assert_eq!(row.github_number, 42);
+        assert!(row.metadata_json.is_some());
+
+        let restored =
+            QueueItem::from_row(&row, "org/repo", "https://github.com/org/repo", None).unwrap();
+        assert_eq!(restored.work_id, item.work_id);
+        assert_eq!(restored.github_number, item.github_number);
+        assert_eq!(restored.task_kind, item.task_kind);
+        assert_eq!(restored.body(), item.body());
+        assert_eq!(restored.author(), item.author());
+    }
+
+    #[test]
+    fn from_row_with_null_metadata_creates_default() {
+        let mut row = test_issue(42, TaskKind::Analyze).to_row(QueuePhase::Pending);
+        row.metadata_json = None;
+
+        let restored =
+            QueueItem::from_row(&row, "org/repo", "https://github.com/org/repo", None).unwrap();
+        assert_eq!(restored.work_id, "issue:org/repo:42");
+        // Default Issue metadata has empty fields
+        assert_eq!(restored.body(), None);
+        assert_eq!(restored.author(), Some(""));
     }
 }

--- a/plugins/autodev/cli/src/core/repository.rs
+++ b/plugins/autodev/cli/src/core/repository.rs
@@ -68,6 +68,14 @@ pub trait QueueRepository {
     fn queue_skip(&self, work_id: &str, reason: Option<&str>) -> Result<()>;
     /// 큐 아이템 목록을 조회한다 (repo별 필터 가능)
     fn queue_list_items(&self, repo: Option<&str>) -> Result<Vec<QueueItemRow>>;
+    /// 큐 아이템을 upsert한다 (INSERT OR REPLACE, created_at 보존)
+    fn queue_upsert(&self, item: &QueueItemRow) -> Result<()>;
+    /// 큐 아이템을 done 상태로 전이한다
+    fn queue_remove(&self, work_id: &str) -> Result<()>;
+    /// 특정 repo의 활성 큐 아이템을 로드한다 (done/skipped 제외)
+    fn queue_load_active(&self, repo_id: &str) -> Result<Vec<QueueItemRow>>;
+    /// CAS 방식으로 phase를 전이한다 (from → to). 성공 시 true.
+    fn queue_transit(&self, work_id: &str, from: QueuePhase, to: QueuePhase) -> Result<bool>;
 }
 
 pub trait ClawDecisionRepository {

--- a/plugins/autodev/cli/src/infra/db/mod.rs
+++ b/plugins/autodev/cli/src/infra/db/mod.rs
@@ -18,7 +18,9 @@ impl Database {
     }
 
     pub fn initialize(&self) -> Result<()> {
-        schema::create_tables(&self.conn)
+        schema::create_tables(&self.conn)?;
+        schema::migrate_v2(&self.conn)?;
+        Ok(())
     }
 
     pub fn conn(&self) -> &Connection {

--- a/plugins/autodev/cli/src/infra/db/repository.rs
+++ b/plugins/autodev/cli/src/infra/db/repository.rs
@@ -754,7 +754,8 @@ impl QueueRepository for Database {
             if let Some(name) = repo {
                 (
                     "SELECT q.work_id, q.repo_id, q.queue_type, q.phase, q.title, \
-                     q.skip_reason, q.created_at, q.updated_at \
+                     q.skip_reason, q.created_at, q.updated_at, \
+                     q.task_kind, q.github_number, q.metadata_json \
                      FROM queue_items q JOIN repositories r ON q.repo_id = r.id \
                      WHERE r.name = ?1 ORDER BY q.created_at DESC"
                         .to_string(),
@@ -763,7 +764,8 @@ impl QueueRepository for Database {
             } else {
                 (
                     "SELECT work_id, repo_id, queue_type, phase, title, \
-                     skip_reason, created_at, updated_at \
+                     skip_reason, created_at, updated_at, \
+                     task_kind, github_number, metadata_json \
                      FROM queue_items ORDER BY created_at DESC"
                         .to_string(),
                     vec![],
@@ -775,6 +777,65 @@ impl QueueRepository for Database {
             params.iter().map(|p| p.as_ref()).collect();
         let rows = stmt.query_map(params_refs.as_slice(), map_queue_item_row)?;
         rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    }
+
+    fn queue_upsert(&self, item: &QueueItemRow) -> Result<()> {
+        let conn = self.conn();
+        let now = Utc::now().to_rfc3339();
+        conn.execute(
+            "INSERT INTO queue_items (work_id, repo_id, queue_type, phase, title, skip_reason, \
+             created_at, updated_at, task_kind, github_number, metadata_json) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11) \
+             ON CONFLICT(work_id) DO UPDATE SET \
+             phase = excluded.phase, title = excluded.title, skip_reason = excluded.skip_reason, \
+             updated_at = ?8, task_kind = excluded.task_kind, \
+             github_number = excluded.github_number, metadata_json = excluded.metadata_json",
+            rusqlite::params![
+                item.work_id,
+                item.repo_id,
+                item.queue_type.as_str(),
+                item.phase.as_str(),
+                item.title,
+                item.skip_reason,
+                item.created_at,
+                now,
+                item.task_kind.as_str(),
+                item.github_number,
+                item.metadata_json,
+            ],
+        )?;
+        Ok(())
+    }
+
+    fn queue_remove(&self, work_id: &str) -> Result<()> {
+        let now = Utc::now().to_rfc3339();
+        self.conn().execute(
+            "UPDATE queue_items SET phase = 'done', updated_at = ?1 WHERE work_id = ?2",
+            rusqlite::params![now, work_id],
+        )?;
+        Ok(())
+    }
+
+    fn queue_load_active(&self, repo_id: &str) -> Result<Vec<QueueItemRow>> {
+        let conn = self.conn();
+        let mut stmt = conn.prepare(
+            "SELECT work_id, repo_id, queue_type, phase, title, \
+             skip_reason, created_at, updated_at, \
+             task_kind, github_number, metadata_json \
+             FROM queue_items WHERE repo_id = ?1 AND phase NOT IN ('done', 'skipped') \
+             ORDER BY created_at ASC",
+        )?;
+        let rows = stmt.query_map(rusqlite::params![repo_id], map_queue_item_row)?;
+        rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    }
+
+    fn queue_transit(&self, work_id: &str, from: QueuePhase, to: QueuePhase) -> Result<bool> {
+        let now = Utc::now().to_rfc3339();
+        let affected = self.conn().execute(
+            "UPDATE queue_items SET phase = ?1, updated_at = ?2 WHERE work_id = ?3 AND phase = ?4",
+            rusqlite::params![to.as_str(), now, work_id, from.as_str()],
+        )?;
+        Ok(affected > 0)
     }
 }
 
@@ -1222,6 +1283,7 @@ fn map_spec_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Spec> {
 fn map_queue_item_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<QueueItemRow> {
     let queue_type_str: String = row.get(2)?;
     let phase_str: String = row.get(3)?;
+    let task_kind_str: String = row.get(8)?;
     Ok(QueueItemRow {
         work_id: row.get(0)?,
         repo_id: row.get(1)?,
@@ -1243,6 +1305,15 @@ fn map_queue_item_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<QueueItemRow>
         skip_reason: row.get(5)?,
         created_at: row.get(6)?,
         updated_at: row.get(7)?,
+        task_kind: task_kind_str.parse().map_err(|e: String| {
+            rusqlite::Error::FromSqlConversionFailure(
+                8,
+                rusqlite::types::Type::Text,
+                Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, e)),
+            )
+        })?,
+        github_number: row.get(9)?,
+        metadata_json: row.get(10)?,
     })
 }
 

--- a/plugins/autodev/cli/src/infra/db/schema.rs
+++ b/plugins/autodev/cli/src/infra/db/schema.rs
@@ -1,6 +1,23 @@
 use anyhow::Result;
 use rusqlite::Connection;
 
+/// v2 마이그레이션: queue_items에 task_kind, github_number, metadata_json 컬럼 추가.
+pub fn migrate_v2(conn: &Connection) -> Result<()> {
+    let migrations = [
+        "ALTER TABLE queue_items ADD COLUMN task_kind TEXT NOT NULL DEFAULT 'analyze'",
+        "ALTER TABLE queue_items ADD COLUMN github_number INTEGER NOT NULL DEFAULT 0",
+        "ALTER TABLE queue_items ADD COLUMN metadata_json TEXT",
+    ];
+    for sql in &migrations {
+        match conn.execute(sql, []) {
+            Ok(_) => {}
+            Err(e) if e.to_string().contains("duplicate column") => {}
+            Err(e) => return Err(e.into()),
+        }
+    }
+    Ok(())
+}
+
 pub fn create_tables(conn: &Connection) -> Result<()> {
     conn.execute_batch(
         "

--- a/plugins/autodev/cli/src/service/daemon/collectors/github.rs
+++ b/plugins/autodev/cli/src/service/daemon/collectors/github.rs
@@ -13,7 +13,7 @@ use crate::core::collector::Collector;
 use crate::core::config::{self, ConfigLoader, Env};
 use crate::core::models::{QueuePhase, QueueType};
 use crate::core::phase::TaskKind;
-use crate::core::repository::{RepoRepository, ScanCursorRepository};
+use crate::core::repository::{QueueRepository, RepoRepository, ScanCursorRepository};
 use crate::core::task::{QueueOp, Task, TaskResult};
 use crate::infra::gh::Gh;
 use crate::infra::git::Git;
@@ -30,7 +30,7 @@ use crate::service::tasks::review::ReviewTask;
 /// GitHub 이슈/PR 스캔 기반 Collector.
 ///
 /// per-repo 큐를 소유하고, 스캔 → Task 생성 → 큐 적용 생명주기를 관리한다.
-pub struct GitHubTaskSource<DB: RepoRepository + ScanCursorRepository> {
+pub struct GitHubTaskSource<DB: RepoRepository + ScanCursorRepository + QueueRepository> {
     workspace: Arc<dyn WorkspaceOps>,
     gh: Arc<dyn Gh>,
     config: Arc<dyn ConfigLoader>,
@@ -41,7 +41,7 @@ pub struct GitHubTaskSource<DB: RepoRepository + ScanCursorRepository> {
     repos: HashMap<String, GitRepository>,
 }
 
-impl<DB: RepoRepository + ScanCursorRepository + Send> GitHubTaskSource<DB> {
+impl<DB: RepoRepository + ScanCursorRepository + QueueRepository + Send> GitHubTaskSource<DB> {
     pub fn new(
         workspace: Arc<dyn WorkspaceOps>,
         gh: Arc<dyn Gh>,
@@ -111,7 +111,7 @@ impl<DB: RepoRepository + ScanCursorRepository + Send> GitHubTaskSource<DB> {
     async fn run_recovery(&mut self) {
         for repo in self.repos.values_mut() {
             repo.refresh(&*self.gh).await;
-            let n = repo.recover_orphan_wip(&*self.gh).await;
+            let n = repo.recover_orphan_wip(&*self.gh, &self.db).await;
             if n > 0 {
                 tracing::info!("recovered {n} orphan wip items in {}", repo.name());
             }
@@ -172,13 +172,17 @@ impl<DB: RepoRepository + ScanCursorRepository + Send> GitHubTaskSource<DB> {
                             tracing::error!("issue scan error for {repo_name}: {e}");
                         }
 
-                        if let Err(e) = repo.scan_approved_issues(&*self.gh).await {
+                        if let Err(e) = repo.scan_approved_issues(&*self.gh, &self.db).await {
                             tracing::error!("approved scan error for {repo_name}: {e}");
                         }
                     }
                     "pulls" => {
                         if let Err(e) = repo
-                            .scan_pulls(&*self.gh, &repo_cfg.sources.github.ignore_authors)
+                            .scan_pulls(
+                                &*self.gh,
+                                &self.db,
+                                &repo_cfg.sources.github.ignore_authors,
+                            )
                             .await
                         {
                             tracing::error!("PR scan error for {repo_name}: {e}");
@@ -186,7 +190,7 @@ impl<DB: RepoRepository + ScanCursorRepository + Send> GitHubTaskSource<DB> {
 
                         // done + merged + NOT extracted → knowledge extraction
                         if repo_cfg.sources.github.knowledge_extraction {
-                            if let Err(e) = repo.scan_done_merged(&*self.gh).await {
+                            if let Err(e) = repo.scan_done_merged(&*self.gh, &self.db).await {
                                 tracing::error!("done_merged scan error for {repo_name}: {e}");
                             }
                         }
@@ -201,6 +205,29 @@ impl<DB: RepoRepository + ScanCursorRepository + Send> GitHubTaskSource<DB> {
     ///
     /// per-repo `issue_concurrency` / `pr_concurrency` 제한을 적용하여,
     /// in-flight 태스크 수를 초과하지 않도록 bounded drain을 수행한다.
+    /// drain + DB transit 공통 헬퍼.
+    /// in-memory 큐에서 drain한 뒤, DB phase도 동기화한다.
+    fn drain_and_sync<F>(
+        db: &DB,
+        queue: &mut crate::core::state_queue::StateQueue<crate::core::queue_item::QueueItem>,
+        limit: usize,
+        predicate: F,
+    ) -> Vec<crate::core::queue_item::QueueItem>
+    where
+        F: Fn(&crate::core::queue_item::QueueItem) -> bool,
+    {
+        let drained =
+            queue.drain_to_filtered(QueuePhase::Pending, QueuePhase::Running, limit, predicate);
+        for item in &drained {
+            if let Err(e) =
+                db.queue_transit(&item.work_id, QueuePhase::Pending, QueuePhase::Running)
+            {
+                tracing::warn!("queue_transit failed for {}: {e}", item.work_id);
+            }
+        }
+        drained
+    }
+
     fn drain_queue_items(&mut self) -> Vec<Box<dyn Task>> {
         let mut tasks: Vec<Box<dyn Task>> = Vec::new();
 
@@ -214,12 +241,9 @@ impl<DB: RepoRepository + ScanCursorRepository + Send> GitHubTaskSource<DB> {
             let mut issue_slots = repo.issue_concurrency.saturating_sub(issue_running);
 
             // Issue: Pending(Analyze) → Running
-            let drained = repo.queue.drain_to_filtered(
-                QueuePhase::Pending,
-                QueuePhase::Running,
-                issue_slots,
-                |i| i.is(QueueType::Issue, TaskKind::Analyze),
-            );
+            let drained = Self::drain_and_sync(&self.db, &mut repo.queue, issue_slots, |i| {
+                i.is(QueueType::Issue, TaskKind::Analyze)
+            });
             issue_slots -= drained.len();
             for item in drained {
                 tracing::debug!("issue #{}: creating AnalyzeTask", item.github_number);
@@ -232,12 +256,9 @@ impl<DB: RepoRepository + ScanCursorRepository + Send> GitHubTaskSource<DB> {
             }
 
             // Issue: Pending(Implement) → Running
-            for item in repo.queue.drain_to_filtered(
-                QueuePhase::Pending,
-                QueuePhase::Running,
-                issue_slots,
-                |i| i.is(QueueType::Issue, TaskKind::Implement),
-            ) {
+            for item in Self::drain_and_sync(&self.db, &mut repo.queue, issue_slots, |i| {
+                i.is(QueueType::Issue, TaskKind::Implement)
+            }) {
                 tracing::debug!("issue #{}: creating ImplementTask", item.github_number);
                 tasks.push(Box::new(ImplementTask::new(
                     Arc::clone(&self.workspace),
@@ -256,12 +277,9 @@ impl<DB: RepoRepository + ScanCursorRepository + Send> GitHubTaskSource<DB> {
             let mut pr_slots = repo.pr_concurrency.saturating_sub(pr_running);
 
             // PR: Pending(Review) → Running
-            let drained = repo.queue.drain_to_filtered(
-                QueuePhase::Pending,
-                QueuePhase::Running,
-                pr_slots,
-                |i| i.is(QueueType::Pr, TaskKind::Review),
-            );
+            let drained = Self::drain_and_sync(&self.db, &mut repo.queue, pr_slots, |i| {
+                i.is(QueueType::Pr, TaskKind::Review)
+            });
             pr_slots -= drained.len();
             for item in drained {
                 tracing::debug!("PR #{}: creating ReviewTask", item.github_number);
@@ -274,12 +292,9 @@ impl<DB: RepoRepository + ScanCursorRepository + Send> GitHubTaskSource<DB> {
             }
 
             // PR: Pending(Improve) → Running
-            let drained = repo.queue.drain_to_filtered(
-                QueuePhase::Pending,
-                QueuePhase::Running,
-                pr_slots,
-                |i| i.is(QueueType::Pr, TaskKind::Improve),
-            );
+            let drained = Self::drain_and_sync(&self.db, &mut repo.queue, pr_slots, |i| {
+                i.is(QueueType::Pr, TaskKind::Improve)
+            });
             pr_slots -= drained.len();
             for item in drained {
                 tracing::debug!("PR #{}: creating ImproveTask", item.github_number);
@@ -305,6 +320,9 @@ impl<DB: RepoRepository + ScanCursorRepository + Send> GitHubTaskSource<DB> {
                     item.github_number
                 );
                 repo.queue.remove(&item.work_id);
+                if let Err(e) = self.db.queue_remove(&item.work_id) {
+                    tracing::warn!("queue_remove failed for {}: {e}", item.work_id);
+                }
                 tasks.push(Box::new(ExtractTask::new(
                     Arc::clone(&self.workspace),
                     Arc::clone(&self.gh),
@@ -337,9 +355,15 @@ impl<DB: RepoRepository + ScanCursorRepository + Send> GitHubTaskSource<DB> {
             match op {
                 QueueOp::Remove => {
                     repo.queue.remove(&result.work_id);
+                    if let Err(e) = self.db.queue_remove(&result.work_id) {
+                        tracing::warn!("queue_remove failed for {}: {e}", result.work_id);
+                    }
                 }
                 QueueOp::Push { phase, item } => {
                     repo.queue.push(*phase, *item.clone());
+                    if let Err(e) = self.db.queue_upsert(&item.to_row(*phase)) {
+                        tracing::error!("queue_upsert failed for {}: {e}", item.work_id);
+                    }
                 }
             }
         }
@@ -347,7 +371,9 @@ impl<DB: RepoRepository + ScanCursorRepository + Send> GitHubTaskSource<DB> {
 }
 
 #[async_trait(?Send)]
-impl<DB: RepoRepository + ScanCursorRepository + Send> Collector for GitHubTaskSource<DB> {
+impl<DB: RepoRepository + ScanCursorRepository + QueueRepository + Send> Collector
+    for GitHubTaskSource<DB>
+{
     async fn poll(&mut self) -> Vec<Box<dyn Task>> {
         self.sync_repos().await;
         self.run_recovery().await;
@@ -522,6 +548,39 @@ mod tests {
         }
         fn cursor_should_scan(&self, _: &str, _: i64) -> anyhow::Result<bool> {
             Ok(false)
+        }
+    }
+
+    impl QueueRepository for MockDb {
+        fn queue_get_phase(&self, _: &str) -> anyhow::Result<Option<QueuePhase>> {
+            Ok(None)
+        }
+        fn queue_advance(&self, _: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn queue_skip(&self, _: &str, _: Option<&str>) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn queue_list_items(
+            &self,
+            _: Option<&str>,
+        ) -> anyhow::Result<Vec<crate::core::models::QueueItemRow>> {
+            Ok(vec![])
+        }
+        fn queue_upsert(&self, _: &crate::core::models::QueueItemRow) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn queue_remove(&self, _: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn queue_load_active(
+            &self,
+            _: &str,
+        ) -> anyhow::Result<Vec<crate::core::models::QueueItemRow>> {
+            Ok(vec![])
+        }
+        fn queue_transit(&self, _: &str, _: QueuePhase, _: QueuePhase) -> anyhow::Result<bool> {
+            Ok(true)
         }
     }
 

--- a/plugins/autodev/cli/src/service/daemon/mod.rs
+++ b/plugins/autodev/cli/src/service/daemon/mod.rs
@@ -347,11 +347,20 @@ pub async fn start(
     );
 
     // ── Startup Reconcile ──
+    // Separate DB connection for startup (source_db is already moved into source)
+    let startup_db = Database::open(&db_path)?;
+    startup_db.initialize()?;
     match GitRepositoryFactory::create_all(&log_db, &*env, &*gh).await {
         Ok(mut repo_map) => {
+            // DB-first 복구: DB에서 활성 아이템을 로드
+            for repo in repo_map.values_mut() {
+                repo.load_from_db(&startup_db);
+            }
+
+            // 라벨 기반 fallback 복구
             let mut total_recovered = 0u64;
             for repo in repo_map.values_mut() {
-                let n = repo.startup_reconcile(&*gh).await;
+                let n = repo.startup_reconcile(&*gh, &startup_db).await;
                 if n > 0 {
                     total_recovered += n;
                 }

--- a/plugins/autodev/cli/src/service/tasks/helpers/git_ops.rs
+++ b/plugins/autodev/cli/src/service/tasks/helpers/git_ops.rs
@@ -5,7 +5,7 @@ use crate::core::labels;
 use crate::core::models::{HasLabels, QueuePhase, QueueType, RepoIssue, RepoPull};
 use crate::core::phase::TaskKind;
 use crate::core::queue_item::{PrMetadata, QueueItem, RepoRef};
-use crate::core::repository::ScanCursorRepository;
+use crate::core::repository::{QueueRepository, ScanCursorRepository};
 use crate::core::state_queue::StateQueue;
 use crate::core::task_queues::make_work_id;
 use crate::infra::gh::Gh;
@@ -136,8 +136,10 @@ impl GitRepository {
     // ─── Queue Helpers ───
 
     /// Issue를 QueueItem으로 변환하여 Pending 큐에 추가한다.
+    #[allow(clippy::too_many_arguments)]
     fn enqueue_issue(
         &mut self,
+        db: &dyn QueueRepository,
         number: i64,
         task_kind: TaskKind,
         title: String,
@@ -147,14 +149,45 @@ impl GitRepository {
     ) {
         let repo = self.repo_ref();
         let item = QueueItem::new_issue(&repo, number, task_kind, title, body, labels, author);
-        self.queue.push(QueuePhase::Pending, item);
+        if self.queue.push(QueuePhase::Pending, item.clone()) {
+            if let Err(e) = db.queue_upsert(&item.to_row(QueuePhase::Pending)) {
+                tracing::error!("queue_upsert failed for {}: {e}", item.work_id);
+            }
+        }
     }
 
     /// PR을 QueueItem으로 변환하여 Pending 큐에 추가한다.
-    fn enqueue_pr(&mut self, number: i64, task_kind: TaskKind, title: String, meta: PrMetadata) {
+    fn enqueue_pr(
+        &mut self,
+        db: &dyn QueueRepository,
+        number: i64,
+        task_kind: TaskKind,
+        title: String,
+        meta: PrMetadata,
+    ) {
         let repo = self.repo_ref();
         let item = QueueItem::new_pr(&repo, number, task_kind, title, meta);
-        self.queue.push(QueuePhase::Pending, item);
+        if self.queue.push(QueuePhase::Pending, item.clone()) {
+            if let Err(e) = db.queue_upsert(&item.to_row(QueuePhase::Pending)) {
+                tracing::error!("queue_upsert failed for {}: {e}", item.work_id);
+            }
+        }
+    }
+
+    /// DB에서 활성 큐 아이템을 로드하여 인메모리 큐에 적재한다.
+    pub fn load_from_db(&mut self, db: &dyn QueueRepository) {
+        match db.queue_load_active(&self.id) {
+            Ok(rows) => {
+                for row in rows {
+                    if let Some(item) =
+                        QueueItem::from_row(&row, &self.name, &self.url, self.gh_host())
+                    {
+                        self.queue.push(row.phase, item);
+                    }
+                }
+            }
+            Err(e) => tracing::error!("queue DB load failed for {}: {e}", self.name),
+        }
     }
 
     // ─── Scanning ───
@@ -162,10 +195,10 @@ impl GitRepository {
     /// `autodev:analyze` 라벨이 있는 이슈를 스캔하여 queue(Pending, Analyze)에 추가.
     ///
     /// 라벨 전이: analyze 제거 → wip 추가 (트리거 소비)
-    pub async fn scan_issues(
+    pub async fn scan_issues<DB: ScanCursorRepository + QueueRepository>(
         &mut self,
         gh: &dyn Gh,
-        db: &dyn ScanCursorRepository,
+        db: &DB,
         ignore_authors: &[String],
         filter_labels: &Option<Vec<String>>,
     ) -> Result<()> {
@@ -221,6 +254,7 @@ impl GitRepository {
             )
             .await;
             self.enqueue_issue(
+                db,
                 issue.number,
                 TaskKind::Analyze,
                 issue.title.clone(),
@@ -240,7 +274,11 @@ impl GitRepository {
     /// `autodev:approved-analysis` 라벨이 있는 이슈를 스캔하여 queue(Pending, Implement)에 추가.
     ///
     /// 라벨 전이: approved-analysis 제거, analyzed 제거 → implementing 추가
-    pub async fn scan_approved_issues(&mut self, gh: &dyn Gh) -> Result<()> {
+    pub async fn scan_approved_issues(
+        &mut self,
+        gh: &dyn Gh,
+        db: &dyn QueueRepository,
+    ) -> Result<()> {
         let params: Vec<(&str, &str)> = vec![
             ("state", "open"),
             ("labels", labels::APPROVED_ANALYSIS),
@@ -290,6 +328,7 @@ impl GitRepository {
             let label_names: Vec<String> = issue.labels.iter().map(|l| l.name.clone()).collect();
 
             self.enqueue_issue(
+                db,
                 issue.number,
                 TaskKind::Implement,
                 issue.title.clone(),
@@ -311,14 +350,20 @@ impl GitRepository {
     ///
     /// Label-Positive 모델: `autodev:wip` 라벨이 있는 PR만 scan 대상.
     /// 외부 PR은 사람이 수동으로 `autodev:wip`를 추가해야 리뷰 대상이 됨.
-    pub async fn scan_pulls(&mut self, gh: &dyn Gh, ignore_authors: &[String]) -> Result<()> {
+    pub async fn scan_pulls(
+        &mut self,
+        gh: &dyn Gh,
+        db: &dyn QueueRepository,
+        ignore_authors: &[String],
+    ) -> Result<()> {
         // Scan wip-labeled PRs → Pending (review)
-        self.scan_pulls_by_label(gh, ignore_authors, labels::WIP, TaskKind::Review)
+        self.scan_pulls_by_label(gh, db, ignore_authors, labels::WIP, TaskKind::Review)
             .await?;
 
         // Scan changes-requested PRs → Pending (improve)
         self.scan_pulls_by_label(
             gh,
+            db,
             ignore_authors,
             labels::CHANGES_REQUESTED,
             TaskKind::Improve,
@@ -332,6 +377,7 @@ impl GitRepository {
     async fn scan_pulls_by_label(
         &mut self,
         gh: &dyn Gh,
+        db: &dyn QueueRepository,
         ignore_authors: &[String],
         label: &str,
         target_kind: TaskKind,
@@ -396,6 +442,7 @@ impl GitRepository {
                 .unwrap_or_default();
 
             self.enqueue_pr(
+                db,
                 number,
                 target_kind,
                 title,
@@ -420,7 +467,7 @@ impl GitRepository {
     /// queue(Pending, Extract)에 추가 (지식 추출 대상).
     ///
     /// Label-Positive: done 라벨 + closed(merged) 상태 + extracted 라벨 없음
-    pub async fn scan_done_merged(&mut self, gh: &dyn Gh) -> Result<()> {
+    pub async fn scan_done_merged(&mut self, gh: &dyn Gh, db: &dyn QueueRepository) -> Result<()> {
         let params: Vec<(&str, &str)> = vec![
             ("state", "closed"),
             ("labels", labels::DONE),
@@ -493,6 +540,7 @@ impl GitRepository {
             }
 
             self.enqueue_pr(
+                db,
                 number,
                 TaskKind::Extract,
                 title,
@@ -518,7 +566,7 @@ impl GitRepository {
     ///
     /// - Issue: wip 라벨 제거 → 다음 scan에서 재발견
     /// - PR: Pending 큐에 재적재 (Label-Positive 모델에서는 라벨 제거 시 재발견 불가)
-    pub async fn recover_orphan_wip(&mut self, gh: &dyn Gh) -> u64 {
+    pub async fn recover_orphan_wip(&mut self, gh: &dyn Gh, db: &dyn QueueRepository) -> u64 {
         let mut recovered = 0u64;
         let gh_host = self.gh_host.as_deref();
 
@@ -557,7 +605,11 @@ impl GitRepository {
                 item.github_number,
                 self.name
             );
-            self.queue.push(QueuePhase::Pending, item);
+            if self.queue.push(QueuePhase::Pending, item.clone()) {
+                if let Err(e) = db.queue_upsert(&item.to_row(QueuePhase::Pending)) {
+                    tracing::error!("queue_upsert failed for {}: {e}", item.work_id);
+                }
+            }
             recovered += 1;
         }
 
@@ -653,7 +705,7 @@ impl GitRepository {
     /// 재시작 시 pre-fetched 상태 기반 큐 복구.
     ///
     /// issues/pulls의 라벨 상태에 따라 적절한 큐에 적재한다.
-    pub async fn startup_reconcile(&mut self, gh: &dyn Gh) -> u64 {
+    pub async fn startup_reconcile(&mut self, gh: &dyn Gh, db: &dyn QueueRepository) -> u64 {
         let mut recovered = 0u64;
         let gh_host = self.gh_host.as_deref();
         let repo = self.repo_ref();
@@ -686,19 +738,19 @@ impl GitRepository {
                 gh.label_add(&self.name, issue.number, labels::IMPLEMENTING, gh_host)
                     .await;
 
-                self.queue.push(
-                    QueuePhase::Pending,
-                    QueueItem::from_issue(&repo, issue, TaskKind::Implement),
-                );
+                let item = QueueItem::from_issue(&repo, issue, TaskKind::Implement);
+                if self.queue.push(QueuePhase::Pending, item.clone()) {
+                    let _ = db.queue_upsert(&item.to_row(QueuePhase::Pending));
+                }
                 recovered += 1;
                 continue;
             }
 
             if issue.is_wip() {
-                self.queue.push(
-                    QueuePhase::Pending,
-                    QueueItem::from_issue(&repo, issue, TaskKind::Analyze),
-                );
+                let item = QueueItem::from_issue(&repo, issue, TaskKind::Analyze);
+                if self.queue.push(QueuePhase::Pending, item.clone()) {
+                    let _ = db.queue_upsert(&item.to_row(QueuePhase::Pending));
+                }
                 recovered += 1;
                 continue;
             }
@@ -715,10 +767,10 @@ impl GitRepository {
                 continue;
             }
 
-            self.queue.push(
-                QueuePhase::Pending,
-                QueueItem::from_pull(&repo, pull, TaskKind::Review),
-            );
+            let item = QueueItem::from_pull(&repo, pull, TaskKind::Review);
+            if self.queue.push(QueuePhase::Pending, item.clone()) {
+                let _ = db.queue_upsert(&item.to_row(QueuePhase::Pending));
+            }
             recovered += 1;
         }
 
@@ -733,10 +785,10 @@ impl GitRepository {
                 continue;
             }
 
-            self.queue.push(
-                QueuePhase::Pending,
-                QueueItem::from_pull(&repo, pull, TaskKind::Improve),
-            );
+            let item = QueueItem::from_pull(&repo, pull, TaskKind::Improve);
+            if self.queue.push(QueuePhase::Pending, item.clone()) {
+                let _ = db.queue_upsert(&item.to_row(QueuePhase::Pending));
+            }
             recovered += 1;
         }
 
@@ -876,6 +928,36 @@ mod tests {
         }
 
         fn cursor_should_scan(&self, _repo_id: &str, _interval_secs: i64) -> Result<bool> {
+            Ok(true)
+        }
+    }
+
+    impl QueueRepository for MockCursorRepo {
+        fn queue_get_phase(&self, _: &str) -> Result<Option<QueuePhase>> {
+            Ok(None)
+        }
+        fn queue_advance(&self, _: &str) -> Result<()> {
+            Ok(())
+        }
+        fn queue_skip(&self, _: &str, _: Option<&str>) -> Result<()> {
+            Ok(())
+        }
+        fn queue_list_items(
+            &self,
+            _: Option<&str>,
+        ) -> Result<Vec<crate::core::models::QueueItemRow>> {
+            Ok(vec![])
+        }
+        fn queue_upsert(&self, _: &crate::core::models::QueueItemRow) -> Result<()> {
+            Ok(())
+        }
+        fn queue_remove(&self, _: &str) -> Result<()> {
+            Ok(())
+        }
+        fn queue_load_active(&self, _: &str) -> Result<Vec<crate::core::models::QueueItemRow>> {
+            Ok(vec![])
+        }
+        fn queue_transit(&self, _: &str, _: QueuePhase, _: QueuePhase) -> Result<bool> {
             Ok(true)
         }
     }
@@ -1179,7 +1261,9 @@ mod tests {
         );
 
         let mut repo = make_repo();
-        repo.scan_approved_issues(&gh).await.unwrap();
+        repo.scan_approved_issues(&gh, &MockCursorRepo::new())
+            .await
+            .unwrap();
 
         assert_eq!(repo.queue.len(QueuePhase::Pending), 1);
         let item = repo.queue.pop(QueuePhase::Pending).unwrap();
@@ -1234,7 +1318,9 @@ mod tests {
         );
 
         let mut repo = make_repo();
-        repo.scan_pulls(&gh, &[]).await.unwrap();
+        repo.scan_pulls(&gh, &MockCursorRepo::new(), &[])
+            .await
+            .unwrap();
 
         assert_eq!(repo.queue.len(QueuePhase::Pending), 1);
         let item = repo.queue.pop(QueuePhase::Pending).unwrap();
@@ -1285,7 +1371,9 @@ mod tests {
             ),
         );
 
-        repo.scan_pulls(&gh, &[]).await.unwrap();
+        repo.scan_pulls(&gh, &MockCursorRepo::new(), &[])
+            .await
+            .unwrap();
 
         // Should not add a second copy
         assert_eq!(repo.queue.len(QueuePhase::Pending), 0);
@@ -1311,7 +1399,7 @@ mod tests {
         );
 
         let mut repo = make_repo();
-        repo.scan_pulls(&gh, &["renovate".to_string()])
+        repo.scan_pulls(&gh, &MockCursorRepo::new(), &["renovate".to_string()])
             .await
             .unwrap();
 
@@ -1348,7 +1436,7 @@ mod tests {
             vec![],
         );
 
-        let recovered = repo.recover_orphan_wip(&gh).await;
+        let recovered = repo.recover_orphan_wip(&gh, &MockCursorRepo::new()).await;
 
         assert_eq!(recovered, 1);
         let removed = gh.removed_labels.lock().unwrap();
@@ -1375,7 +1463,7 @@ mod tests {
         repo.queue
             .push(QueuePhase::Pending, issue_item("org/repo", 1));
 
-        let recovered = repo.recover_orphan_wip(&gh).await;
+        let recovered = repo.recover_orphan_wip(&gh, &MockCursorRepo::new()).await;
 
         assert_eq!(recovered, 0);
         assert!(gh.removed_labels.lock().unwrap().is_empty());
@@ -1394,7 +1482,7 @@ mod tests {
             }))],
         );
 
-        let recovered = repo.recover_orphan_wip(&gh).await;
+        let recovered = repo.recover_orphan_wip(&gh, &MockCursorRepo::new()).await;
 
         assert_eq!(recovered, 1);
         // PR은 라벨 제거 대신 Pending 큐에 재적재 (Label-Positive)
@@ -1509,7 +1597,7 @@ mod tests {
             vec![],
         );
 
-        let result = repo.startup_reconcile(&gh).await;
+        let result = repo.startup_reconcile(&gh, &MockCursorRepo::new()).await;
         assert_eq!(result, 0);
         assert!(!repo.contains("issue:org/repo:10"));
     }
@@ -1531,7 +1619,7 @@ mod tests {
             vec![],
         );
 
-        let result = repo.startup_reconcile(&gh).await;
+        let result = repo.startup_reconcile(&gh, &MockCursorRepo::new()).await;
         assert_eq!(result, 0);
     }
 
@@ -1546,7 +1634,7 @@ mod tests {
             vec![],
         );
 
-        let result = repo.startup_reconcile(&gh).await;
+        let result = repo.startup_reconcile(&gh, &MockCursorRepo::new()).await;
 
         assert_eq!(result, 1);
         assert!(repo.contains("issue:org/repo:42"));
@@ -1569,7 +1657,7 @@ mod tests {
             vec![],
         );
 
-        let result = repo.startup_reconcile(&gh).await;
+        let result = repo.startup_reconcile(&gh, &MockCursorRepo::new()).await;
 
         assert_eq!(result, 1);
         assert!(repo.contains("issue:org/repo:3"));
@@ -1599,7 +1687,7 @@ mod tests {
             }))],
         );
 
-        let result = repo.startup_reconcile(&gh).await;
+        let result = repo.startup_reconcile(&gh, &MockCursorRepo::new()).await;
 
         assert_eq!(result, 1);
         assert!(repo.contains("pr:org/repo:20"));
@@ -1619,7 +1707,7 @@ mod tests {
             }))],
         );
 
-        let result = repo.startup_reconcile(&gh).await;
+        let result = repo.startup_reconcile(&gh, &MockCursorRepo::new()).await;
         assert_eq!(result, 0);
         assert!(!repo.contains("pr:org/repo:20"));
     }
@@ -1638,7 +1726,7 @@ mod tests {
         repo.queue
             .push(QueuePhase::Pending, issue_item("org/repo", 10));
 
-        let result = repo.startup_reconcile(&gh).await;
+        let result = repo.startup_reconcile(&gh, &MockCursorRepo::new()).await;
         assert_eq!(result, 0);
     }
 
@@ -1659,7 +1747,7 @@ mod tests {
             vec![],
         );
 
-        let result = repo.startup_reconcile(&gh).await;
+        let result = repo.startup_reconcile(&gh, &MockCursorRepo::new()).await;
         assert_eq!(result, 0);
     }
 }

--- a/plugins/autodev/cli/tests/queue_advance_tests.rs
+++ b/plugins/autodev/cli/tests/queue_advance_tests.rs
@@ -1,4 +1,5 @@
-use autodev::core::models::QueuePhase;
+use autodev::core::models::{QueueItemRow, QueuePhase, QueueType};
+use autodev::core::phase::TaskKind;
 use autodev::core::repository::*;
 use autodev::infra::db::Database;
 use std::path::Path;
@@ -264,4 +265,179 @@ fn cli_queue_list_db_empty() {
 
     let output = autodev::cli::queue::queue_list_db(&db, None, false, None, false).unwrap();
     assert!(output.contains("no queue items"));
+}
+
+// ═══════════════════════════════════════════════
+// 6. migrate_v2 idempotent
+// ═══════════════════════════════════════════════
+
+#[test]
+fn migrate_v2_idempotent() {
+    let db = open_memory_db();
+    // initialize already calls migrate_v2, calling it again should not error
+    db.initialize().unwrap();
+}
+
+// ═══════════════════════════════════════════════
+// 7. queue_upsert / queue_remove / queue_load_active / queue_transit
+// ═══════════════════════════════════════════════
+
+fn make_row(repo_id: &str, work_id: &str, phase: QueuePhase) -> QueueItemRow {
+    let now = chrono::Utc::now().to_rfc3339();
+    QueueItemRow {
+        work_id: work_id.to_string(),
+        repo_id: repo_id.to_string(),
+        queue_type: QueueType::Issue,
+        phase,
+        title: Some("Test".to_string()),
+        skip_reason: None,
+        created_at: now.clone(),
+        updated_at: now,
+        task_kind: TaskKind::Analyze,
+        github_number: 42,
+        metadata_json: None,
+    }
+}
+
+#[test]
+fn queue_upsert_insert() {
+    let db = open_memory_db();
+    let repo_id = add_test_repo(&db);
+    let row = make_row(&repo_id, "issue:org/test-repo:1", QueuePhase::Pending);
+
+    db.queue_upsert(&row).unwrap();
+
+    let items = db.queue_list_items(None).unwrap();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].work_id, "issue:org/test-repo:1");
+    assert_eq!(items[0].task_kind, TaskKind::Analyze);
+    assert_eq!(items[0].github_number, 42);
+}
+
+#[test]
+fn queue_upsert_update() {
+    let db = open_memory_db();
+    let repo_id = add_test_repo(&db);
+
+    let row = make_row(&repo_id, "issue:org/test-repo:1", QueuePhase::Pending);
+    db.queue_upsert(&row).unwrap();
+
+    // Update phase
+    let mut row2 = row;
+    row2.phase = QueuePhase::Running;
+    db.queue_upsert(&row2).unwrap();
+
+    let phase = db.queue_get_phase("issue:org/test-repo:1").unwrap();
+    assert_eq!(phase, Some(QueuePhase::Running));
+
+    // Should still be 1 item
+    let items = db.queue_list_items(None).unwrap();
+    assert_eq!(items.len(), 1);
+}
+
+#[test]
+fn queue_upsert_preserves_created_at() {
+    let db = open_memory_db();
+    let repo_id = add_test_repo(&db);
+
+    let row = make_row(&repo_id, "issue:org/test-repo:1", QueuePhase::Pending);
+    let original_created = row.created_at.clone();
+    db.queue_upsert(&row).unwrap();
+
+    // Upsert with different created_at
+    let mut row2 = row;
+    row2.phase = QueuePhase::Running;
+    row2.created_at = "2099-01-01T00:00:00Z".to_string();
+    db.queue_upsert(&row2).unwrap();
+
+    let items = db.queue_list_items(None).unwrap();
+    // ON CONFLICT DO UPDATE does not touch created_at
+    assert_eq!(items[0].created_at, original_created);
+}
+
+#[test]
+fn queue_load_active_excludes_terminal() {
+    let db = open_memory_db();
+    let repo_id = add_test_repo(&db);
+
+    db.queue_upsert(&make_row(&repo_id, "w-1", QueuePhase::Pending))
+        .unwrap();
+    db.queue_upsert(&make_row(&repo_id, "w-2", QueuePhase::Running))
+        .unwrap();
+    db.queue_upsert(&make_row(&repo_id, "w-3", QueuePhase::Done))
+        .unwrap();
+    db.queue_upsert(&make_row(&repo_id, "w-4", QueuePhase::Skipped))
+        .unwrap();
+
+    let active = db.queue_load_active(&repo_id).unwrap();
+    assert_eq!(active.len(), 2);
+    let ids: Vec<&str> = active.iter().map(|r| r.work_id.as_str()).collect();
+    assert!(ids.contains(&"w-1"));
+    assert!(ids.contains(&"w-2"));
+}
+
+#[test]
+fn queue_transit_cas_success() {
+    let db = open_memory_db();
+    let repo_id = add_test_repo(&db);
+    db.queue_upsert(&make_row(&repo_id, "w-1", QueuePhase::Pending))
+        .unwrap();
+
+    let ok = db
+        .queue_transit("w-1", QueuePhase::Pending, QueuePhase::Running)
+        .unwrap();
+    assert!(ok);
+
+    let phase = db.queue_get_phase("w-1").unwrap();
+    assert_eq!(phase, Some(QueuePhase::Running));
+}
+
+#[test]
+fn queue_transit_cas_wrong_phase() {
+    let db = open_memory_db();
+    let repo_id = add_test_repo(&db);
+    db.queue_upsert(&make_row(&repo_id, "w-1", QueuePhase::Running))
+        .unwrap();
+
+    let ok = db
+        .queue_transit("w-1", QueuePhase::Pending, QueuePhase::Running)
+        .unwrap();
+    assert!(!ok);
+
+    // Phase unchanged
+    let phase = db.queue_get_phase("w-1").unwrap();
+    assert_eq!(phase, Some(QueuePhase::Running));
+}
+
+#[test]
+fn queue_remove_marks_done() {
+    let db = open_memory_db();
+    let repo_id = add_test_repo(&db);
+    db.queue_upsert(&make_row(&repo_id, "w-1", QueuePhase::Running))
+        .unwrap();
+
+    db.queue_remove("w-1").unwrap();
+
+    let phase = db.queue_get_phase("w-1").unwrap();
+    assert_eq!(phase, Some(QueuePhase::Done));
+}
+
+// ═══════════════════════════════════════════════
+// 8. CLI output includes task_kind
+// ═══════════════════════════════════════════════
+
+#[test]
+fn cli_queue_list_shows_task_kind() {
+    let db = open_memory_db();
+    let repo_id = add_test_repo(&db);
+    db.queue_upsert(&make_row(
+        &repo_id,
+        "issue:org/test-repo:42",
+        QueuePhase::Pending,
+    ))
+    .unwrap();
+
+    let output = autodev::cli::queue::queue_list_db(&db, None, false, None, false).unwrap();
+    assert!(output.contains("analyze"));
+    assert!(output.contains("#42"));
 }


### PR DESCRIPTION
## Summary

- **Wave 1**: `QueueItemRow`에 `task_kind`, `github_number`, `metadata_json` 필드 추가. `ItemMetadata`/`PrMetadata`에 Serialize/Deserialize 구현. `QueueItem::to_row()`/`from_row()` 변환 메서드 추가. `migrate_v2` 스키마 마이그레이션.
- **Wave 2**: `QueueRepository` trait에 `queue_upsert`, `queue_remove`, `queue_load_active`, `queue_transit` 4개 메서드 추가 및 SQLite 구현.
- **Wave 3**: `enqueue_issue`/`enqueue_pr`에 DB write-through 추가. `drain_queue_items`/`apply_queue_ops`에 DB 동기화. Startup flow를 DB-first 복구 → 라벨 fallback으로 변경. `drain_and_sync` 헬퍼 추출.
- **Wave 4**: CLI `queue list` 출력에 `task_kind`, `github_number` 표시.

## Test plan

- [x] `cargo fmt --check` 통과
- [x] `cargo clippy -- -D warnings` 통과
- [x] 전체 527 tests 통과 (303 lib + 224 integration)
- [x] Wave 1: metadata JSON roundtrip, to_row/from_row roundtrip, migrate_v2 idempotent
- [x] Wave 2: queue_upsert insert/update/preserves_created_at, queue_load_active, queue_transit CAS, queue_remove
- [x] Wave 4: CLI output에 task_kind 포함 확인
- [ ] 기존 drain/apply/concurrency 테스트 모두 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)