### PR TITLE
feat(autodev): add spec completion verification and HITL response handler

### DIFF
--- a/plugins/autodev/cli/Cargo.lock
+++ b/plugins/autodev/cli/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autodev"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/plugins/autodev/cli/src/cli/spec.rs
+++ b/plugins/autodev/cli/src/cli/spec.rs
@@ -165,6 +165,9 @@ pub fn spec_unlink(db: &Database, spec_id: &str, issue_number: i64) -> Result<()
     Ok(())
 }
 
+/// 스펙 완료 HITL 이벤트 식별 마커.
+const COMPLETION_HITL_MARKER: &str = "ready for completion";
+
 /// Check if a spec is ready for completion and transition to Completing status.
 ///
 /// Verifies the spec is Active, has linked issues, then transitions to
@@ -185,6 +188,36 @@ pub fn spec_check_completion(db: &Database, id: &str) -> Result<(String, NewHitl
     if issues.is_empty() {
         anyhow::bail!("spec {id} has no linked issues. Link issues before completing.");
     }
+
+    // Verify linked issues are done (queue items in done/skipped phase)
+    let queue_items = db.queue_list_items(None)?;
+    let mut pending_issues = Vec::new();
+    for issue in &issues {
+        // work_id 형식: "issue:{repo_name}:{issue_number}"
+        let matching_item = queue_items.iter().find(|q| {
+            q.work_id.ends_with(&format!(":{}", issue.issue_number))
+                && q.work_id.starts_with("issue:")
+        });
+        match matching_item {
+            Some(item) if item.phase != QueuePhase::Done && item.skip_reason.is_none() => {
+                pending_issues.push(format!("#{} (phase: {})", issue.issue_number, item.phase));
+            }
+            None => {
+                // 큐에 없는 이슈는 아직 처리되지 않은 것으로 간주
+            }
+            _ => {} // done 또는 skipped
+        }
+    }
+
+    let issues_warning = if pending_issues.is_empty() {
+        String::new()
+    } else {
+        format!(
+            "\n\n⚠ {} issue(s) not yet done: {}",
+            pending_issues.len(),
+            pending_issues.join(", ")
+        )
+    };
 
     // Check for conflicts before completing
     let conflict_warning = if let Some(ref source_path) = spec.source_path {
@@ -218,13 +251,13 @@ pub fn spec_check_completion(db: &Database, id: &str) -> Result<(String, NewHitl
         work_id: None,
         severity: HitlSeverity::High,
         situation: format!(
-            "Spec '{}' is ready for completion. Linked issues: {}",
+            "Spec '{}' is {COMPLETION_HITL_MARKER}. Linked issues: {}",
             spec.title,
             issue_list.join(", ")
         ),
         context: format!(
-            "Spec ID: {}\nTitle: {}\nLinked issues: {}\n\nPlease confirm completion or reject to return to Active.{}",
-            id, spec.title, issue_list.join(", "), conflict_warning
+            "Spec ID: {}\nTitle: {}\nLinked issues: {}\n\nPlease confirm completion or reject to return to Active.{}{}",
+            id, spec.title, issue_list.join(", "), issues_warning, conflict_warning
         ),
         options: vec![
             "Confirm completion".to_string(),
@@ -241,6 +274,47 @@ pub fn spec_check_completion(db: &Database, id: &str) -> Result<(String, NewHitl
         ),
         hitl_event,
     ))
+}
+
+/// HITL 응답으로 스펙 완료를 확정하거나 거부한다.
+///
+/// - choice 1 (Confirm completion): Completing → Completed
+/// - choice 2 (Reject): Completing → Active
+///
+/// 스펙 완료 관련 HITL 이벤트가 아니면 None을 반환한다.
+pub fn handle_spec_completion_response(
+    db: &Database,
+    event: &HitlEvent,
+    choice: Option<i32>,
+) -> Option<String> {
+    // 스펙 완료 관련 HITL인지 확인
+    let spec_id = event.spec_id.as_deref()?;
+    if !event.situation.contains(COMPLETION_HITL_MARKER) {
+        return None;
+    }
+
+    let spec = db.spec_show(spec_id).ok()??;
+    if spec.status != SpecStatus::Completing {
+        return None;
+    }
+
+    match choice {
+        Some(1) => {
+            // Confirm → Completed
+            if let Err(e) = db.spec_set_status(spec_id, SpecStatus::Completed) {
+                return Some(format!("Failed to complete spec {spec_id}: {e}"));
+            }
+            Some(format!("Spec {spec_id} marked as Completed"))
+        }
+        Some(2) => {
+            // Reject → Active
+            if let Err(e) = db.spec_set_status(spec_id, SpecStatus::Active) {
+                return Some(format!("Failed to reactivate spec {spec_id}: {e}"));
+            }
+            Some(format!("Spec {spec_id} returned to Active"))
+        }
+        _ => None,
+    }
 }
 
 /// Validate that a spec body contains required sections.

--- a/plugins/autodev/cli/src/main.rs
+++ b/plugins/autodev/cli/src/main.rs
@@ -836,9 +836,10 @@ async fn main() -> Result<()> {
                 let output = client::hitl::respond(&db, &id, choice, message.as_deref())?;
                 println!("{output}");
 
-                // Auto-collect feedback if the response has a message
+                // Post-response processing
                 use autodev::core::repository::HitlRepository;
                 if let Ok(Some(event)) = db.hitl_show(&id) {
+                    // Auto-collect feedback if the response has a message
                     if let Some(ref msg) = message {
                         if let Err(e) = client::convention::collect_feedback_from_hitl(
                             &db,
@@ -848,6 +849,13 @@ async fn main() -> Result<()> {
                         ) {
                             eprintln!("warning: failed to auto-collect feedback: {e}");
                         }
+                    }
+
+                    // Handle spec completion response (approve → Completed, reject → Active)
+                    if let Some(result_msg) =
+                        client::spec::handle_spec_completion_response(&db, &event, choice)
+                    {
+                        println!("{result_msg}");
                     }
 
                     // Force-trigger claw-evaluate so the response is processed immediately


### PR DESCRIPTION
## Summary

- `spec_check_completion()` 이 연결된 이슈의 큐 상태를 검증하여 미완료 이슈를 HITL 컨텍스트에 경고로 포함
- `handle_spec_completion_response()` 신규 추가: HITL 응답으로 스펙 완료 확정 또는 거부
  - choice 1 (승인): Completing → Completed
  - choice 2 (거부): Completing → Active
- `hitl respond` 후 자동으로 스펙 완료 응답 처리 (main.rs에서 배선)
- `COMPLETION_HITL_MARKER` 상수로 생산자/소비자 간 문자열 동기화

## Test plan

- [x] `cargo clippy --tests -- -D warnings` 통과
- [x] `cargo test` 전체 통과 (327+ tests, 0 failed)
- [ ] 미완료 이슈가 있는 스펙에서 `spec complete` → 경고 메시지 확인
- [ ] HITL 응답 choice 1 → 스펙 Completed 전환 확인
- [ ] HITL 응답 choice 2 → 스펙 Active 복귀 확인

Closes #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)