### PR TITLE
fix(autodev): connect notifier to all HITL creation paths and add force-trigger events

### DIFF
--- a/plugins/autodev/cli/src/cli/convention.rs
+++ b/plugins/autodev/cli/src/cli/convention.rs
@@ -656,22 +656,31 @@ pub fn pattern_type_to_rule_file(pattern_type: &str) -> String {
     format!(".claude/rules/{pattern_type}.md")
 }
 
+/// propose_updates의 결과: 출력 메시지와 생성된 HITL 이벤트 목록.
+pub struct ProposeResult {
+    pub output: String,
+    pub hitl_events: Vec<crate::core::models::NewHitlEvent>,
+}
+
 /// Check actionable feedback patterns and create HITL events for convention updates.
 ///
 /// Queries patterns with `occurrence_count >= threshold` and `status = Active`,
 /// then creates a HITL event for each so a human can approve, edit, or reject.
-/// Returns a summary message.
-pub fn propose_updates(db: &Database, repo_id: &str, threshold: i32) -> Result<String> {
+/// Returns a summary message and created HITL events for notification dispatch.
+pub fn propose_updates(db: &Database, repo_id: &str, threshold: i32) -> Result<ProposeResult> {
     use crate::core::models::{HitlSeverity, NewHitlEvent};
     use crate::core::repository::HitlRepository;
 
     let patterns = db.feedback_list_actionable(repo_id, threshold)?;
 
     if patterns.is_empty() {
-        return Ok("No actionable patterns found.\n".to_string());
+        return Ok(ProposeResult {
+            output: "No actionable patterns found.\n".to_string(),
+            hitl_events: Vec::new(),
+        });
     }
 
-    let mut proposed = 0;
+    let mut hitl_events = Vec::new();
 
     for pattern in &patterns {
         let rule_file = pattern_type_to_rule_file(&pattern.pattern_type);
@@ -695,10 +704,13 @@ pub fn propose_updates(db: &Database, repo_id: &str, threshold: i32) -> Result<S
 
         db.hitl_create(&hitl_event)?;
         db.feedback_set_status(&pattern.id, FeedbackPatternStatus::Proposed)?;
-        proposed += 1;
+        hitl_events.push(hitl_event);
     }
 
-    Ok(format!("Proposed {proposed} convention update(s)\n"))
+    Ok(ProposeResult {
+        output: format!("Proposed {} convention update(s)\n", hitl_events.len()),
+        hitl_events,
+    })
 }
 
 // ─── Convention Apply ───

--- a/plugins/autodev/cli/src/cli/hitl.rs
+++ b/plugins/autodev/cli/src/cli/hitl.rs
@@ -152,7 +152,10 @@ pub fn timeout(db: &Database, hours: i64, action: TimeoutAction) -> Result<Timeo
 
     let mut results = Vec::new();
     for event in &expired {
-        db.hitl_set_status(&event.id, HitlStatus::Expired)?;
+        // Remind는 알림만 재발송하므로 상태를 변경하지 않는다.
+        if action != TimeoutAction::Remind {
+            db.hitl_set_status(&event.id, HitlStatus::Expired)?;
+        }
 
         match action {
             TimeoutAction::PauseSpec => {
@@ -169,12 +172,15 @@ pub fn timeout(db: &Database, hours: i64, action: TimeoutAction) -> Result<Timeo
             TimeoutAction::Expire => {
                 results.push(format!("  {} → expired", event.id));
             }
+            TimeoutAction::Remind => {
+                results.push(format!("  {} → remind sent", event.id));
+            }
         }
     }
 
     Ok(TimeoutResult {
         output: format!(
-            "Processed {} expired events (action: {}):\n{}",
+            "Processed {} events (action: {}):\n{}",
             expired.len(),
             action,
             results.join("\n")

--- a/plugins/autodev/cli/src/cli/queue.rs
+++ b/plugins/autodev/cli/src/cli/queue.rs
@@ -7,10 +7,20 @@ use crate::core::queue_item::{ItemMetadata, QueueItem};
 use crate::core::repository::{ClawDecisionRepository, HitlRepository, QueueRepository};
 use crate::infra::db::Database;
 
+/// queue_advance의 결과: 출력 메시지와 생성된 HITL 이벤트.
+pub struct QueueAdvanceResult {
+    pub output: String,
+    pub hitl_event: Option<NewHitlEvent>,
+}
+
 /// 큐 아이템을 다음 phase로 전이한다.
 /// Claw의 CLI 진입점으로서 claw_decisions에 advance 기록을 남긴다.
 /// PR의 review_iteration이 max_iterations 이상이면 HITL 이벤트를 자동 생성한다.
-pub fn queue_advance(db: &Database, work_id: &str, reason: Option<&str>) -> Result<String> {
+pub fn queue_advance(
+    db: &Database,
+    work_id: &str,
+    reason: Option<&str>,
+) -> Result<QueueAdvanceResult> {
     // advance 전에 item 조회 (decision 기록 + HITL 체크 + before phase 취득)
     let item = db
         .queue_get_item(work_id)?
@@ -28,13 +38,17 @@ pub fn queue_advance(db: &Database, work_id: &str, reason: Option<&str>) -> Resu
     record_decision(db, &item.repo_id, DecisionType::Advance, work_id, reason);
 
     // H3: PR review iteration 임계값 초과 시 HITL 자동 생성
-    if item.queue_type == QueueType::Pr {
-        if let Some(review_iteration) = extract_review_iteration(&item.metadata_json) {
-            check_review_overflow(db, &item.repo_id, work_id, review_iteration);
-        }
-    }
+    let hitl_event = if item.queue_type == QueueType::Pr {
+        extract_review_iteration(&item.metadata_json)
+            .and_then(|ri| check_review_overflow(db, &item.repo_id, work_id, ri))
+    } else {
+        None
+    };
 
-    Ok(format!("advanced: {work_id} ({before} → {after})"))
+    Ok(QueueAdvanceResult {
+        output: format!("advanced: {work_id} ({before} → {after})"),
+        hitl_event,
+    })
 }
 
 /// 큐 아이템을 skip 처리한다.
@@ -94,10 +108,17 @@ fn extract_review_iteration(metadata_json: &Option<String>) -> Option<u32> {
 /// NOTE: max_iterations는 ReviewStage::default().max_iterations와 동일한 기본값(2)을 사용한다.
 /// CLI에서는 per-repo config 로드 없이 실행되므로, 여기서는 기본값을 사용한다.
 /// Claw cron이 구현되면 config에서 로드된 값을 전달하게 된다.
-fn check_review_overflow(db: &Database, repo_id: &str, work_id: &str, review_iteration: u32) {
+///
+/// 생성된 HITL 이벤트를 반환하여 호출자가 알림을 발송할 수 있게 한다.
+fn check_review_overflow(
+    db: &Database,
+    repo_id: &str,
+    work_id: &str,
+    review_iteration: u32,
+) -> Option<NewHitlEvent> {
     let max_iterations = crate::core::config::models::ReviewStage::default().max_iterations;
     if review_iteration >= max_iterations {
-        let _ = db.hitl_create(&NewHitlEvent {
+        let event = NewHitlEvent {
             repo_id: repo_id.to_string(),
             spec_id: None,
             work_id: Some(work_id.to_string()),
@@ -111,7 +132,11 @@ fn check_review_overflow(db: &Database, repo_id: &str, work_id: &str, review_ite
                 "Skip this PR".to_string(),
                 "Merge as-is".to_string(),
             ],
-        });
+        };
+        let _ = db.hitl_create(&event);
+        Some(event)
+    } else {
+        None
     }
 }
 

--- a/plugins/autodev/cli/src/cli/spec.rs
+++ b/plugins/autodev/cli/src/cli/spec.rs
@@ -5,6 +5,12 @@ use crate::core::models::*;
 use crate::core::repository::*;
 use crate::infra::db::Database;
 
+/// spec_add의 결과: 출력 메시지와 해결된 repo_id.
+pub struct SpecAddResult {
+    pub output: String,
+    pub repo_id: String,
+}
+
 /// Add a new spec
 pub fn spec_add(
     db: &Database,
@@ -14,11 +20,11 @@ pub fn spec_add(
     file: Option<&str>,
     test_commands: Option<&str>,
     acceptance_criteria: Option<&str>,
-) -> Result<String> {
+) -> Result<SpecAddResult> {
     let repo_id = resolve_repo_id(db, repo_name)?;
 
     let new_spec = NewSpec {
-        repo_id,
+        repo_id: repo_id.clone(),
         title: title.to_string(),
         body: body.to_string(),
         source_path: file.map(|s| s.to_string()),
@@ -29,16 +35,16 @@ pub fn spec_add(
     let id = db.spec_add(&new_spec)?;
 
     let missing = validate_spec_sections(body);
-    if !missing.is_empty() {
-        let mut result = format!(
-            "⚠ Missing sections: {}. Recommended: add these as ## headers.\n",
+    let output = if !missing.is_empty() {
+        format!(
+            "⚠ Missing sections: {}. Recommended: add these as ## headers.\n{id}",
             missing.join(", ")
-        );
-        result.push_str(&id);
-        return Ok(result);
-    }
+        )
+    } else {
+        id
+    };
 
-    Ok(id)
+    Ok(SpecAddResult { output, repo_id })
 }
 
 /// List specs

--- a/plugins/autodev/cli/src/core/models.rs
+++ b/plugins/autodev/cli/src/core/models.rs
@@ -562,6 +562,8 @@ pub enum TimeoutAction {
     Expire,
     /// 만료 후 연결된 스펙 일시 정지
     PauseSpec,
+    /// 알림 재발송 (만료하지 않음)
+    Remind,
 }
 
 impl fmt::Display for TimeoutAction {
@@ -569,6 +571,7 @@ impl fmt::Display for TimeoutAction {
         match self {
             TimeoutAction::Expire => write!(f, "expire"),
             TimeoutAction::PauseSpec => write!(f, "pause-spec"),
+            TimeoutAction::Remind => write!(f, "remind"),
         }
     }
 }

--- a/plugins/autodev/cli/src/main.rs
+++ b/plugins/autodev/cli/src/main.rs
@@ -565,6 +565,14 @@ async fn dispatch_notification(
     }
 }
 
+/// Force-trigger claw-evaluate cron job so the daemon picks up changes immediately.
+///
+/// Silently ignores errors (e.g. cron job not yet seeded).
+fn try_force_trigger_evaluate(db: &autodev::infra::db::Database, repo_id: &str) {
+    use autodev::core::repository::CronRepository;
+    let _ = db.cron_reset_last_run(client::cron::CLAW_EVALUATE_JOB, Some(repo_id));
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
@@ -697,8 +705,19 @@ async fn main() -> Result<()> {
                 }
             }
             QueueAction::Advance { work_id, reason } => {
-                let output = client::queue::queue_advance(&db, &work_id, reason.as_deref())?;
-                println!("{output}");
+                let result = client::queue::queue_advance(&db, &work_id, reason.as_deref())?;
+                println!("{}", result.output);
+
+                // Dispatch HITL notification if review overflow created one
+                if let Some(ref hitl_event) = result.hitl_event {
+                    if let Some(ref dispatcher) =
+                        autodev::service::daemon::notifiers::dispatcher::NotificationDispatcher::from_config(&cfg.daemon)
+                    {
+                        let notif =
+                            autodev::core::notifier::NotificationEvent::from_hitl_created(hitl_event);
+                        dispatch_notification(dispatcher, &notif).await;
+                    }
+                }
             }
             QueueAction::Skip { work_id, reason } => {
                 let output = client::queue::queue_skip(&db, &work_id, reason.as_deref())?;
@@ -727,7 +746,7 @@ async fn main() -> Result<()> {
                 test_commands,
                 acceptance_criteria,
             } => {
-                let id = client::spec::spec_add(
+                let result = client::spec::spec_add(
                     &db,
                     &title,
                     &body,
@@ -736,7 +755,10 @@ async fn main() -> Result<()> {
                     test_commands.as_deref(),
                     acceptance_criteria.as_deref(),
                 )?;
-                println!("created: {id}");
+                println!("created: {}", result.output);
+
+                // Force-trigger claw-evaluate so the new spec is evaluated immediately
+                try_force_trigger_evaluate(&db, &result.repo_id);
             }
             SpecAction::List { repo, json } => {
                 let output = client::spec::spec_list(&db, repo.as_deref(), json)?;
@@ -812,9 +834,9 @@ async fn main() -> Result<()> {
                 println!("{output}");
 
                 // Auto-collect feedback if the response has a message
-                if let Some(ref msg) = message {
-                    use autodev::core::repository::HitlRepository;
-                    if let Ok(Some(event)) = db.hitl_show(&id) {
+                use autodev::core::repository::HitlRepository;
+                if let Ok(Some(event)) = db.hitl_show(&id) {
+                    if let Some(ref msg) = message {
                         if let Err(e) = client::convention::collect_feedback_from_hitl(
                             &db,
                             &event.repo_id,
@@ -824,6 +846,9 @@ async fn main() -> Result<()> {
                             eprintln!("warning: failed to auto-collect feedback: {e}");
                         }
                     }
+
+                    // Force-trigger claw-evaluate so the response is processed immediately
+                    try_force_trigger_evaluate(&db, &event.repo_id);
                 }
             }
             HitlAction::Timeout { hours, action } => {
@@ -1073,8 +1098,21 @@ async fn main() -> Result<()> {
             }
             ConventionAction::Propose { repo, threshold } => {
                 let repo_id = client::resolve_repo_id(&db, &repo)?;
-                let output = client::convention::propose_updates(&db, &repo_id, threshold)?;
-                print!("{output}");
+                let result = client::convention::propose_updates(&db, &repo_id, threshold)?;
+                print!("{}", result.output);
+
+                // Dispatch HITL notifications for proposed convention updates
+                if !result.hitl_events.is_empty() {
+                    if let Some(ref dispatcher) =
+                        autodev::service::daemon::notifiers::dispatcher::NotificationDispatcher::from_config(&cfg.daemon)
+                    {
+                        for hitl_event in &result.hitl_events {
+                            let notif =
+                                autodev::core::notifier::NotificationEvent::from_hitl_created(hitl_event);
+                            dispatch_notification(dispatcher, &notif).await;
+                        }
+                    }
+                }
             }
             ConventionAction::ApplyApproved { repo } => {
                 let repo_id = client::resolve_repo_id(&db, &repo)?;

--- a/plugins/autodev/cli/tests/feedback_pattern_tests.rs
+++ b/plugins/autodev/cli/tests/feedback_pattern_tests.rs
@@ -519,8 +519,8 @@ fn propose_updates_creates_hitl_events() {
             .unwrap();
     }
 
-    let output = autodev::cli::convention::propose_updates(&db, &repo_id, 3).unwrap();
-    assert!(output.contains("Proposed 1 convention update(s)"));
+    let result = autodev::cli::convention::propose_updates(&db, &repo_id, 3).unwrap();
+    assert!(result.output.contains("Proposed 1 convention update(s)"));
 
     // Verify HITL event was created
     let events = db.hitl_list(Some("org/propose-test")).unwrap();
@@ -545,8 +545,8 @@ fn propose_updates_skips_below_threshold() {
     db.feedback_upsert(&make_pattern(&repo_id, "testing", "Add tests"))
         .unwrap();
 
-    let output = autodev::cli::convention::propose_updates(&db, &repo_id, 3).unwrap();
-    assert!(output.contains("No actionable patterns found."));
+    let result = autodev::cli::convention::propose_updates(&db, &repo_id, 3).unwrap();
+    assert!(result.output.contains("No actionable patterns found."));
 
     // No HITL events should be created
     let events = db.hitl_list(Some("org/propose-skip-test")).unwrap();
@@ -584,8 +584,8 @@ fn propose_updates_no_actionable_patterns() {
     let db = open_memory_db();
     let repo_id = add_test_repo(&db, "org/propose-empty-test");
 
-    let output = autodev::cli::convention::propose_updates(&db, &repo_id, 3).unwrap();
-    assert!(output.contains("No actionable patterns found."));
+    let result = autodev::cli::convention::propose_updates(&db, &repo_id, 3).unwrap();
+    assert!(result.output.contains("No actionable patterns found."));
 }
 
 // ═══════════════════════════════════════════════
@@ -603,10 +603,10 @@ fn propose_updates_idempotent() {
     }
 
     // First call should propose
-    let output1 = autodev::cli::convention::propose_updates(&db, &repo_id, 3).unwrap();
-    assert!(output1.contains("Proposed 1 convention update(s)"));
+    let result1 = autodev::cli::convention::propose_updates(&db, &repo_id, 3).unwrap();
+    assert!(result1.output.contains("Proposed 1 convention update(s)"));
 
     // Second call should find no actionable patterns (status is now Proposed)
-    let output2 = autodev::cli::convention::propose_updates(&db, &repo_id, 3).unwrap();
-    assert!(output2.contains("No actionable patterns found."));
+    let result2 = autodev::cli::convention::propose_updates(&db, &repo_id, 3).unwrap();
+    assert!(result2.output.contains("No actionable patterns found."));
 }

--- a/plugins/autodev/cli/tests/queue_advance_tests.rs
+++ b/plugins/autodev/cli/tests/queue_advance_tests.rs
@@ -221,9 +221,9 @@ fn cli_queue_advance_changes_phase() {
     let repo_id = add_test_repo(&db);
     insert_queue_item(&db, &repo_id, "work-cli-1", "pending");
 
-    let output = autodev::cli::queue::queue_advance(&db, "work-cli-1", None).unwrap();
-    assert!(output.contains("pending"));
-    assert!(output.contains("ready"));
+    let result = autodev::cli::queue::queue_advance(&db, "work-cli-1", None).unwrap();
+    assert!(result.output.contains("pending"));
+    assert!(result.output.contains("ready"));
 
     let phase = db.queue_get_phase("work-cli-1").unwrap();
     assert_eq!(phase, Some(QueuePhase::Ready));


### PR DESCRIPTION
## Summary

- **#286**: 모든 HITL 생성 경로(queue advance review overflow, convention propose)에 알림 디스패치 연결. `TimeoutAction::Remind` variant 추가로 만료 없이 알림 재발송 지원.
- **#287**: `spec add`, `hitl respond` CLI 커맨드 실행 후 `claw-evaluate` cron job을 force-trigger하여 데몬이 변경사항을 즉시 처리하도록 함.

## Changes

- `TimeoutAction::Remind` variant 추가 (알림 재발송, 상태 미변경)
- `check_review_overflow()` → `Option<NewHitlEvent>` 반환으로 알림 디스패치 가능
- `propose_updates()` → `ProposeResult { output, hitl_events }` 반환
- `spec_add()` → `SpecAddResult { output, repo_id }` 반환 (이중 resolve_repo_id 제거)
- `queue_advance()` → `QueueAdvanceResult { output, hitl_event }` 반환
- `try_force_trigger_evaluate()` 헬퍼로 CLI에서 claw-evaluate cron job reset
- 기존 테스트 업데이트 (구조체 반환값 대응)

## Test plan

- [x] `cargo clippy --tests -- -D warnings` 통과
- [x] `cargo test` 전체 통과 (327+ tests, 0 failed)
- [ ] 데몬 실행 상태에서 `spec add` → claw-evaluate 즉시 트리거 확인
- [ ] `hitl respond` → claw-evaluate 즉시 트리거 확인
- [ ] `hitl timeout --action remind` → 알림 재발송, 상태 유지 확인

Closes #286, closes #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)