### PR TITLE
feat(autodev): add force-trigger for claw-evaluate on task events (C3)

### DIFF
--- a/plugins/autodev/cli/Cargo.lock
+++ b/plugins/autodev/cli/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autodev"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/plugins/autodev/cli/src/cli/cron.rs
+++ b/plugins/autodev/cli/src/cli/cron.rs
@@ -193,6 +193,9 @@ struct BuiltinCronDef {
     schedule: CronSchedule,
 }
 
+/// Cron job name for claw-evaluate (used by daemon force-trigger).
+pub const CLAW_EVALUATE_JOB: &str = "claw-evaluate";
+
 /// 템플릿에서 포함한 스크립트 내용
 const CLAW_EVALUATE_SH: &str = include_str!("../../../templates/crons/claw-evaluate.sh");
 const GAP_DETECTION_SH: &str = include_str!("../../../templates/crons/gap-detection.sh");
@@ -204,7 +207,7 @@ const LOG_CLEANUP_SH: &str = include_str!("../../../templates/crons/log-cleanup.
 fn per_repo_cron_defs(claw_cfg: &config::models::ClawConfig) -> Vec<BuiltinCronDef> {
     vec![
         BuiltinCronDef {
-            name: "claw-evaluate",
+            name: CLAW_EVALUATE_JOB,
             script_filename: "claw-evaluate.sh",
             script_content: CLAW_EVALUATE_SH,
             schedule: CronSchedule::Interval {

--- a/plugins/autodev/cli/src/core/repository.rs
+++ b/plugins/autodev/cli/src/core/repository.rs
@@ -108,5 +108,7 @@ pub trait CronRepository {
     fn cron_set_status(&self, name: &str, repo: Option<&str>, status: CronStatus) -> Result<()>;
     fn cron_remove(&self, name: &str, repo: Option<&str>) -> Result<()>;
     fn cron_update_last_run(&self, id: &str) -> Result<()>;
+    /// Reset last_run_at to NULL so the job is picked up as due on the next tick.
+    fn cron_reset_last_run(&self, name: &str, repo: Option<&str>) -> Result<()>;
     fn cron_find_due(&self) -> Result<Vec<CronJob>>;
 }

--- a/plugins/autodev/cli/src/infra/db/repository.rs
+++ b/plugins/autodev/cli/src/infra/db/repository.rs
@@ -1221,6 +1221,24 @@ impl CronRepository for Database {
         Ok(())
     }
 
+    fn cron_reset_last_run(&self, name: &str, repo: Option<&str>) -> Result<()> {
+        let rows_affected = if let Some(repo_id) = repo {
+            self.conn().execute(
+                "UPDATE cron_jobs SET last_run_at = NULL WHERE name = ?1 AND repo_id = ?2",
+                rusqlite::params![name, repo_id],
+            )?
+        } else {
+            self.conn().execute(
+                "UPDATE cron_jobs SET last_run_at = NULL WHERE name = ?1 AND repo_id IS NULL",
+                rusqlite::params![name],
+            )?
+        };
+        if rows_affected == 0 {
+            anyhow::bail!("cron job not found: {name}");
+        }
+        Ok(())
+    }
+
     fn cron_find_due(&self) -> Result<Vec<CronJob>> {
         let conn = self.conn();
         let now = Utc::now();

--- a/plugins/autodev/cli/src/service/daemon/cron/engine.rs
+++ b/plugins/autodev/cli/src/service/daemon/cron/engine.rs
@@ -110,6 +110,16 @@ impl CronEngine {
         true
     }
 
+    /// Mark a cron job for immediate execution on the next tick by resetting its last_run_at.
+    ///
+    /// This is used for event-driven triggers (e.g., task failure → claw-evaluate).
+    pub fn force_trigger(&self, name: &str) {
+        match self.db.cron_reset_last_run(name, None) {
+            Ok(()) => info!("cron: force-triggered '{name}' for next tick"),
+            Err(e) => warn!("cron: failed to force-trigger '{name}': {e}"),
+        }
+    }
+
     /// Check if a specific job is currently running.
     pub fn is_running(&self, job_id: &str) -> bool {
         self.running.get(job_id).is_some_and(|h| !h.is_finished())
@@ -252,6 +262,38 @@ mod tests {
         // Second tick should NOT execute (interval not elapsed)
         let results = engine.tick().await;
         assert!(results.is_empty());
+    }
+
+    #[tokio::test]
+    async fn force_trigger_resets_last_run_and_job_runs_again() {
+        let (dir, db) = setup_db();
+
+        db.cron_add(&NewCronJob {
+            name: "force-test".to_string(),
+            repo_id: None,
+            schedule: CronSchedule::Interval { secs: 3600 }, // 1 hour
+            script_path: "echo forced".to_string(),
+            builtin: false,
+        })
+        .unwrap();
+
+        let mut engine = CronEngine::new(db, dir.path().to_path_buf());
+
+        // First tick runs the job
+        let results = engine.tick().await;
+        assert_eq!(results.len(), 1);
+
+        // Second tick should NOT run (interval not elapsed)
+        let results = engine.tick().await;
+        assert!(results.is_empty());
+
+        // Force trigger resets last_run_at
+        engine.force_trigger("force-test");
+
+        // Third tick should run again
+        let results = engine.tick().await;
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].stdout.trim(), "forced");
     }
 
     #[tokio::test]

--- a/plugins/autodev/cli/src/service/daemon/mod.rs
+++ b/plugins/autodev/cli/src/service/daemon/mod.rs
@@ -198,6 +198,11 @@ impl Daemon {
                                     }
                                 }
                             }
+
+                            // Force-trigger claw-evaluate on any task completion/failure
+                            if let Some(ref cron) = self.cron_engine {
+                                cron.force_trigger(crate::cli::cron::CLAW_EVALUATE_JOB);
+                            }
                         }
                         Err(e) => {
                             tracing::error!("spawned task panicked: {e}");


### PR DESCRIPTION
## Summary
- **C3: Force trigger** — Task completion/failure events now immediately trigger `claw-evaluate` cron job, without waiting for the next cron cycle
- Adds `CronEngine::force_trigger(name)` that resets `last_run_at` to NULL so the job runs on the next daemon tick
- Extracts `CLAW_EVALUATE_JOB` constant to eliminate magic strings

## Changes
| File | Change |
|------|--------|
| `core/repository.rs` | `cron_reset_last_run(name, repo)` trait method |
| `infra/db/repository.rs` | SQLite implementation (UPDATE SET NULL) |
| `cron/engine.rs` | `force_trigger(name)` + integration test |
| `cli/cron.rs` | `CLAW_EVALUATE_JOB` constant, used in builtin definition |
| `daemon/mod.rs` | Calls `force_trigger` after task completion/failure |

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --check` passes  
- [x] `cargo test` — all 17 test suites pass (including new `force_trigger_resets_last_run_and_job_runs_again`)
- [ ] Manual: Start daemon, trigger a task, verify claw-evaluate runs immediately after completion

Partially addresses #265 (C3 of C1-C3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)