### PR TITLE
feat(autodev): enrich board state with HITL summary, claw status, and acceptance criteria

### DIFF
--- a/plugins/autodev/cli/Cargo.lock
+++ b/plugins/autodev/cli/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autodev"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/plugins/autodev/cli/src/core/board.rs
+++ b/plugins/autodev/cli/src/core/board.rs
@@ -9,6 +9,23 @@ pub trait BoardRenderer: Send + Sync {
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct BoardState {
     pub repos: Vec<RepoBoardState>,
+    /// Cross-repo HITL pending summary.
+    pub hitl_summary: HitlSummary,
+    /// Claw daemon status.
+    pub claw_status: ClawStatus,
+}
+
+/// Cross-repo HITL summary for board header.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct HitlSummary {
+    pub pending: i64,
+    pub total: i64,
+}
+
+/// Claw daemon status indicator.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct ClawStatus {
+    pub running: bool,
 }
 
 /// Per-repo board state with specs and queue columns.
@@ -27,6 +44,8 @@ pub struct SpecBoardEntry {
     pub status: String,
     pub progress: String, // e.g. "3/5"
     pub hitl_count: u32,
+    /// Acceptance criteria (from spec, if defined).
+    pub acceptance_criteria: Option<String>,
 }
 
 /// A named column in the kanban board.

--- a/plugins/autodev/cli/src/core/repository.rs
+++ b/plugins/autodev/cli/src/core/repository.rs
@@ -58,6 +58,7 @@ pub trait HitlRepository {
     fn hitl_respond(&self, response: &NewHitlResponse) -> Result<()>;
     fn hitl_set_status(&self, id: &str, status: HitlStatus) -> Result<()>;
     fn hitl_pending_count(&self, repo: Option<&str>) -> Result<i64>;
+    fn hitl_total_count(&self, repo: Option<&str>) -> Result<i64>;
     fn hitl_responses(&self, event_id: &str) -> Result<Vec<HitlResponse>>;
     fn hitl_expired_list(&self, timeout_hours: i64) -> Result<Vec<HitlEvent>>;
 }

--- a/plugins/autodev/cli/src/infra/db/repository.rs
+++ b/plugins/autodev/cli/src/infra/db/repository.rs
@@ -688,6 +688,25 @@ impl HitlRepository for Database {
         Ok(count)
     }
 
+    fn hitl_total_count(&self, repo: Option<&str>) -> Result<i64> {
+        let conn = self.conn();
+        let (query, params): (String, Vec<Box<dyn rusqlite::types::ToSql>>) =
+            if let Some(name) = repo {
+                (
+                    "SELECT COUNT(*) FROM hitl_events e JOIN repositories r ON e.repo_id = r.id \
+                     WHERE r.name = ?1"
+                        .to_string(),
+                    vec![Box::new(name.to_string())],
+                )
+            } else {
+                ("SELECT COUNT(*) FROM hitl_events".to_string(), vec![])
+            };
+        let params_refs: Vec<&dyn rusqlite::types::ToSql> =
+            params.iter().map(|p| p.as_ref()).collect();
+        let count: i64 = conn.query_row(&query, params_refs.as_slice(), |row| row.get(0))?;
+        Ok(count)
+    }
+
     fn hitl_responses(&self, event_id: &str) -> Result<Vec<HitlResponse>> {
         let conn = self.conn();
         let mut stmt = conn.prepare(

--- a/plugins/autodev/cli/src/main.rs
+++ b/plugins/autodev/cli/src/main.rs
@@ -926,7 +926,7 @@ async fn main() -> Result<()> {
             use autodev::core::board::BoardRenderer;
             use autodev::tui::board::{BoardStateBuilder, TextBoardRenderer};
 
-            let state = BoardStateBuilder::build(&db, repo.as_deref())?;
+            let state = BoardStateBuilder::build(&db, repo.as_deref(), &home)?;
             if json {
                 let json_str = serde_json::to_string_pretty(&state)?;
                 println!("{json_str}");

--- a/plugins/autodev/cli/src/tui/board.rs
+++ b/plugins/autodev/cli/src/tui/board.rs
@@ -16,7 +16,11 @@ const COLUMN_NAMES: &[&str] = &["Pending", "Ready", "Running", "Done", "Skipped"
 
 impl BoardStateBuilder {
     /// Build board state from DB, optionally filtered by repo name.
-    pub fn build(db: &Database, repo_filter: Option<&str>) -> Result<BoardState> {
+    pub fn build(
+        db: &Database,
+        repo_filter: Option<&str>,
+        home: &std::path::Path,
+    ) -> Result<BoardState> {
         let all_repos = db.repo_find_enabled()?;
         let all_items = db.queue_list_items(repo_filter)?;
         let all_specs = db.spec_list(repo_filter)?;
@@ -67,6 +71,7 @@ impl BoardStateBuilder {
                     status: spec.status.to_string(),
                     progress: format!("{done_count}/{total}"),
                     hitl_count,
+                    acceptance_criteria: spec.acceptance_criteria.clone(),
                 });
             }
 
@@ -98,7 +103,23 @@ impl BoardStateBuilder {
             });
         }
 
-        Ok(BoardState { repos: board_repos })
+        // Cross-repo HITL summary
+        let hitl_pending = db.hitl_pending_count(None)?;
+        let hitl_total = db.hitl_total_count(None)?;
+
+        // Claw daemon status (check if status file exists)
+        let claw_running = home.join("daemon.status.json").exists();
+
+        Ok(BoardState {
+            repos: board_repos,
+            hitl_summary: HitlSummary {
+                pending: hitl_pending,
+                total: hitl_total,
+            },
+            claw_status: ClawStatus {
+                running: claw_running,
+            },
+        })
     }
 }
 
@@ -114,6 +135,21 @@ impl BoardRenderer for TextBoardRenderer {
         }
 
         let mut out = String::new();
+
+        // Header: Claw status + HITL summary
+        let claw_icon = if state.claw_status.running {
+            "●"
+        } else {
+            "○"
+        };
+        out.push_str(&format!("Claw: {claw_icon}"));
+        if state.hitl_summary.pending > 0 {
+            out.push_str(&format!(
+                "  HITL: {} pending / {} total",
+                state.hitl_summary.pending, state.hitl_summary.total
+            ));
+        }
+        out.push_str("\n\n");
 
         for (i, repo) in state.repos.iter().enumerate() {
             if i > 0 {
@@ -134,6 +170,12 @@ impl BoardRenderer for TextBoardRenderer {
                     out.push_str(&format!("  HITL: {}", spec.hitl_count));
                 }
                 out.push('\n');
+                if let Some(ref ac) = spec.acceptance_criteria {
+                    // 각 줄을 체크리스트로 표시
+                    for line in ac.lines().filter(|l| !l.trim().is_empty()) {
+                        out.push_str(&format!("    {line}\n"));
+                    }
+                }
             }
 
             // Kanban table
@@ -274,6 +316,7 @@ mod tests {
                     status: "active".to_string(),
                     progress: "3/5".to_string(),
                     hitl_count: 1,
+                    acceptance_criteria: None,
                 }],
                 columns: vec![
                     BoardColumn {
@@ -321,6 +364,7 @@ mod tests {
                     },
                 ],
             }],
+            ..Default::default()
         };
 
         let output = renderer.render(&state);
