### PR TITLE
refactor(autodev): implement spec-aligned claw integration

### DIFF
--- a/plugins/autodev/cli/src/cli/queue.rs
+++ b/plugins/autodev/cli/src/cli/queue.rs
@@ -1,15 +1,21 @@
 use anyhow::Result;
 
-use crate::core::models::{QueuePhase, QueueType};
-use crate::core::repository::QueueRepository;
+use crate::core::models::{
+    DecisionType, HitlSeverity, NewClawDecision, NewHitlEvent, QueuePhase, QueueType,
+};
+use crate::core::queue_item::{ItemMetadata, QueueItem};
+use crate::core::repository::{ClawDecisionRepository, HitlRepository, QueueRepository};
 use crate::infra::db::Database;
 
-/// 큐 아이템을 다음 phase로 전이한다
-pub fn queue_advance(db: &Database, work_id: &str) -> Result<String> {
-    let before = db
-        .queue_get_phase(work_id)?
-        .ok_or_else(|| anyhow::anyhow!("queue item not found: {work_id}"))
-        .map(|p| p.to_string())?;
+/// 큐 아이템을 다음 phase로 전이한다.
+/// Claw의 CLI 진입점으로서 claw_decisions에 advance 기록을 남긴다.
+/// PR의 review_iteration이 max_iterations 이상이면 HITL 이벤트를 자동 생성한다.
+pub fn queue_advance(db: &Database, work_id: &str, reason: Option<&str>) -> Result<String> {
+    // advance 전에 item 조회 (decision 기록 + HITL 체크 + before phase 취득)
+    let item = db
+        .queue_get_item(work_id)?
+        .ok_or_else(|| anyhow::anyhow!("queue item not found: {work_id}"))?;
+    let before = item.phase.to_string();
 
     db.queue_advance(work_id)?;
 
@@ -18,11 +24,27 @@ pub fn queue_advance(db: &Database, work_id: &str) -> Result<String> {
         .map(|p| p.to_string())
         .unwrap_or_else(|| "unknown".to_string());
 
+    // Decision 기록
+    record_decision(db, &item.repo_id, DecisionType::Advance, work_id, reason);
+
+    // H3: PR review iteration 임계값 초과 시 HITL 자동 생성
+    if item.queue_type == QueueType::Pr {
+        if let Some(review_iteration) = extract_review_iteration(&item.metadata_json) {
+            check_review_overflow(db, &item.repo_id, work_id, review_iteration);
+        }
+    }
+
     Ok(format!("advanced: {work_id} ({before} → {after})"))
 }
 
-/// 큐 아이템을 skip 처리한다
+/// 큐 아이템을 skip 처리한다.
+/// Claw의 CLI 진입점으로서 claw_decisions에 skip 기록을 남긴다.
 pub fn queue_skip(db: &Database, work_id: &str, reason: Option<&str>) -> Result<String> {
+    // Decision 기록: skip 전에 item 조회 (skip 후에도 조회 가능하지만 일관성을 위해 선행)
+    if let Ok(Some(item)) = db.queue_get_item(work_id) {
+        record_decision(db, &item.repo_id, DecisionType::Skip, work_id, reason);
+    }
+
     db.queue_skip(work_id, reason)?;
 
     let mut output = format!("skipped: {work_id}");
@@ -30,6 +52,67 @@ pub fn queue_skip(db: &Database, work_id: &str, reason: Option<&str>) -> Result<
         output.push_str(&format!(" (reason: {r})"));
     }
     Ok(output)
+}
+
+/// claw_decisions에 판단 기록을 남기는 공통 헬퍼.
+fn record_decision(
+    db: &Database,
+    repo_id: &str,
+    decision_type: DecisionType,
+    work_id: &str,
+    reason: Option<&str>,
+) {
+    let default_reason = match decision_type {
+        DecisionType::Advance => "manual advance",
+        DecisionType::Skip => "manual skip",
+        DecisionType::Hitl => "manual hitl",
+        DecisionType::Replan => "manual replan",
+    };
+    let _ = db.decision_add(&NewClawDecision {
+        repo_id: repo_id.to_string(),
+        spec_id: None,
+        decision_type,
+        target_work_id: Some(work_id.to_string()),
+        reasoning: reason.unwrap_or(default_reason).to_string(),
+        context_json: None,
+    });
+}
+
+/// metadata_json에서 review_iteration을 추출한다.
+/// 기존 QueueItem::metadata_from_json()을 재사용하여 ItemMetadata enum을 파싱한다.
+fn extract_review_iteration(metadata_json: &Option<String>) -> Option<u32> {
+    let json = metadata_json.as_deref()?;
+    let meta = QueueItem::metadata_from_json(json)?;
+    match meta {
+        ItemMetadata::Pr(pr) => Some(pr.review_iteration),
+        ItemMetadata::Issue { .. } => None,
+    }
+}
+
+/// review_iteration >= max_iterations이면 HITL 이벤트를 생성한다.
+///
+/// NOTE: max_iterations는 ReviewStage::default().max_iterations와 동일한 기본값(2)을 사용한다.
+/// CLI에서는 per-repo config 로드 없이 실행되므로, 여기서는 기본값을 사용한다.
+/// Claw cron이 구현되면 config에서 로드된 값을 전달하게 된다.
+fn check_review_overflow(db: &Database, repo_id: &str, work_id: &str, review_iteration: u32) {
+    let max_iterations = crate::core::config::models::ReviewStage::default().max_iterations;
+    if review_iteration >= max_iterations {
+        let _ = db.hitl_create(&NewHitlEvent {
+            repo_id: repo_id.to_string(),
+            spec_id: None,
+            work_id: Some(work_id.to_string()),
+            severity: HitlSeverity::Medium,
+            situation: format!(
+                "PR review iteration ({review_iteration}) reached maximum ({max_iterations})"
+            ),
+            context: format!("work_id: {work_id}"),
+            options: vec![
+                "Continue reviewing".to_string(),
+                "Skip this PR".to_string(),
+                "Merge as-is".to_string(),
+            ],
+        });
+    }
 }
 
 /// DB 기반 큐 아이템 목록 조회

--- a/plugins/autodev/cli/src/core/config/models.rs
+++ b/plugins/autodev/cli/src/core/config/models.rs
@@ -15,6 +15,7 @@ pub struct WorkflowConfig {
     pub sources: SourcesConfig,
     pub daemon: DaemonConfig,
     pub workflows: Workflows,
+    pub claw: ClawConfig,
 }
 
 /// 태스크 소스 설정 — 소스 종류별 하위 키
@@ -88,6 +89,31 @@ impl Default for GitHubSourceConfig {
             knowledge_extraction: true,
             auto_approve: false,
             auto_approve_threshold: 0.8,
+        }
+    }
+}
+
+// ═══════════════════════════════════════════════
+// claw — Claw 레이어 설정
+// ═══════════════════════════════════════════════
+
+/// Claw 레이어 설정.
+///
+/// `enabled: true`이면 daemon은 Ready→Running drain만 수행하고,
+/// Pending→Ready 전이는 Claw(CLI)가 담당한다.
+/// `enabled: false`(기본)이면 기존 Pending→Running 직행 동작을 유지한다.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ClawConfig {
+    pub enabled: bool,
+    pub recovery_interval_secs: u64,
+}
+
+impl Default for ClawConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            recovery_interval_secs: 120,
         }
     }
 }
