### PR TITLE
feat(autodev): wire 5-level failure escalation in daemon task loop

### DIFF
--- a/plugins/autodev/cli/Cargo.lock
+++ b/plugins/autodev/cli/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autodev"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/plugins/autodev/cli/src/service/daemon/escalation.rs
+++ b/plugins/autodev/cli/src/service/daemon/escalation.rs
@@ -1,0 +1,100 @@
+//! 5-Level failure escalation for the daemon task loop.
+//!
+//! failure_count 증가 → EscalationLevel 판정 → 대응 액션 수행.
+//! Retry/Comment: 아이템을 pending으로 되돌려 재시도.
+//! Hitl/Replan: HITL 이벤트 생성 후 큐에서 제거.
+//! Skip: 즉시 제거 (기존 동작).
+
+use crate::core::models::{EscalationLevel, HitlSeverity, NewHitlEvent, QueuePhase};
+use crate::core::repository::{HitlRepository, QueueRepository};
+use crate::infra::db::Database;
+
+/// 에스컬레이션 처리 결과.
+pub enum EscalationOutcome {
+    /// 아이템을 pending으로 되돌려 재시도한다. apply(Remove)를 건너뛴다.
+    Retry,
+    /// 아이템을 제거한다. 기본 동작을 그대로 수행한다.
+    Remove,
+}
+
+/// 실패한 태스크에 대해 에스컬레이션을 수행한다.
+///
+/// 1. failure_count를 1 증가시킨다.
+/// 2. EscalationLevel을 산출한다.
+/// 3. 레벨에 따라 대응한다:
+///    - Retry: pending으로 되돌린다.
+///    - Comment: GitHub에 코멘트를 남기고 pending으로 되돌린다.
+///    - Hitl: HITL 이벤트를 생성하고 제거한다.
+///    - Skip: 제거한다 (기존 동작).
+///    - Replan: HITL 이벤트(replan)를 생성하고 제거한다.
+pub fn escalate(
+    db: &Database,
+    work_id: &str,
+    repo_id: &str,
+    failure_msg: &str,
+) -> EscalationOutcome {
+    // 1. failure_count 증가
+    let new_count = match db.queue_increment_failure(work_id) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!("failed to increment failure_count for {work_id}: {e}");
+            return EscalationOutcome::Remove;
+        }
+    };
+
+    let level = EscalationLevel::from(new_count);
+    tracing::info!("escalation: {work_id} failure_count={new_count} → level={level}");
+
+    match level {
+        EscalationLevel::Retry | EscalationLevel::Comment => {
+            // pending으로 되돌려 재시도 (Comment 레벨의 코멘트는 태스크 자체가 이미 남김)
+            if let Err(e) = db.queue_transit(work_id, QueuePhase::Running, QueuePhase::Pending) {
+                tracing::warn!("failed to reset {work_id} to pending: {e}");
+                return EscalationOutcome::Remove;
+            }
+            EscalationOutcome::Retry
+        }
+        EscalationLevel::Hitl => {
+            // HITL 이벤트 생성: 사람이 개입하도록 알린다.
+            if let Err(e) = db.hitl_create(&NewHitlEvent {
+                repo_id: repo_id.to_string(),
+                spec_id: None,
+                work_id: Some(work_id.to_string()),
+                severity: HitlSeverity::High,
+                situation: format!("Task failed {new_count} times — human intervention required"),
+                context: failure_msg.to_string(),
+                options: vec![
+                    "Retry this task".to_string(),
+                    "Skip and move on".to_string(),
+                    "Reassign or replan".to_string(),
+                ],
+            }) {
+                tracing::warn!("failed to create HITL event for {work_id}: {e}");
+            }
+            EscalationOutcome::Remove
+        }
+        EscalationLevel::Skip => EscalationOutcome::Remove,
+        EscalationLevel::Replan => {
+            // HITL 이벤트(replan) 생성: 스펙 수준 재계획 요청
+            if let Err(e) = db.hitl_create(&NewHitlEvent {
+                repo_id: repo_id.to_string(),
+                spec_id: None,
+                work_id: Some(work_id.to_string()),
+                severity: HitlSeverity::High,
+                situation: format!("Task failed {new_count} times — replan recommended"),
+                context: format!(
+                    "Repeated failures suggest the approach needs revision.\n\
+                     Last error: {failure_msg}"
+                ),
+                options: vec![
+                    "Replan: update spec and decompose differently".to_string(),
+                    "Force retry with current approach".to_string(),
+                    "Abandon this task".to_string(),
+                ],
+            }) {
+                tracing::warn!("failed to create HITL event for {work_id}: {e}");
+            }
+            EscalationOutcome::Remove
+        }
+    }
+}

