### PR TITLE
fix(autodev): sync cron daemon env vars and add --cwd to agent command

### DIFF
--- a/plugins/autodev/cli/Cargo.lock
+++ b/plugins/autodev/cli/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autodev"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/plugins/autodev/cli/src/main.rs
+++ b/plugins/autodev/cli/src/main.rs
@@ -123,6 +123,9 @@ enum Commands {
         /// 대상 레포 이름 (org/repo)
         #[arg(long)]
         repo: Option<String>,
+        /// 에이전트 세션의 작업 디렉토리 (기본: ~/.autodev/claw-workspace)
+        #[arg(long)]
+        cwd: Option<String>,
     },
     /// Convention bootstrap — detect tech stack and generate .claude/rules/
     Convention {
@@ -936,10 +939,23 @@ async fn main() -> Result<()> {
                 print!("{output}");
             }
         }
-        Commands::Agent { prompt, repo } => {
-            let ws = client::claw::claw_workspace_path(&home);
+        Commands::Agent { prompt, repo, cwd } => {
+            let default_ws = client::claw::claw_workspace_path(&home);
+            let ws = if let Some(ref dir) = cwd {
+                std::path::PathBuf::from(dir)
+            } else {
+                default_ws.clone()
+            };
             if !ws.exists() {
-                anyhow::bail!("Claw workspace not initialized. Run 'autodev claw init' first.");
+                anyhow::bail!(
+                    "Working directory not found: {}. {}",
+                    ws.display(),
+                    if cwd.is_none() {
+                        "Run 'autodev claw init' first."
+                    } else {
+                        "Check the --cwd path."
+                    }
+                );
             }
 
             // Resolve repo context if --repo is provided

--- a/plugins/autodev/cli/src/service/daemon/cron/runner.rs
+++ b/plugins/autodev/cli/src/service/daemon/cron/runner.rs
@@ -88,10 +88,28 @@ impl ScriptRunner {
         vars.insert("AUTODEV_JOB_NAME".to_string(), job.name.clone());
         vars.insert("AUTODEV_JOB_ID".to_string(), job.id.clone());
 
+        // Global workspace paths
+        let claw_workspace = home.join("claw-workspace");
+        vars.insert(
+            "AUTODEV_CLAW_WORKSPACE".to_string(),
+            claw_workspace.to_string_lossy().to_string(),
+        );
+
         // Per-repo variables
         if let Some(repo) = repo_info {
             vars.insert("AUTODEV_REPO_NAME".to_string(), repo.name.clone());
             vars.insert("AUTODEV_REPO_URL".to_string(), repo.url.clone());
+
+            let sanitized = crate::core::config::sanitize_repo_name(&repo.name);
+            let workspace = home.join("workspaces").join(&sanitized);
+            vars.insert(
+                "AUTODEV_WORKSPACE".to_string(),
+                workspace.to_string_lossy().to_string(),
+            );
+            vars.insert(
+                "AUTODEV_REPO_ROOT".to_string(),
+                workspace.join("main").to_string_lossy().to_string(),
+            );
         }
 
         if let Some(ref repo_id) = job.repo_id {


### PR DESCRIPTION
## Summary

### #308: Cron env var 동기화
데몬 cron runner(`ScriptRunner::build_env_vars`)에 CLI trigger 경로와 동일한 환경 변수 추가:
- `AUTODEV_CLAW_WORKSPACE` — claw 워크스페이스 경로
- `AUTODEV_WORKSPACE` — per-repo 워크스페이스 경로
- `AUTODEV_REPO_ROOT` — 레포 메인 클론 경로

### #309: Agent --cwd 옵션
`autodev agent --cwd <dir>` 옵션 추가로 에이전트 세션의 작업 디렉토리를 지정 가능. 기본값은 기존과 동일(`~/.autodev/claw-workspace`).

## Test plan
- [x] `cargo clippy --tests -- -D warnings` 통과
- [x] `cargo test` 전체 통과 (327+ tests, 0 failed)
- [ ] `autodev agent --cwd /tmp/test` → 지정 디렉토리에서 실행 확인
- [ ] cron daemon에서 `gap-detection.sh` 실행 시 `$AUTODEV_REPO_ROOT` 정의 확인

Closes #308, closes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)