@@ -274,5 +300,35 @@ workflows:
             Some("/custom-analyze")
         );
         assert_eq!(cfg.workflows.review.max_iterations, 3);
+    }
+
+    #[test]
+    fn claw_config_defaults() {
+        let cfg = ClawConfig::default();
+        assert!(!cfg.enabled);
+        assert_eq!(cfg.recovery_interval_secs, 120);
+    }
+
+    #[test]
+    fn claw_config_from_yaml() {
+        let yaml = r#"
+claw:
+  enabled: true
+  recovery_interval_secs: 60
+"#;
+        let cfg: WorkflowConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(cfg.claw.enabled);
+        assert_eq!(cfg.claw.recovery_interval_secs, 60);
+    }
+
+    #[test]
+    fn claw_config_defaults_when_omitted() {
+        let yaml = r#"
+daemon:
+  log_level: "info"
+"#;
+        let cfg: WorkflowConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(!cfg.claw.enabled);
+        assert_eq!(cfg.claw.recovery_interval_secs, 120);
     }
 }

--- a/plugins/autodev/cli/src/core/repository.rs
+++ b/plugins/autodev/cli/src/core/repository.rs
@@ -76,6 +76,8 @@ pub trait QueueRepository {
     fn queue_load_active(&self, repo_id: &str) -> Result<Vec<QueueItemRow>>;
     /// CAS 방식으로 phase를 전이한다 (from → to). 성공 시 true.
     fn queue_transit(&self, work_id: &str, from: QueuePhase, to: QueuePhase) -> Result<bool>;
+    /// 단일 큐 아이템을 work_id로 조회한다
+    fn queue_get_item(&self, work_id: &str) -> Result<Option<QueueItemRow>>;
 }
 
 pub trait ClawDecisionRepository {

--- a/plugins/autodev/cli/src/infra/db/repository.rs
+++ b/plugins/autodev/cli/src/infra/db/repository.rs
@@ -837,6 +837,19 @@ impl QueueRepository for Database {
         )?;
         Ok(affected > 0)
     }
