### PR TITLE
feat(autodev): add M1 convention auto-refinement feedback infrastructure

### DIFF
--- a/plugins/autodev/cli/Cargo.lock
+++ b/plugins/autodev/cli/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autodev"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/plugins/autodev/cli/src/cli/convention.rs
+++ b/plugins/autodev/cli/src/cli/convention.rs
@@ -1,5 +1,10 @@
 use std::path::Path;
 
+use anyhow::Result;
+
+use crate::core::repository::FeedbackPatternRepository;
+use crate::infra::db::Database;
+
 /// Detected technology stack from a repository.
 #[derive(Debug, Default, Clone)]
 pub struct TechStack {
@@ -557,3 +562,58 @@ npx eslint .
 npx prettier --check .
 ```
 "#;
+
+// ─── Feedback Patterns CLI ───
+
+/// List feedback patterns for a repo, formatted as a table.
+pub fn patterns(
+    db: &Database,
+    repo_id: Option<&str>,
+    min_count: Option<i32>,
+    json: bool,
+) -> Result<String> {
+    let patterns = if let Some(rid) = repo_id {
+        if let Some(mc) = min_count.filter(|&c| c > 1) {
+            db.feedback_list_actionable(rid, mc)?
+        } else {
+            db.feedback_list(rid)?
+        }
+    } else {
+        // No repo_id: return empty with a message
+        return Ok("Specify --repo to list feedback patterns.\n".to_string());
+    };
+
+    if json {
+        return Ok(serde_json::to_string_pretty(&patterns)?);
+    }
+
+    if patterns.is_empty() {
+        return Ok("No feedback patterns found.\n".to_string());
+    }
+
+    let mut output = String::new();
+    output.push_str(&format!(
+        "{:<8} {:<16} {:<10} {:<8} {:<10} {}\n",
+        "COUNT", "TYPE", "STATUS", "CONF", "SOURCE", "SUGGESTION"
+    ));
+    output.push_str(&format!("{}\n", "-".repeat(80)));
+
+    for p in &patterns {
+        let suggestion_short = if p.suggestion.len() > 40 {
+            format!("{}...", &p.suggestion[..37])
+        } else {
+            p.suggestion.clone()
+        };
+        output.push_str(&format!(
+            "{:<8} {:<16} {:<10} {:<8.2} {:<10} {}\n",
+            p.occurrence_count,
+            p.pattern_type,
+            p.status.as_str(),
+            p.confidence,
+            p.source,
+            suggestion_short,
+        ));
+    }
+
+    Ok(output)
+}

--- a/plugins/autodev/cli/src/core/models.rs
+++ b/plugins/autodev/cli/src/core/models.rs
@@ -679,6 +679,70 @@ pub struct NewCronJob {
     pub builtin: bool,
 }
 
+// ─── Feedback Pattern models ───
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FeedbackPattern {
+    pub id: String,
+    pub repo_id: String,
+    pub pattern_type: String,
+    pub suggestion: String,
+    pub source: String,
+    pub occurrence_count: i32,
+    pub confidence: f64,
+    pub status: FeedbackPatternStatus,
+    pub sources_json: String,
+    pub created_at: String,
+    pub last_seen_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FeedbackPatternStatus {
+    Active,
+    Proposed,
+    Applied,
+    Rejected,
+}
+
+impl FeedbackPatternStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            FeedbackPatternStatus::Active => "active",
+            FeedbackPatternStatus::Proposed => "proposed",
+            FeedbackPatternStatus::Applied => "applied",
+            FeedbackPatternStatus::Rejected => "rejected",
+        }
+    }
+}
+
+impl std::str::FromStr for FeedbackPatternStatus {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "active" => Ok(FeedbackPatternStatus::Active),
+            "proposed" => Ok(FeedbackPatternStatus::Proposed),
+            "applied" => Ok(FeedbackPatternStatus::Applied),
+            "rejected" => Ok(FeedbackPatternStatus::Rejected),
+            _ => Err(format!("invalid feedback pattern status: {s}")),
+        }
+    }
+}
+
+impl fmt::Display for FeedbackPatternStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+pub struct NewFeedbackPattern {
+    pub repo_id: String,
+    pub pattern_type: String,
+    pub suggestion: String,
+    pub source: String,
+}
+
 // ─── Claw Decision models ───
 
 /// Claw decision type

--- a/plugins/autodev/cli/src/core/repository.rs
+++ b/plugins/autodev/cli/src/core/repository.rs
@@ -95,6 +95,17 @@ pub trait ClawDecisionRepository {
     fn decision_count(&self, repo: Option<&str>) -> Result<i64>;
 }
 
+pub trait FeedbackPatternRepository {
+    fn feedback_upsert(&self, pattern: &NewFeedbackPattern) -> Result<String>;
+    fn feedback_list(&self, repo_id: &str) -> Result<Vec<FeedbackPattern>>;
+    fn feedback_list_actionable(
+        &self,
+        repo_id: &str,
+        min_count: i32,
+    ) -> Result<Vec<FeedbackPattern>>;
+    fn feedback_set_status(&self, id: &str, status: FeedbackPatternStatus) -> Result<()>;
+}
+
 pub trait CronRepository {
     fn cron_add(&self, job: &NewCronJob) -> Result<String>;
     fn cron_list(&self, repo: Option<&str>) -> Result<Vec<CronJob>>;

--- a/plugins/autodev/cli/src/infra/db/repository.rs
+++ b/plugins/autodev/cli/src/infra/db/repository.rs
@@ -54,6 +54,10 @@ impl RepoRepository for Database {
             rusqlite::params![repo_id],
         )?;
         tx.execute(
+            "DELETE FROM feedback_patterns WHERE repo_id = ?1",
+            rusqlite::params![repo_id],
+        )?;
+        tx.execute(
             "DELETE FROM cron_jobs WHERE repo_id = ?1",
             rusqlite::params![repo_id],
         )?;
@@ -1027,6 +1031,105 @@ impl ClawDecisionRepository for Database {
     }
 }
 
+impl FeedbackPatternRepository for Database {
+    fn feedback_upsert(&self, pattern: &NewFeedbackPattern) -> Result<String> {
+        let conn = self.conn();
+        let now = Utc::now().to_rfc3339();
+        let id = Uuid::new_v4().to_string();
+
+        // Try insert first
+        let inserted = conn.execute(
+            "INSERT OR IGNORE INTO feedback_patterns \
+             (id, repo_id, pattern_type, suggestion, source, occurrence_count, confidence, status, sources_json, created_at, last_seen_at) \
+             VALUES (?1, ?2, ?3, ?4, ?5, 1, 0.5, 'active', ?6, ?7, ?7)",
+            rusqlite::params![
+                id,
+                pattern.repo_id,
+                pattern.pattern_type,
+                pattern.suggestion,
+                pattern.source,
+                format!(r#"{{"{}": 1}}"#, pattern.source),
+                now
+            ],
+        )?;
+
+        if inserted == 0 {
+            // Row already exists — increment occurrence_count and update sources_json
+            conn.execute(
+                "UPDATE feedback_patterns \
+                 SET occurrence_count = occurrence_count + 1, \
+                     last_seen_at = ?1, \
+                     source = ?2, \
+                     sources_json = json_set(sources_json, '$.' || ?2, \
+                         COALESCE(json_extract(sources_json, '$.' || ?2), 0) + 1) \
+                 WHERE repo_id = ?3 AND pattern_type = ?4 AND suggestion = ?5",
+                rusqlite::params![
+                    now,
+                    pattern.source,
+                    pattern.repo_id,
+                    pattern.pattern_type,
+                    pattern.suggestion
+                ],
+            )?;
+
+            // Return the existing id
+            let existing_id: String = conn.query_row(
+                "SELECT id FROM feedback_patterns \
+                 WHERE repo_id = ?1 AND pattern_type = ?2 AND suggestion = ?3",
+                rusqlite::params![pattern.repo_id, pattern.pattern_type, pattern.suggestion],
+                |row| row.get(0),
+            )?;
+            return Ok(existing_id);
+        }
+
+        Ok(id)
+    }
+
+    fn feedback_list(&self, repo_id: &str) -> Result<Vec<FeedbackPattern>> {
+        let conn = self.conn();
+        let mut stmt = conn.prepare(
+            "SELECT id, repo_id, pattern_type, suggestion, source, occurrence_count, \
+             confidence, status, sources_json, created_at, last_seen_at \
+             FROM feedback_patterns WHERE repo_id = ?1 \
+             ORDER BY occurrence_count DESC, last_seen_at DESC",
+        )?;
+        let rows = stmt.query_map(rusqlite::params![repo_id], map_feedback_pattern_row)?;
+        rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    }
+
+    fn feedback_list_actionable(
+        &self,
+        repo_id: &str,
+        min_count: i32,
+    ) -> Result<Vec<FeedbackPattern>> {
+        let conn = self.conn();
+        let mut stmt = conn.prepare(
+            "SELECT id, repo_id, pattern_type, suggestion, source, occurrence_count, \
+             confidence, status, sources_json, created_at, last_seen_at \
+             FROM feedback_patterns \
+             WHERE repo_id = ?1 AND occurrence_count >= ?2 AND status = 'active' \
+             ORDER BY occurrence_count DESC, last_seen_at DESC",
+        )?;
+        let rows = stmt.query_map(
+            rusqlite::params![repo_id, min_count],
+            map_feedback_pattern_row,
+        )?;
+        rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
+    }
+
+    fn feedback_set_status(&self, id: &str, status: FeedbackPatternStatus) -> Result<()> {
+        let conn = self.conn();
+        let rows_affected = conn.execute(
+            "UPDATE feedback_patterns SET status = ?1 WHERE id = ?2",
+            rusqlite::params![status.as_str(), id],
+        )?;
+        if rows_affected == 0 {
+            anyhow::bail!("feedback pattern not found: {id}");
+        }
+        Ok(())
+    }
+}
+
 impl CronRepository for Database {
     fn cron_add(&self, job: &NewCronJob) -> Result<String> {
         let conn = self.conn();
@@ -1424,6 +1527,29 @@ fn map_queue_item_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<QueueItemRow>
         metadata_json: row.get(10)?,
         failure_count: row.get::<_, Option<i32>>(11)?.unwrap_or(0),
         escalation_level: row.get::<_, Option<i32>>(12)?.unwrap_or(0),
+    })
+}
+
+fn map_feedback_pattern_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<FeedbackPattern> {
+    let status_str: String = row.get(7)?;
+    Ok(FeedbackPattern {
+        id: row.get(0)?,
+        repo_id: row.get(1)?,
+        pattern_type: row.get(2)?,
+        suggestion: row.get(3)?,
+        source: row.get(4)?,
+        occurrence_count: row.get(5)?,
+        confidence: row.get(6)?,
+        status: status_str.parse().map_err(|e: String| {
+            rusqlite::Error::FromSqlConversionFailure(
+                7,
+                rusqlite::types::Type::Text,
+                Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, e)),
+            )
+        })?,
+        sources_json: row.get(8)?,
+        created_at: row.get(9)?,
+        last_seen_at: row.get(10)?,
     })
 }
 

--- a/plugins/autodev/cli/src/infra/db/schema.rs
+++ b/plugins/autodev/cli/src/infra/db/schema.rs
@@ -187,6 +187,22 @@ pub fn create_tables(conn: &Connection) -> Result<()> {
         CREATE INDEX IF NOT EXISTS idx_claw_decisions_repo ON claw_decisions(repo_id, created_at);
         CREATE INDEX IF NOT EXISTS idx_claw_decisions_spec ON claw_decisions(spec_id, created_at);
 
+        CREATE TABLE IF NOT EXISTS feedback_patterns (
+            id              TEXT PRIMARY KEY,
+            repo_id         TEXT NOT NULL REFERENCES repositories(id),
+            pattern_type    TEXT NOT NULL,
+            suggestion      TEXT NOT NULL,
+            source          TEXT NOT NULL,
+            occurrence_count INTEGER NOT NULL DEFAULT 1,
+            confidence      REAL NOT NULL DEFAULT 0.5,
+            status          TEXT NOT NULL DEFAULT 'active',
+            sources_json    TEXT NOT NULL DEFAULT '{}',
+            created_at      TEXT NOT NULL,
+            last_seen_at    TEXT NOT NULL,
+            UNIQUE(repo_id, pattern_type, suggestion)
+        );
+        CREATE INDEX IF NOT EXISTS idx_feedback_patterns_repo ON feedback_patterns(repo_id, status);
+
         COMMIT;
         ",
     )?;

--- a/plugins/autodev/cli/src/main.rs
+++ b/plugins/autodev/cli/src/main.rs
@@ -146,6 +146,18 @@ enum ConventionAction {
         #[arg(long)]
         apply: bool,
     },
+    /// 피드백 패턴 조회
+    Patterns {
+        /// 레포 이름 (org/repo)
+        #[arg(long)]
+        repo: Option<String>,
+        /// 최소 발생 횟수 필터
+        #[arg(long, default_value = "1")]
+        min_count: i32,
+        /// JSON 출력
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1003,6 +1015,23 @@ async fn main() -> Result<()> {
                     "{}",
                     client::convention::format_bootstrap_result(&result, !apply)
                 );
+            }
+            ConventionAction::Patterns {
+                repo,
+                min_count,
+                json,
+            } => {
+                let repo_id = repo
+                    .as_deref()
+                    .map(|name| client::resolve_repo_id(&db, name));
+                let repo_id = match repo_id {
+                    Some(Ok(id)) => Some(id),
+                    Some(Err(e)) => return Err(e),
+                    None => None,
+                };
+                let output =
+                    client::convention::patterns(&db, repo_id.as_deref(), Some(min_count), json)?;
+                print!("{output}");
             }
         },
     }

--- a/plugins/autodev/cli/tests/feedback_pattern_tests.rs
+++ b/plugins/autodev/cli/tests/feedback_pattern_tests.rs
@@ -1,0 +1,287 @@
+use autodev::core::models::*;
+use autodev::core::repository::*;
+use autodev::infra::db::Database;
+use std::path::Path;
+
+// ─── Helpers ───
+
+fn open_memory_db() -> Database {
+    let db = Database::open(Path::new(":memory:")).expect("open in-memory db");
+    db.initialize().expect("initialize schema");
+    db
+}
+
+fn add_test_repo(db: &Database, name: &str) -> String {
+    db.repo_add(&format!("https://github.com/{name}"), name)
+        .expect("add repo")
+}
+
+fn make_pattern(repo_id: &str, pattern_type: &str, suggestion: &str) -> NewFeedbackPattern {
+    NewFeedbackPattern {
+        repo_id: repo_id.to_string(),
+        pattern_type: pattern_type.to_string(),
+        suggestion: suggestion.to_string(),
+        source: "hitl".to_string(),
+    }
+}
+
+// ═══════════════════════════════════════════════
+// 1. feedback_upsert creates new pattern
+// ═══════════════════════════════════════════════
+
+#[test]
+fn feedback_upsert_creates_new_pattern() {
+    let db = open_memory_db();
+    let repo_id = add_test_repo(&db, "org/repo-a");
+
+    let id = db
+        .feedback_upsert(&make_pattern(&repo_id, "error-handling", "Use Result<T>"))
+        .unwrap();
+    assert!(!id.is_empty());
+    assert_eq!(id.len(), 36); // UUID v4
+
+    let patterns = db.feedback_list(&repo_id).unwrap();
+    assert_eq!(patterns.len(), 1);
+    assert_eq!(patterns[0].pattern_type, "error-handling");
+    assert_eq!(patterns[0].suggestion, "Use Result<T>");
+    assert_eq!(patterns[0].source, "hitl");
+    assert_eq!(patterns[0].occurrence_count, 1);
+    assert_eq!(patterns[0].status, FeedbackPatternStatus::Active);
+}
+
+// ═══════════════════════════════════════════════
+// 2. feedback_upsert increments count on duplicate
+// ═══════════════════════════════════════════════
+
+#[test]
+fn feedback_upsert_increments_on_duplicate() {
+    let db = open_memory_db();
+    let repo_id = add_test_repo(&db, "org/repo-a");
+
+    let id1 = db
+        .feedback_upsert(&make_pattern(&repo_id, "testing", "Add unit tests"))
+        .unwrap();
+    let id2 = db
+        .feedback_upsert(&make_pattern(&repo_id, "testing", "Add unit tests"))
+        .unwrap();
+
+    // Same id returned
+    assert_eq!(id1, id2);
+
+    let patterns = db.feedback_list(&repo_id).unwrap();
+    assert_eq!(patterns.len(), 1);
+    assert_eq!(patterns[0].occurrence_count, 2);
+}
+
+// ═══════════════════════════════════════════════
+// 3. feedback_upsert updates sources_json on duplicate
+// ═══════════════════════════════════════════════
+
+#[test]
+fn feedback_upsert_updates_sources_json() {
+    let db = open_memory_db();
+    let repo_id = add_test_repo(&db, "org/repo-a");
+
+    db.feedback_upsert(&make_pattern(&repo_id, "style", "Use snake_case"))
+        .unwrap();
+
+    // Second upsert with different source
+    let mut pattern = make_pattern(&repo_id, "style", "Use snake_case");
+    pattern.source = "pr-review".to_string();
+    db.feedback_upsert(&pattern).unwrap();
+
+    let patterns = db.feedback_list(&repo_id).unwrap();
+    assert_eq!(patterns.len(), 1);
+    assert_eq!(patterns[0].occurrence_count, 2);
+
+    // Verify sources_json contains both sources
+    let sources: serde_json::Value =
+        serde_json::from_str(&patterns[0].sources_json).expect("valid JSON");
+    assert_eq!(sources["hitl"], 1);
+    assert_eq!(sources["pr-review"], 1);
+}
+
+// ═══════════════════════════════════════════════
+// 4. feedback_list returns only patterns for the specified repo_id
+// ═══════════════════════════════════════════════
+
+#[test]
+fn feedback_list_scoped_by_repo() {
+    let db = open_memory_db();
+    let repo_a = add_test_repo(&db, "org/repo-a");
+    let repo_b = add_test_repo(&db, "org/repo-b");
+
+    db.feedback_upsert(&make_pattern(&repo_a, "testing", "Add tests"))
+        .unwrap();
+    db.feedback_upsert(&make_pattern(&repo_a, "style", "Use fmt"))
+        .unwrap();
+    db.feedback_upsert(&make_pattern(&repo_b, "testing", "Add tests"))
+        .unwrap();
+
+    let patterns_a = db.feedback_list(&repo_a).unwrap();
+    assert_eq!(patterns_a.len(), 2);
+
+    let patterns_b = db.feedback_list(&repo_b).unwrap();
+    assert_eq!(patterns_b.len(), 1);
+}
+
+// ═══════════════════════════════════════════════
+// 5. feedback_list_actionable filters by min_count
+// ═══════════════════════════════════════════════
+
+#[test]
+fn feedback_list_actionable_filters_by_min_count() {
+    let db = open_memory_db();
+    let repo_id = add_test_repo(&db, "org/repo-a");
+
+    // Pattern with 1 occurrence
+    db.feedback_upsert(&make_pattern(&repo_id, "testing", "Add tests"))
+        .unwrap();
+
+    // Pattern with 3 occurrences
+    db.feedback_upsert(&make_pattern(&repo_id, "style", "Use fmt"))
+        .unwrap();
+    db.feedback_upsert(&make_pattern(&repo_id, "style", "Use fmt"))
+        .unwrap();
+    db.feedback_upsert(&make_pattern(&repo_id, "style", "Use fmt"))
+        .unwrap();
+
+    let all = db.feedback_list_actionable(&repo_id, 1).unwrap();
+    assert_eq!(all.len(), 2);
+
+    let high_count = db.feedback_list_actionable(&repo_id, 3).unwrap();
+    assert_eq!(high_count.len(), 1);
+    assert_eq!(high_count[0].pattern_type, "style");
+
+    let none = db.feedback_list_actionable(&repo_id, 10).unwrap();
+    assert!(none.is_empty());
+}
+
+// ═══════════════════════════════════════════════
+// 6. feedback_list_actionable excludes non-active status
+// ═══════════════════════════════════════════════
+
+#[test]
+fn feedback_list_actionable_excludes_non_active() {
+    let db = open_memory_db();
+    let repo_id = add_test_repo(&db, "org/repo-a");
+
+    let id = db
+        .feedback_upsert(&make_pattern(&repo_id, "testing", "Add tests"))
+        .unwrap();
+    db.feedback_upsert(&make_pattern(&repo_id, "testing", "Add tests"))
+        .unwrap();
+
+    // Mark as applied
+    db.feedback_set_status(&id, FeedbackPatternStatus::Applied)
+        .unwrap();
+
+    let actionable = db.feedback_list_actionable(&repo_id, 1).unwrap();
+    assert!(actionable.is_empty());
+}
+
+// ═══════════════════════════════════════════════
+// 7. feedback_set_status updates status
+// ═══════════════════════════════════════════════
+
+#[test]
+fn feedback_set_status_updates_correctly() {
+    let db = open_memory_db();
+    let repo_id = add_test_repo(&db, "org/repo-a");
+
+    let id = db
+        .feedback_upsert(&make_pattern(&repo_id, "testing", "Add tests"))
+        .unwrap();
+
+    let patterns = db.feedback_list(&repo_id).unwrap();
+    assert_eq!(patterns[0].status, FeedbackPatternStatus::Active);
+
+    db.feedback_set_status(&id, FeedbackPatternStatus::Rejected)
+        .unwrap();
+
+    let patterns = db.feedback_list(&repo_id).unwrap();
+    assert_eq!(patterns[0].status, FeedbackPatternStatus::Rejected);
+}
+
+// ═══════════════════════════════════════════════
+// 8. feedback_set_status on nonexistent id fails
+// ═══════════════════════════════════════════════
+
+#[test]
+fn feedback_set_status_nonexistent_fails() {
+    let db = open_memory_db();
+    let result = db.feedback_set_status("nonexistent", FeedbackPatternStatus::Applied);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("not found"));
+}
+
+// ═══════════════════════════════════════════════
+// 9. patterns CLI function formats output correctly
+// ═══════════════════════════════════════════════
+
+#[test]
+fn patterns_cli_formats_table() {
+    let db = open_memory_db();
+    let repo_id = add_test_repo(&db, "org/repo-a");
+
+    db.feedback_upsert(&make_pattern(&repo_id, "error-handling", "Use anyhow"))
+        .unwrap();
+    db.feedback_upsert(&make_pattern(&repo_id, "testing", "Add unit tests"))
+        .unwrap();
+
+    let output = autodev::cli::convention::patterns(&db, Some(&repo_id), Some(1), false).unwrap();
+    assert!(output.contains("COUNT"));
+    assert!(output.contains("TYPE"));
+    assert!(output.contains("error-handling"));
+    assert!(output.contains("testing"));
+}
+
+// ═══════════════════════════════════════════════
+// 10. patterns CLI function with JSON output
+// ═══════════════════════════════════════════════
+
+#[test]
+fn patterns_cli_json_output() {
+    let db = open_memory_db();
+    let repo_id = add_test_repo(&db, "org/repo-a");
+
+    db.feedback_upsert(&make_pattern(&repo_id, "style", "Use snake_case"))
+        .unwrap();
+
+    let output = autodev::cli::convention::patterns(&db, Some(&repo_id), None, true).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&output).expect("valid JSON output");
+    assert!(parsed.is_array());
+    assert_eq!(parsed.as_array().unwrap().len(), 1);
+    assert_eq!(parsed[0]["pattern_type"], "style");
+}
+
+// ═══════════════════════════════════════════════
+// 11. patterns CLI function without repo returns message
+// ═══════════════════════════════════════════════
+
+#[test]
+fn patterns_cli_no_repo_returns_message() {
+    let db = open_memory_db();
+    let output = autodev::cli::convention::patterns(&db, None, None, false).unwrap();
+    assert!(output.contains("Specify --repo"));
+}
+
+// ═══════════════════════════════════════════════
+// 12. Different (repo, pattern_type, suggestion) combos create separate entries
+// ═══════════════════════════════════════════════
+
+#[test]
+fn feedback_upsert_different_combos_create_separate() {
+    let db = open_memory_db();
+    let repo_id = add_test_repo(&db, "org/repo-a");
+
+    db.feedback_upsert(&make_pattern(&repo_id, "testing", "Add unit tests"))
+        .unwrap();
+    db.feedback_upsert(&make_pattern(&repo_id, "testing", "Add integration tests"))
+        .unwrap();
+    db.feedback_upsert(&make_pattern(&repo_id, "style", "Add unit tests"))
+        .unwrap();
+
+    let patterns = db.feedback_list(&repo_id).unwrap();
+    assert_eq!(patterns.len(), 3);
+}


### PR DESCRIPTION
## Summary
- Add `feedback_patterns` DB table (repo_id scoped) for collecting convention feedback from multiple sources (HITL, PR review, spec changes, workspace edits)
- Implement `FeedbackPatternRepository` trait with upsert (auto-increment on duplicate), list, actionable filtering, and status management
- Add `autodev convention patterns` CLI command with table and JSON output formats
- Include 12 integration tests covering all repository operations and CLI formatting

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] `cargo test` passes (all existing + 12 new tests)
- [x] Upsert creates new pattern and increments on duplicate (repo_id, pattern_type, suggestion)
- [x] Repo-scoped isolation verified (patterns from repo A not visible in repo B queries)
- [x] Actionable filter respects min_count and active status
- [x] Status transitions work correctly
- [x] CLI table and JSON output format correctly

Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)