--- a/plugins/autodev/cli/src/service/daemon/mod.rs
+++ b/plugins/autodev/cli/src/service/daemon/mod.rs
@@ -3,6 +3,7 @@ pub mod agent_impl;
 pub mod collectors;
 pub mod cron;
 pub mod daily_reporter;
+pub mod escalation;
 pub mod log;
 pub mod notifiers;
 pub mod pid;
@@ -179,12 +180,45 @@ impl Daemon {
                                 "task completed: {} - {} (in-flight: {})",
                                 task_result.work_id, task_result.status, self.tracker.total
                             );
-                            self.manager.apply(&task_result);
+
+                            // Escalation: 실패 시 failure_count 증가 → 레벨별 대응
+                            let escalation_retry =
+                                if let TaskStatus::Failed(ref msg) = task_result.status {
+                                    match crate::cli::resolve_repo_id(
+                                        &self.log_db,
+                                        &task_result.repo_name,
+                                    ) {
+                                        Ok(repo_id) => matches!(
+                                            escalation::escalate(
+                                                &self.log_db,
+                                                &task_result.work_id,
+                                                &repo_id,
+                                                msg,
+                                            ),
+                                            escalation::EscalationOutcome::Retry
+                                        ),
+                                        Err(e) => {
+                                            tracing::warn!(
+                                                "skipping escalation for {}: {e}",
+                                                task_result.work_id
+                                            );
+                                            false
+                                        }
+                                    }
+                                } else {
+                                    false
+                                };
+
+                            // Retry일 때는 apply(Remove) 건너뛴다 — pending으로 이미 복구됨.
+                            if !escalation_retry {
+                                self.manager.apply(&task_result);
+                            }
+
                             for log_entry in &task_result.logs {
                                 let _ = self.log_db.log_insert(log_entry);
                             }
 
-                            // Notify on task failure
+                            // Notify on task failure (escalation으로 retry되더라도 기록)
                             if let TaskStatus::Failed(ref msg) = task_result.status {
                                 if let Some(ref dispatcher) = self.notifier {
                                     let notif = NotificationEvent::from_task_failed(


### PR DESCRIPTION
## Summary

- 데몬 태스크 실패 시 `failure_count` 기반 5-Level 에스컬레이션 파이프라인 연결
- 기존에 정의만 되어있던 `EscalationLevel` enum과 `queue_increment_failure` DB 메서드를 실제 데몬 루프에 배선

## Escalation Levels

| Level | failure_count | 동작 |
|-------|--------------|------|
| Retry | 0-1 | pending으로 되돌려 자동 재시도 |
| Comment | 2 | 재시도 (코멘트는 태스크가 이미 남김) |
| Hitl | 3 | HITL 이벤트 생성 → 사람 개입 요청 |
| Skip | 4 | 큐에서 제거 (기존 동작) |
| Replan | 5+ | HITL 이벤트(replan) 생성 → 스펙 재계획 권고 |

## Changes

- `escalation.rs`: 에스컬레이션 판정 + 대응 모듈 신규 생성
- `daemon/mod.rs`: 태스크 실패 시 escalation 호출, Retry일 때 `apply(Remove)` 건너뛰기
- `resolve_repo_id` 재사용으로 잘못된 repo_id 방지
- HITL 생성 실패 시 경고 로그 (silent data loss 방지)

## Test plan

- [x] `cargo clippy --tests -- -D warnings` 통과
- [x] `cargo test` 전체 통과 (327+ tests, 0 failed)
- [ ] 데몬 실행 중 태스크 실패 → failure_count 증가 확인
- [ ] failure_count=1 → 자동 재시도 (pending 복구) 확인
- [ ] failure_count=3 → HITL 이벤트 생성 확인
- [ ] failure_count=5 → replan HITL 이벤트 생성 확인

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)