+
+    fn queue_get_item(&self, work_id: &str) -> Result<Option<QueueItemRow>> {
+        let conn = self.conn();
+        let result = conn.query_row(
+            "SELECT work_id, repo_id, queue_type, phase, title, \
+             skip_reason, created_at, updated_at, \
+             task_kind, github_number, metadata_json \
+             FROM queue_items WHERE work_id = ?1",
+            rusqlite::params![work_id],
+            map_queue_item_row,
+        );
+        optional_query_row(result)
+    }
 }
 
 impl ClawDecisionRepository for Database {

--- a/plugins/autodev/cli/src/main.rs
+++ b/plugins/autodev/cli/src/main.rs
@@ -180,6 +180,9 @@ enum QueueAction {
     Advance {
         /// 작업 ID
         work_id: String,
+        /// 판단 사유 (claw_decisions에 기록)
+        #[arg(long)]
+        reason: Option<String>,
     },
     /// 큐 아이템을 skip 처리
     Skip {
@@ -600,8 +603,8 @@ async fn main() -> Result<()> {
                     println!("{output}");
                 }
             }
-            QueueAction::Advance { work_id } => {
-                let output = client::queue::queue_advance(&db, &work_id)?;
+            QueueAction::Advance { work_id, reason } => {
+                let output = client::queue::queue_advance(&db, &work_id, reason.as_deref())?;
                 println!("{output}");
             }
             QueueAction::Skip { work_id, reason } => {

--- a/plugins/autodev/cli/src/service/daemon/collectors/github.rs
+++ b/plugins/autodev/cli/src/service/daemon/collectors/github.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 
 use crate::core::collector::Collector;
+use crate::core::config::models::ClawConfig;
 use crate::core::config::{self, ConfigLoader, Env};
 use crate::core::models::{QueuePhase, QueueType};
 use crate::core::phase::TaskKind;
@@ -39,9 +40,16 @@ pub struct GitHubTaskSource<DB: RepoRepository + ScanCursorRepository + QueueRep
     sw: Arc<dyn SuggestWorkflow>,
     db: DB,
     repos: HashMap<String, GitRepository>,
+    /// claw.enabled feature flag: true이면 Ready→Running drain, false이면 Pending→Running
+    claw_enabled: bool,
+    /// 인메모리 recovery throttle 타임스탬프
+    last_recovery: Option<std::time::Instant>,
+    /// recovery 실행 최소 간격 (초)
+    recovery_interval_secs: u64,
 }
 
 impl<DB: RepoRepository + ScanCursorRepository + QueueRepository + Send> GitHubTaskSource<DB> {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         workspace: Arc<dyn WorkspaceOps>,
         gh: Arc<dyn Gh>,
@@ -50,6 +58,7 @@ impl<DB: RepoRepository + ScanCursorRepository + QueueRepository + Send> GitHubT
         git: Arc<dyn Git>,
         sw: Arc<dyn SuggestWorkflow>,
         db: DB,
+        claw: ClawConfig,
     ) -> Self {
         Self {
             workspace,
@@ -60,6 +69,9 @@ impl<DB: RepoRepository + ScanCursorRepository + QueueRepository + Send> GitHubT
             sw,
             db,
             repos: HashMap::new(),
+            claw_enabled: claw.enabled,
+            last_recovery: None,
+            recovery_interval_secs: claw.recovery_interval_secs,
         }
     }
 
@@ -201,6 +213,26 @@ impl<DB: RepoRepository + ScanCursorRepository + QueueRepository + Send> GitHubT
         }
     }
 
+    /// Claw enabled일 때 DB에서 Ready로 전이된 아이템을 in-memory 큐에 반영한다.
+    ///
+    /// Claw(CLI)가 DB에서 Pending→Ready 전이 → daemon의 in-memory queue는 여전히 Pending.
+    /// DB를 읽어 Ready 상태인 아이템을 in-memory에서도 Ready로 전이한다.
+    fn sync_queue_phases(&mut self) {
+        if !self.claw_enabled {
+            return;
+        }
+        for repo in self.repos.values_mut() {
+            if let Ok(rows) = self.db.queue_load_active(repo.id()) {
+                for row in rows {
+                    if row.phase == QueuePhase::Ready {
+                        repo.queue
+                            .transit(&row.work_id, QueuePhase::Pending, QueuePhase::Ready);
+                    }
+                }
+            }
+        }
+    }
+
     /// 모든 repo의 큐에서 ready 아이템을 pop → working phase 전이 → Task 생성.
     ///
     /// per-repo `issue_concurrency` / `pr_concurrency` 제한을 적용하여,
@@ -210,18 +242,16 @@ impl<DB: RepoRepository + ScanCursorRepository + QueueRepository + Send> GitHubT
     fn drain_and_sync<F>(
         db: &DB,
         queue: &mut crate::core::state_queue::StateQueue<crate::core::queue_item::QueueItem>,
+        from_phase: QueuePhase,
         limit: usize,
         predicate: F,
     ) -> Vec<crate::core::queue_item::QueueItem>
     where
         F: Fn(&crate::core::queue_item::QueueItem) -> bool,
     {
-        let drained =
-            queue.drain_to_filtered(QueuePhase::Pending, QueuePhase::Running, limit, predicate);
+        let drained = queue.drain_to_filtered(from_phase, QueuePhase::Running, limit, predicate);
         for item in &drained {
-            if let Err(e) =
-                db.queue_transit(&item.work_id, QueuePhase::Pending, QueuePhase::Running)
-            {
+            if let Err(e) = db.queue_transit(&item.work_id, from_phase, QueuePhase::Running) {
                 tracing::warn!("queue_transit failed for {}: {e}", item.work_id);
             }
         }
@@ -230,6 +260,12 @@ impl<DB: RepoRepository + ScanCursorRepository + QueueRepository + Send> GitHubT
 
     fn drain_queue_items(&mut self) -> Vec<Box<dyn Task>> {
         let mut tasks: Vec<Box<dyn Task>> = Vec::new();
+        // claw_enabled: Ready→Running, otherwise: Pending→Running
+        let from_phase = if self.claw_enabled {
+            QueuePhase::Ready
+        } else {
+            QueuePhase::Pending
+        };
 
         for repo in self.repos.values_mut() {
             // ─── Issue concurrency: Analyze + Implement running 합산 제한 ───
@@ -240,10 +276,11 @@ impl<DB: RepoRepository + ScanCursorRepository + QueueRepository + Send> GitHubT
                 .count();
             let mut issue_slots = repo.issue_concurrency.saturating_sub(issue_running);
 
-            // Issue: Pending(Analyze) → Running
-            let drained = Self::drain_and_sync(&self.db, &mut repo.queue, issue_slots, |i| {
-                i.is(QueueType::Issue, TaskKind::Analyze)
-            });
+            // Issue: from_phase(Analyze) → Running
+            let drained =
+                Self::drain_and_sync(&self.db, &mut repo.queue, from_phase, issue_slots, |i| {
+                    i.is(QueueType::Issue, TaskKind::Analyze)
+                });
             issue_slots -= drained.len();
             for item in drained {
                 tracing::debug!("issue #{}: creating AnalyzeTask", item.github_number);
@@ -255,10 +292,12 @@ impl<DB: RepoRepository + ScanCursorRepository + QueueRepository + Send> GitHubT
                 )));
             }
 
-            // Issue: Pending(Implement) → Running
-            for item in Self::drain_and_sync(&self.db, &mut repo.queue, issue_slots, |i| {
-                i.is(QueueType::Issue, TaskKind::Implement)
-            }) {
+            // Issue: from_phase(Implement) → Running
+            for item in
+                Self::drain_and_sync(&self.db, &mut repo.queue, from_phase, issue_slots, |i| {
+                    i.is(QueueType::Issue, TaskKind::Implement)
+                })
+            {
                 tracing::debug!("issue #{}: creating ImplementTask", item.github_number);
                 tasks.push(Box::new(ImplementTask::new(
                     Arc::clone(&self.workspace),
@@ -276,10 +315,11 @@ impl<DB: RepoRepository + ScanCursorRepository + QueueRepository + Send> GitHubT
                 .count();
             let mut pr_slots = repo.pr_concurrency.saturating_sub(pr_running);
 
-            // PR: Pending(Review) → Running
-            let drained = Self::drain_and_sync(&self.db, &mut repo.queue, pr_slots, |i| {
-                i.is(QueueType::Pr, TaskKind::Review)
-            });
+            // PR: from_phase(Review) → Running
+            let drained =
+                Self::drain_and_sync(&self.db, &mut repo.queue, from_phase, pr_slots, |i| {
+                    i.is(QueueType::Pr, TaskKind::Review)
+                });
             pr_slots -= drained.len();
             for item in drained {
                 tracing::debug!("PR #{}: creating ReviewTask", item.github_number);
@@ -291,10 +331,11 @@ impl<DB: RepoRepository + ScanCursorRepository + QueueRepository + Send> GitHubT
                 )));
             }
 
-            // PR: Pending(Improve) → Running
-            let drained = Self::drain_and_sync(&self.db, &mut repo.queue, pr_slots, |i| {
-                i.is(QueueType::Pr, TaskKind::Improve)
-            });
+            // PR: from_phase(Improve) → Running
+            let drained =
+                Self::drain_and_sync(&self.db, &mut repo.queue, from_phase, pr_slots, |i| {
+                    i.is(QueueType::Pr, TaskKind::Improve)
+                });
             pr_slots -= drained.len();
             for item in drained {
                 tracing::debug!("PR #{}: creating ImproveTask", item.github_number);
@@ -305,15 +346,14 @@ impl<DB: RepoRepository + ScanCursorRepository + QueueRepository + Send> GitHubT
                 )));
             }
 
-            // PR: Pending(Extract) → fire-and-forget
+            // PR: from_phase(Extract) → fire-and-forget
             // Extract는 PR이 이미 done 상태이므로 큐에 남겨둘 필요 없음.
             // drain_to_filtered로 꺼낸 뒤 즉시 remove하여 Running에 잔류하지 않도록 한다.
-            let extract_items = repo.queue.drain_to_filtered(
-                QueuePhase::Pending,
-                QueuePhase::Running,
-                pr_slots,
-                |i| i.is(QueueType::Pr, TaskKind::Extract),
-            );
+            let extract_items =
+                repo.queue
+                    .drain_to_filtered(from_phase, QueuePhase::Running, pr_slots, |i| {
+                        i.is(QueueType::Pr, TaskKind::Extract)
+                    });
             for item in extract_items {
                 tracing::debug!(
                     "PR #{}: creating ExtractTask (knowledge)",
@@ -376,8 +416,18 @@ impl<DB: RepoRepository + ScanCursorRepository + QueueRepository + Send> Collect
 {
     async fn poll(&mut self) -> Vec<Box<dyn Task>> {
         self.sync_repos().await;
-        self.run_recovery().await;
+
+        // Recovery throttle: 첫 tick에서는 항상 실행, 이후 interval 경과 시에만 실행
+        let should_recover = self.last_recovery.map_or(true, |t| {
+            t.elapsed().as_secs() >= self.recovery_interval_secs
+        });
+        if should_recover {
+            self.run_recovery().await;
+            self.last_recovery = Some(std::time::Instant::now());
+        }
+
         self.run_scans().await;
+        self.sync_queue_phases();
         self.drain_queue_items()
     }
 
@@ -510,14 +560,19 @@ mod tests {
         }
     }
 
-    /// Minimal DB mock for tests — only provides repo_find_enabled.
+    /// Minimal DB mock for tests.
+    /// `active_items`를 설정하면 `queue_load_active()`에서 반환한다.
     struct MockDb {
         repos: Vec<EnabledRepo>,
+        active_items: Vec<crate::core::models::QueueItemRow>,
     }
 
     impl MockDb {
         fn empty() -> Self {
-            Self { repos: vec![] }
+            Self {
+                repos: vec![],
+                active_items: vec![],
+            }
         }
     }
 
@@ -577,10 +632,16 @@ mod tests {
             &self,
             _: &str,
         ) -> anyhow::Result<Vec<crate::core::models::QueueItemRow>> {
-            Ok(vec![])
+            Ok(self.active_items.clone())
         }
         fn queue_transit(&self, _: &str, _: QueuePhase, _: QueuePhase) -> anyhow::Result<bool> {
             Ok(true)
+        }
+        fn queue_get_item(
+            &self,
+            _: &str,
+        ) -> anyhow::Result<Option<crate::core::models::QueueItemRow>> {
+            Ok(None)
         }
     }
 
@@ -593,6 +654,7 @@ mod tests {
             Arc::new(MockGit),
             Arc::new(MockSuggestWorkflow),
             MockDb::empty(),
+            ClawConfig::default(),
         )
     }
 
@@ -1212,6 +1274,158 @@ mod tests {
                 .filter(|i| i.is(QueueType::Pr, TaskKind::Review))
                 .count(),
             1
+        );
+    }
+
+    // ═══════════════════════════════════════════════
+    // claw_enabled: drain phase gating tests
+    // ═══════════════════════════════════════════════
+
+    fn make_claw_source(gh: Arc<MockGh>) -> GitHubTaskSource<MockDb> {
+        GitHubTaskSource::new(
+            Arc::new(MockWorkspace),
+            gh,
+            Arc::new(MockConfigLoader),
+            Arc::new(MockEnv),
+            Arc::new(MockGit),
+            Arc::new(MockSuggestWorkflow),
+            MockDb::empty(),
+            ClawConfig {
+                enabled: true,
+                ..ClawConfig::default()
+            },
+        )
+    }
+
+    #[test]
+    fn drain_from_ready_when_claw_enabled() {
+        let gh = Arc::new(MockGh::new());
+        let mut source = make_claw_source(gh);
+
+        let mut repo = GitRepository::new(
+            "r1".to_string(),
+            "org/repo".to_string(),
+            "https://github.com/org/repo".to_string(),
+            None,
+        );
+        // Item in Ready phase — should be drained when claw_enabled
+        repo.queue.push(
+            QueuePhase::Ready,
+            make_test_queue_item(QueueType::Issue, TaskKind::Analyze, "org/repo", 1),
+        );
+        source.repos.insert("org/repo".to_string(), repo);
+
+        let tasks = source.drain_queue_items();
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].work_id(), "issue:org/repo:1");
+    }
+
+    #[test]
+    fn pending_items_not_drained_when_claw_enabled() {
+        let gh = Arc::new(MockGh::new());
+        let mut source = make_claw_source(gh);
+
+        let mut repo = GitRepository::new(
+            "r1".to_string(),
+            "org/repo".to_string(),
+            "https://github.com/org/repo".to_string(),
+            None,
+        );
+        // Item in Pending phase — should NOT be drained when claw_enabled
+        repo.queue.push(
+            QueuePhase::Pending,
+            make_test_queue_item(QueueType::Issue, TaskKind::Analyze, "org/repo", 1),
+        );
+        source.repos.insert("org/repo".to_string(), repo);
+
+        let tasks = source.drain_queue_items();
+        assert!(tasks.is_empty());
+        // Item should remain in Pending
+        assert_eq!(source.repos["org/repo"].queue.len(QueuePhase::Pending), 1);
+    }
+
+    #[test]
+    fn drain_from_pending_when_claw_disabled() {
+        let gh = Arc::new(MockGh::new());
+        let mut source = make_source(gh); // claw_enabled = false
+
+        let mut repo = GitRepository::new(
+            "r1".to_string(),
+            "org/repo".to_string(),
+            "https://github.com/org/repo".to_string(),
+            None,
+        );
+        repo.queue.push(
+            QueuePhase::Pending,
+            make_test_queue_item(QueueType::Issue, TaskKind::Analyze, "org/repo", 1),
+        );
+        source.repos.insert("org/repo".to_string(), repo);
+
+        let tasks = source.drain_queue_items();
+        assert_eq!(tasks.len(), 1);
+    }
+
+    #[test]
+    fn sync_queue_phases_promotes_ready() {
+        let now = chrono::Utc::now().to_rfc3339();
+        let active_row = crate::core::models::QueueItemRow {
+            work_id: "issue:org/repo:1".to_string(),
+            repo_id: "r1".to_string(),
+            queue_type: QueueType::Issue,
+            phase: QueuePhase::Ready,
+            title: Some("Test".to_string()),
+            skip_reason: None,
+            created_at: now.clone(),
+            updated_at: now,
+            task_kind: TaskKind::Analyze,
+            github_number: 1,
+            metadata_json: None,
+        };
+
+        let db = MockDb {
+            repos: vec![],
+            active_items: vec![active_row],
+        };
+
+        let mut source = GitHubTaskSource::new(
+            Arc::new(MockWorkspace),
+            Arc::new(MockGh::new()),
+            Arc::new(MockConfigLoader),
+            Arc::new(MockEnv),
+            Arc::new(MockGit),
+            Arc::new(MockSuggestWorkflow),
+            db,
+            ClawConfig {
+                enabled: true,
+                ..ClawConfig::default()
+            },
+        );
+
+        let mut repo = GitRepository::new(
+            "r1".to_string(),
+            "org/repo".to_string(),
+            "https://github.com/org/repo".to_string(),
+            None,
+        );
+        // Item starts in Pending in memory
+        repo.queue.push(
+            QueuePhase::Pending,
+            make_test_queue_item(QueueType::Issue, TaskKind::Analyze, "org/repo", 1),
+        );
+        source.repos.insert("org/repo".to_string(), repo);
+
+        // Before sync: item is Pending
+        assert_eq!(
+            source.repos["org/repo"].queue.phase_of("issue:org/repo:1"),
+            Some(QueuePhase::Pending)
+        );
+
+        source.sync_queue_phases();
+
+        // After sync: item should be Ready (promoted from DB state)
+        assert_eq!(
+            source.repos["org/repo"].queue.phase_of("issue:org/repo:1"),
+            Some(QueuePhase::Ready)
         );
     }
 }

