### PR TITLE
feat(autodev): add convention propose command for feedback-driven updates

### DIFF
--- a/plugins/autodev/cli/src/cli/convention.rs
+++ b/plugins/autodev/cli/src/cli/convention.rs
@@ -648,6 +648,58 @@ pub fn collect_feedback_from_hitl(
     Ok(())
 }
 
+// ─── Convention Update Proposal ───
+
+/// Map pattern_type to a convention rule file path.
+pub fn pattern_type_to_rule_file(pattern_type: &str) -> String {
+    format!(".claude/rules/{pattern_type}.md")
+}
+
+/// Check actionable feedback patterns and create HITL events for convention updates.
+///
+/// Queries patterns with `occurrence_count >= threshold` and `status = Active`,
+/// then creates a HITL event for each so a human can approve, edit, or reject.
+/// Returns a summary message.
+pub fn propose_updates(db: &Database, repo_id: &str, threshold: i32) -> Result<String> {
+    use crate::core::models::{FeedbackPatternStatus, HitlSeverity, NewHitlEvent};
+    use crate::core::repository::HitlRepository;
+
+    let patterns = db.feedback_list_actionable(repo_id, threshold)?;
+
+    if patterns.is_empty() {
+        return Ok("No actionable patterns found.\n".to_string());
+    }
+
+    let mut proposed = 0;
+
+    for pattern in &patterns {
+        let rule_file = pattern_type_to_rule_file(&pattern.pattern_type);
+
+        let hitl_event = NewHitlEvent {
+            repo_id: repo_id.to_string(),
+            spec_id: None,
+            work_id: None,
+            severity: HitlSeverity::Medium,
+            situation: format!("Convention update suggested: {}", pattern.pattern_type),
+            context: format!(
+                "Rule file: {}\nOccurrences: {}\nSuggestion: {}\nSources: {}",
+                rule_file, pattern.occurrence_count, pattern.suggestion, pattern.sources_json
+            ),
+            options: vec![
+                "Apply this convention rule".to_string(),
+                "Edit and apply".to_string(),
+                "Reject".to_string(),
+            ],
+        };
+
+        db.hitl_create(&hitl_event)?;
+        db.feedback_set_status(&pattern.id, FeedbackPatternStatus::Proposed)?;
+        proposed += 1;
+    }
+
+    Ok(format!("Proposed {proposed} convention update(s)\n"))
+}
+
 // ─── Feedback Patterns CLI ───
 
 /// List feedback patterns for a repo, formatted as a table.

--- a/plugins/autodev/cli/src/main.rs
+++ b/plugins/autodev/cli/src/main.rs
@@ -163,6 +163,14 @@ enum ConventionAction {
         /// 레포 이름 (org/repo)
         repo: String,
     },
