### PR TITLE
feat(autodev): trigger claw init and convention detection on repo add

### DIFF
--- a/plugins/autodev/cli/Cargo.lock
+++ b/plugins/autodev/cli/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autodev"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/plugins/autodev/cli/src/cli/mod.rs
+++ b/plugins/autodev/cli/src/cli/mod.rs
@@ -145,6 +145,41 @@ pub fn repo_add(
         println!("cron: seeded {seeded} built-in cron jobs for {name}");
     }
 
+    // Claw auto-initialization when claw.enabled
+    if cfg.claw.enabled {
+        // 1. Init global claw workspace (idempotent)
+        if let Err(e) = claw::claw_init(&home) {
+            eprintln!("warning: claw init failed: {e}");
+        }
+
+        // 2. Init per-repo claw override directory
+        if let Err(e) = claw::claw_init_repo(&home, &name) {
+            eprintln!("warning: claw init --repo failed: {e}");
+        } else {
+            println!("claw: initialized per-repo override for {name}");
+        }
+
+        // 3. Check target repo's .claude/rules/ and suggest convention bootstrap
+        let repo_root = config::workspaces_path(env)
+            .join(config::sanitize_repo_name(&name))
+            .join("main");
+        let rules_dir = repo_root.join(".claude/rules");
+        if !rules_dir.exists()
+            || rules_dir
+                .read_dir()
+                .map_or(true, |mut d| d.next().is_none())
+        {
+            let stack = convention::detect_tech_stack(&repo_root);
+            if !stack.languages.is_empty() {
+                println!(
+                    "hint: detected stack: {}. Run 'autodev convention bootstrap {} --apply' to generate .claude/rules/",
+                    stack.languages.join(", "),
+                    repo_root.display()
+                );
+            }
+        }
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

`repo add` 시 `claw.enabled: true`이면 자동으로:
1. 글로벌 claw 워크스페이스 초기화 (idempotent)
2. per-repo claw 오버라이드 디렉토리 생성
3. 타겟 레포의 `.claude/rules/` 확인 → 비어있으면 기술 스택 감지 + `convention bootstrap` 안내

## Test plan
- [x] `cargo clippy --tests -- -D warnings` 통과
- [x] `cargo test` 전체 통과 (327+ tests, 0 failed)
- [ ] claw.enabled=true 설정 후 `repo add` → claw init + hint 메시지 확인
- [ ] claw.enabled=false 설정 후 `repo add` → 기존 동작 변경 없음 확인

Closes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)