--- a/plugins/autodev/cli/src/service/daemon/mod.rs
+++ b/plugins/autodev/cli/src/service/daemon/mod.rs
@@ -344,6 +344,7 @@ pub async fn start(
         Arc::clone(&git),
         Arc::clone(&sw),
         source_db,
+        cfg.claw.clone(),
     );
 
     // ── Startup Reconcile ──

--- a/plugins/autodev/cli/src/service/tasks/helpers/git_ops.rs
+++ b/plugins/autodev/cli/src/service/tasks/helpers/git_ops.rs
@@ -960,6 +960,9 @@ mod tests {
         fn queue_transit(&self, _: &str, _: QueuePhase, _: QueuePhase) -> Result<bool> {
             Ok(true)
         }
+        fn queue_get_item(&self, _: &str) -> Result<Option<crate::core::models::QueueItemRow>> {
+            Ok(None)
+        }
     }
 
     // ─── Test Helpers ───

--- a/plugins/autodev/cli/tests/queue_advance_tests.rs
+++ b/plugins/autodev/cli/tests/queue_advance_tests.rs
@@ -221,7 +221,7 @@ fn cli_queue_advance_changes_phase() {
     let repo_id = add_test_repo(&db);
     insert_queue_item(&db, &repo_id, "work-cli-1", "pending");
 
-    let output = autodev::cli::queue::queue_advance(&db, "work-cli-1").unwrap();
+    let output = autodev::cli::queue::queue_advance(&db, "work-cli-1", None).unwrap();
     assert!(output.contains("pending"));
     assert!(output.contains("ready"));
 
@@ -440,4 +440,148 @@ fn cli_queue_list_shows_task_kind() {
     let output = autodev::cli::queue::queue_list_db(&db, None, false, None, false).unwrap();
     assert!(output.contains("analyze"));
     assert!(output.contains("#42"));
+}
+
+// ═══════════════════════════════════════════════
+// 9. Decision recording (H2)
+// ═══════════════════════════════════════════════
+
+#[test]
+fn advance_records_decision() {
+    let db = open_memory_db();
+    let repo_id = add_test_repo(&db);
+    insert_queue_item(&db, &repo_id, "work-dec-1", "pending");
+
+    autodev::cli::queue::queue_advance(&db, "work-dec-1", Some("auto-approved")).unwrap();
+
+    let decisions = db.decision_list(None, 10).unwrap();
+    assert!(!decisions.is_empty());
+    let d = &decisions[0];
+    assert_eq!(
+        d.decision_type,
+        autodev::core::models::DecisionType::Advance
+    );
+    assert_eq!(d.target_work_id.as_deref(), Some("work-dec-1"));
+    assert_eq!(d.reasoning, "auto-approved");
+}
+
+#[test]
+fn skip_records_decision() {
+    let db = open_memory_db();
+    let repo_id = add_test_repo(&db);
+    insert_queue_item(&db, &repo_id, "work-dec-2", "pending");
+
+    autodev::cli::queue::queue_skip(&db, "work-dec-2", Some("out of scope")).unwrap();
+
+    let decisions = db.decision_list(None, 10).unwrap();
+    assert!(!decisions.is_empty());
+    let d = &decisions[0];
+    assert_eq!(d.decision_type, autodev::core::models::DecisionType::Skip);
+    assert_eq!(d.target_work_id.as_deref(), Some("work-dec-2"));
+    assert_eq!(d.reasoning, "out of scope");
+}
+
+// ═══════════════════════════════════════════════
+// 10. queue_get_item
+// ═══════════════════════════════════════════════
+
+#[test]
+fn queue_get_item_returns_existing() {
+    let db = open_memory_db();
+    let repo_id = add_test_repo(&db);
+    db.queue_upsert(&make_row(
+        &repo_id,
+        "issue:org/test-repo:99",
+        QueuePhase::Pending,
+    ))
+    .unwrap();
+
+    let item = db.queue_get_item("issue:org/test-repo:99").unwrap();
+    assert!(item.is_some());
+    let item = item.unwrap();
+    assert_eq!(item.work_id, "issue:org/test-repo:99");
+    assert_eq!(item.phase, QueuePhase::Pending);
+}
+
+#[test]
+fn queue_get_item_returns_none_for_nonexistent() {
+    let db = open_memory_db();
+
+    let item = db.queue_get_item("nonexistent").unwrap();
+    assert!(item.is_none());
+}
+
+// ═══════════════════════════════════════════════
+// 11. HITL auto-trigger on review overflow (H3)
+// ═══════════════════════════════════════════════
+
+#[test]
+fn advance_creates_hitl_on_review_overflow() {
+    let db = open_memory_db();
+    let repo_id = add_test_repo(&db);
+
+    // Insert a PR item with review_iteration >= max (2)
+    let pr_metadata = serde_json::json!({
+        "Pr": {
+            "head_branch": "feat/test",
+            "base_branch": "main",
+            "review_comment": null,
+            "source_issue_number": null,
+            "review_iteration": 3
+        }
+    });
+    let now = chrono::Utc::now().to_rfc3339();
+    db.conn()
+        .execute(
+            "INSERT INTO queue_items (work_id, repo_id, queue_type, phase, title, created_at, updated_at, metadata_json) \
+             VALUES (?1, ?2, 'pr', 'pending', 'PR with high iterations', ?3, ?3, ?4)",
+            rusqlite::params!["pr:org/test-repo:50", repo_id, now, pr_metadata.to_string()],
+        )
+        .unwrap();
+
+    autodev::cli::queue::queue_advance(&db, "pr:org/test-repo:50", None).unwrap();
+
+    // Should have created a HITL event
+    let hitl_events = db.hitl_list(None).unwrap();
+    assert!(
+        !hitl_events.is_empty(),
+        "HITL event should be created for review overflow"
+    );
+    let event = &hitl_events[0];
+    assert!(event.situation.contains("review iteration"));
+    assert_eq!(event.work_id.as_deref(), Some("pr:org/test-repo:50"));
+}
+
+#[test]
+fn advance_no_hitl_when_below_threshold() {
+    let db = open_memory_db();
+    let repo_id = add_test_repo(&db);
+
+    // Insert a PR item with review_iteration below max
+    let pr_metadata = serde_json::json!({
+        "Pr": {
+            "head_branch": "feat/test",
+            "base_branch": "main",
+            "review_comment": null,
+            "source_issue_number": null,
+            "review_iteration": 1
+        }
+    });
+    let now = chrono::Utc::now().to_rfc3339();
+    db.conn()
+        .execute(
+            "INSERT INTO queue_items (work_id, repo_id, queue_type, phase, title, created_at, updated_at, metadata_json) \
+             VALUES (?1, ?2, 'pr', 'pending', 'Normal PR', ?3, ?3, ?4)",
+            rusqlite::params!["pr:org/test-repo:51", repo_id, now, pr_metadata.to_string()],
+        )
+        .unwrap();
+
+    autodev::cli::queue::queue_advance(&db, "pr:org/test-repo:51", None).unwrap();
+
+    // Should NOT have created a HITL event
+    let hitl_events = db.hitl_list(None).unwrap();
+    assert!(
+        hitl_events.is_empty(),
+        "No HITL event for low iteration count"
+    );
 }


### PR DESCRIPTION
## Summary

- **C1 (Drain Phase Gating)**: `claw.enabled` feature flag controls drain source phase — `Ready→Running` when enabled, `Pending→Running` when disabled (default). `sync_queue_phases()` syncs DB Ready state to in-memory queue.
- **H1 (Recovery Throttle)**: In-memory `last_recovery` timestamp with configurable `recovery_interval_secs` (default 120s), independent from scan cursor.
- **H2 (Decision Recording)**: `queue advance` and `queue skip` CLI commands record to `claw_decisions` table via `record_decision()` helper. Added `--reason` flag to advance.
- **H3 (HITL Auto-Trigger)**: `queue advance` checks PR `review_iteration >= max_iterations` and auto-creates HITL event using `ReviewStage::default().max_iterations`.

Closes #255 Phase 2.

## Changed files

| File | Change |
|---|---|
| `core/config/models.rs` | `ClawConfig` struct (enabled, recovery_interval_secs) |
| `service/daemon/collectors/github.rs` | Recovery throttle, drain phase gating, sync_queue_phases |
| `cli/queue.rs` | Decision recording, HITL trigger, extract_review_iteration |
| `core/repository.rs` | `queue_get_item()` trait method |
| `infra/db/repository.rs` | `queue_get_item()` SQLite impl |
| `main.rs` | `--reason` option on `queue advance` |
| `service/daemon/mod.rs` | Pass `ClawConfig` to GitHubTaskSource |

## Test plan

- [x] `drain_from_ready_when_claw_enabled` — Ready items drain when claw enabled
- [x] `pending_items_not_drained_when_claw_enabled` — Pending items stay when claw enabled
- [x] `drain_from_pending_when_claw_disabled` — Existing behavior preserved
- [x] `sync_queue_phases_promotes_ready` — DB Ready → in-memory Ready
- [x] `advance_records_decision` / `skip_records_decision` — claw_decisions recorded
- [x] `queue_get_item_returns_existing` / `_nonexistent` — new trait method
- [x] `advance_creates_hitl_on_review_overflow` / `advance_no_hitl_when_below_threshold` — HITL trigger
- [x] `claw_config_defaults` / `_from_yaml` / `_defaults_when_omitted` — config tests
- [x] `cargo fmt --check` ✅
- [x] `cargo clippy -- -D warnings` ✅
- [x] `cargo test` — 537 tests pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)