+    /// 피드백 패턴 기반 컨벤션 업데이트 제안
+    Propose {
+        /// 레포 이름 (org/repo)
+        repo: String,
+        /// 최소 발생 횟수 임계값 (기본: 3)
+        #[arg(long, default_value = "3")]
+        threshold: i32,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1056,6 +1064,11 @@ async fn main() -> Result<()> {
             ConventionAction::CollectFeedback { repo } => {
                 let repo_id = client::resolve_repo_id(&db, &repo)?;
                 let output = client::convention::collect_feedback(&db, &repo, &repo_id)?;
+                print!("{output}");
+            }
+            ConventionAction::Propose { repo, threshold } => {
+                let repo_id = client::resolve_repo_id(&db, &repo)?;
+                let output = client::convention::propose_updates(&db, &repo_id, threshold)?;
                 print!("{output}");
             }
         },

--- a/plugins/autodev/cli/tests/feedback_pattern_tests.rs
+++ b/plugins/autodev/cli/tests/feedback_pattern_tests.rs
@@ -485,3 +485,128 @@ fn collect_feedback_from_hitl_skips_empty_message() {
     let patterns = db.feedback_list(&repo_id).unwrap();
     assert!(patterns.is_empty());
 }
+
+// ═══════════════════════════════════════════════
+// 19. pattern_type_to_rule_file maps correctly
+// ═══════════════════════════════════════════════
+
+#[test]
+fn pattern_type_to_rule_file_maps_correctly() {
+    use autodev::cli::convention::pattern_type_to_rule_file;
+    assert_eq!(
+        pattern_type_to_rule_file("error-handling"),
+        ".claude/rules/error-handling.md"
+    );
+    assert_eq!(
+        pattern_type_to_rule_file("testing"),
+        ".claude/rules/testing.md"
+    );
+    assert_eq!(pattern_type_to_rule_file("style"), ".claude/rules/style.md");
+}
+
+// ═══════════════════════════════════════════════
+// 20. propose_updates creates HITL events for patterns above threshold
+// ═══════════════════════════════════════════════
+
+#[test]
+fn propose_updates_creates_hitl_events() {
+    let db = open_memory_db();
+    let repo_id = add_test_repo(&db, "org/propose-test");
+
+    // Create a pattern with 3 occurrences
+    for _ in 0..3 {
+        db.feedback_upsert(&make_pattern(&repo_id, "error-handling", "Use anyhow"))
+            .unwrap();
+    }
+
+    let output = autodev::cli::convention::propose_updates(&db, &repo_id, 3).unwrap();
+    assert!(output.contains("Proposed 1 convention update(s)"));
+
+    // Verify HITL event was created
+    let events = db.hitl_list(Some("org/propose-test")).unwrap();
+    assert_eq!(events.len(), 1);
+    assert!(events[0]
+        .situation
+        .contains("Convention update suggested: error-handling"));
+}
+
+// ═══════════════════════════════════════════════
+// 21. propose_updates skips patterns below threshold
+// ═══════════════════════════════════════════════
+
+#[test]
+fn propose_updates_skips_below_threshold() {
+    let db = open_memory_db();
+    let repo_id = add_test_repo(&db, "org/propose-skip-test");
+
+    // Create a pattern with only 2 occurrences (below threshold of 3)
+    db.feedback_upsert(&make_pattern(&repo_id, "testing", "Add tests"))
+        .unwrap();
+    db.feedback_upsert(&make_pattern(&repo_id, "testing", "Add tests"))
+        .unwrap();
+
+    let output = autodev::cli::convention::propose_updates(&db, &repo_id, 3).unwrap();
+    assert!(output.contains("No actionable patterns found."));
+
+    // No HITL events should be created
+    let events = db.hitl_list(Some("org/propose-skip-test")).unwrap();
+    assert!(events.is_empty());
+}
+
+// ═══════════════════════════════════════════════
+// 22. propose_updates marks patterns as Proposed
+// ═══════════════════════════════════════════════
+
+#[test]
+fn propose_updates_marks_patterns_as_proposed() {
+    let db = open_memory_db();
+    let repo_id = add_test_repo(&db, "org/propose-status-test");
+
+    for _ in 0..3 {
+        db.feedback_upsert(&make_pattern(&repo_id, "style", "Use snake_case"))
+            .unwrap();
+    }
+
+    autodev::cli::convention::propose_updates(&db, &repo_id, 3).unwrap();
+
+    // Pattern should now be Proposed
+    let patterns = db.feedback_list(&repo_id).unwrap();
+    assert_eq!(patterns.len(), 1);
+    assert_eq!(patterns[0].status, FeedbackPatternStatus::Proposed);
+}
+
+// ═══════════════════════════════════════════════
+// 23. propose_updates returns no actionable when none qualify
+// ═══════════════════════════════════════════════
+
+#[test]
+fn propose_updates_no_actionable_patterns() {
+    let db = open_memory_db();
+    let repo_id = add_test_repo(&db, "org/propose-empty-test");
+
+    let output = autodev::cli::convention::propose_updates(&db, &repo_id, 3).unwrap();
+    assert!(output.contains("No actionable patterns found."));
+}
+
+// ═══════════════════════════════════════════════
+// 24. propose_updates is idempotent (already-proposed patterns are skipped)
+// ═══════════════════════════════════════════════
+
+#[test]
+fn propose_updates_idempotent() {
+    let db = open_memory_db();
+    let repo_id = add_test_repo(&db, "org/propose-idempotent-test");
+
+    for _ in 0..3 {
+        db.feedback_upsert(&make_pattern(&repo_id, "error-handling", "Use Result<T>"))
+            .unwrap();
+    }
+
+    // First call should propose
+    let output1 = autodev::cli::convention::propose_updates(&db, &repo_id, 3).unwrap();
+    assert!(output1.contains("Proposed 1 convention update(s)"));
+
+    // Second call should find no actionable patterns (status is now Proposed)
+    let output2 = autodev::cli::convention::propose_updates(&db, &repo_id, 3).unwrap();
+    assert!(output2.contains("No actionable patterns found."));
+}


### PR DESCRIPTION
## Summary
- Add `autodev convention propose --repo <org/repo> [--threshold N]` CLI command (M1 Step 3)
- When feedback patterns reach the threshold (default: 3 occurrences), creates HITL events for human review with options: Apply, Edit and apply, or Reject
- Marks proposed patterns as `Proposed` status to ensure idempotency

## Test plan
- [x] `propose_updates` creates HITL events for patterns with count >= threshold
- [x] `propose_updates` skips patterns below threshold
- [x] `propose_updates` marks proposed patterns as `Proposed` status
- [x] `propose_updates` returns "No actionable patterns" when none qualify
- [x] `propose_updates` is idempotent (second call finds no actionable patterns)
- [x] `pattern_type_to_rule_file` maps correctly
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] All 29 feedback pattern tests pass

Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)