@@ -361,6 +405,7 @@ mod tests {
                     },
                 ],
             }],
+            ..Default::default()
         };
 
         let output = renderer.render(&state);
@@ -400,6 +445,7 @@ mod tests {
                     }],
                 },
             ],
+            ..Default::default()
         };
 
         let output = renderer.render(&state);
@@ -421,9 +467,11 @@ mod tests {
                     status: "active".to_string(),
                     progress: "0/3".to_string(),
                     hitl_count: 0,
+                    acceptance_criteria: None,
                 }],
                 columns: vec![],
             }],
+            ..Default::default()
         };
 
         let output = renderer.render(&state);
@@ -452,7 +500,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let db = setup_test_db(tmp.path());
 
-        let state = BoardStateBuilder::build(&db, None).unwrap();
+        let state = BoardStateBuilder::build(&db, None, tmp.path()).unwrap();
         assert!(state.repos.is_empty());
     }
 
@@ -495,7 +543,7 @@ mod tests {
             Some("PR B1"),
         );
 
-        let state = BoardStateBuilder::build(&db, None).unwrap();
+        let state = BoardStateBuilder::build(&db, None, tmp.path()).unwrap();
         assert_eq!(state.repos.len(), 2);
 
         let repo_a = state
@@ -569,7 +617,7 @@ mod tests {
             Some("Task 3"),
         );
 
-        let state = BoardStateBuilder::build(&db, None).unwrap();
+        let state = BoardStateBuilder::build(&db, None, tmp.path()).unwrap();
         assert_eq!(state.repos.len(), 1);
 
         let repo = &state.repos[0];
@@ -607,7 +655,7 @@ mod tests {
             Some("B"),
         );
 
-        let state = BoardStateBuilder::build(&db, Some("org/repo-a")).unwrap();
+        let state = BoardStateBuilder::build(&db, Some("org/repo-a"), tmp.path()).unwrap();
         assert_eq!(state.repos.len(), 1);
         assert_eq!(state.repos[0].repo_name, "org/repo-a");
     }


### PR DESCRIPTION
## Summary

- `BoardState`에 `HitlSummary` (pending/total) 추가: 전체 HITL 현황을 보드 헤더에 표시
- `BoardState`에 `ClawStatus` (running) 추가: daemon.status.json 존재 여부로 판단
- `SpecBoardEntry`에 `acceptance_criteria` 추가: 스펙별 수락 기준을 체크리스트로 렌더링
- `hitl_total_count()` DB 쿼리 추가: 전체 이벤트 로드 대신 COUNT 쿼리 사용
- `TextBoardRenderer` 헤더에 Claw 상태 아이콘 + HITL 요약 표시

## Board Output Example

```
Claw: ●  HITL: 2 pending / 5 total

org/my-repo
  Specs: Auth Module [Active] 3/5  HITL: 2
    - [ ] JWT 인증 구현
    - [ ] 세션 관리 테스트
  ┌─────────┬───────┬─────────┬──────┬─────────┐
  │ Pending │ Ready │ Running │ Done │ Skipped │
  ...
```

## Test plan

- [x] `cargo clippy --tests -- -D warnings` 통과
- [x] `cargo test` 전체 통과 (327+ tests, 0 failed)
- [ ] `autodev board --json` → hitl_summary, claw_status 필드 확인
- [ ] 데몬 실행 시 `Claw: ●`, 미실행 시 `Claw: ○` 확인

Closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)