### PR TITLE
fix(autodev): preserve worktrees on failure for all task types (M3)

### DIFF
--- a/plugins/autodev/cli/Cargo.lock
+++ b/plugins/autodev/cli/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autodev"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/plugins/autodev/cli/src/service/tasks/improve.rs
+++ b/plugins/autodev/cli/src/service/tasks/improve.rs
@@ -180,6 +180,8 @@ impl Task for ImproveTask {
                 phase: QueuePhase::Pending,
                 item: Box::new(next_item),
             });
+
+            self.cleanup_worktree().await;
         } else {
             // add-first: IMPROVE_FAILED 추가 후 CHANGES_REQUESTED 제거
             self.gh
@@ -199,13 +201,14 @@ impl Task for ImproveTask {
                 )
                 .await;
 
+            let head_branch = self.item.head_branch().unwrap_or("").to_string();
             let fail_comment = format!(
                 "<!-- autodev:improve-failed -->\n\
                  ⚠️ Improve agent failed (exit_code={}).\n\n\
-                 **Branch**: `{}`\n\
-                 Check the agent logs for details.",
+                 **Branch**: `{head_branch}`\n\
+                 Worktree has been preserved for debugging:\n\
+                 ```\ngit worktree list | grep '{head_branch}'\n```",
                 response.exit_code,
-                self.item.head_branch().unwrap_or("")
             );
             self.gh
                 .issue_comment(
@@ -216,10 +219,9 @@ impl Task for ImproveTask {
                 )
                 .await;
 
+            tracing::warn!("worktree preserved for debugging: {}", self.work_id());
             ops.push(QueueOp::Remove);
         }
-
-        self.cleanup_worktree().await;
 
         TaskResult {
             work_id: self.item.work_id.clone(),

--- a/plugins/autodev/cli/src/service/tasks/review.rs
+++ b/plugins/autodev/cli/src/service/tasks/review.rs
@@ -233,13 +233,14 @@ impl Task for ReviewTask {
                 )
                 .await;
 
+            let head_branch = self.item.head_branch().unwrap_or("").to_string();
             let fail_comment = format!(
                 "<!-- autodev:review-failed -->\n\
                  ⚠️ Review agent failed (exit_code={}).\n\n\
-                 **Branch**: `{}`\n\
-                 Check the agent logs for details.",
+                 **Branch**: `{head_branch}`\n\
+                 Worktree has been preserved for debugging:\n\
+                 ```\ngit worktree list | grep '{head_branch}'\n```",
                 response.exit_code,
-                self.item.head_branch().unwrap_or("")
             );
             self.gh
                 .issue_comment(
@@ -250,7 +251,7 @@ impl Task for ReviewTask {
                 )
                 .await;
 
-            self.cleanup_worktree().await;
+            tracing::warn!("worktree preserved for debugging: {}", self.work_id());
             return TaskResult {
                 work_id: self.item.work_id.clone(),
                 repo_name: self.item.repo_name.clone(),


### PR DESCRIPTION
## Summary
- **M3: Worktree preservation on failure** — ReviewTask and ImproveTask now preserve worktrees on agent failure, consistent with ImplementTask's existing behavior
- Failure comments include debugging instructions (`git worktree list | grep '<branch>'`)
- Cleanup only runs on success path

## Changes
| File | Change |
|------|--------|
| `review.rs` | Remove `cleanup_worktree()` on failure; add preservation notice + tracing |
| `improve.rs` | Move `cleanup_worktree()` into success branch; add preservation notice |

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] `cargo test` — all 17 test suites pass
- [ ] Manual: Trigger review/improve failure, verify worktree is preserved

Partially addresses #269 (M3 of M1-M3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)