### PR TITLE
fix(autodev): wire usage_insert into daemon task loop for token tracking

### DIFF
--- a/plugins/autodev/cli/Cargo.lock
+++ b/plugins/autodev/cli/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autodev"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/plugins/autodev/cli/src/core/repository.rs
+++ b/plugins/autodev/cli/src/core/repository.rs
@@ -19,7 +19,8 @@ pub trait ScanCursorRepository {
 }
 
 pub trait ConsumerLogRepository {
-    fn log_insert(&self, log: &NewConsumerLog) -> Result<()>;
+    /// 로그를 삽입하고 생성된 log_id를 반환한다.
+    fn log_insert(&self, log: &NewConsumerLog) -> Result<String>;
     fn log_recent(&self, repo_name: Option<&str>, limit: usize) -> Result<Vec<LogEntry>>;
     /// 특정 날짜의 knowledge extraction stdout를 모두 반환
     fn log_knowledge_stdout_by_date(&self, date: &str) -> Result<Vec<String>>;

--- a/plugins/autodev/cli/src/infra/db/repository.rs
+++ b/plugins/autodev/cli/src/infra/db/repository.rs
@@ -151,7 +151,7 @@ impl ScanCursorRepository for Database {
 }
 
 impl ConsumerLogRepository for Database {
-    fn log_insert(&self, log: &NewConsumerLog) -> Result<()> {
+    fn log_insert(&self, log: &NewConsumerLog) -> Result<String> {
         let id = Uuid::new_v4().to_string();
         self.conn().execute(
             "INSERT INTO consumer_logs (id, repo_id, queue_type, queue_item_id, worker_id, command, stdout, stderr, exit_code, started_at, finished_at, duration_ms) \
@@ -162,7 +162,7 @@ impl ConsumerLogRepository for Database {
                 log.started_at, log.finished_at, log.duration_ms
             ],
         )?;
-        Ok(())
+        Ok(id)
     }
 
     fn log_recent(&self, repo_name: Option<&str>, limit: usize) -> Result<Vec<LogEntry>> {

--- a/plugins/autodev/cli/src/service/daemon/mod.rs
+++ b/plugins/autodev/cli/src/service/daemon/mod.rs
@@ -22,7 +22,7 @@ use tokio::task::JoinSet;
 use tracing::info;
 
 use crate::core::config::{self, Env};
-use crate::core::repository::ConsumerLogRepository;
+use crate::core::repository::{ConsumerLogRepository, TokenUsageRepository};
 use crate::infra::claude::Claude;
 use crate::infra::db::Database;
 use crate::infra::gh::Gh;
@@ -215,7 +215,15 @@ impl Daemon {
                             }
 
                             for log_entry in &task_result.logs {
-                                let _ = self.log_db.log_insert(log_entry);
+                                if let Ok(log_id) = self.log_db.log_insert(log_entry) {
+                                    let usage =
+                                        parse_token_usage(&log_id, log_entry);
+                                    if usage.input_tokens > 0 || usage.output_tokens > 0 {
+                                        if let Err(e) = self.log_db.usage_insert(&usage) {
+                                            tracing::warn!("failed to record token usage: {e}");
+                                        }
+                                    }
+                                }
                             }
 
                             // Notify on task failure (escalation으로 retry되더라도 기록)
@@ -357,6 +365,54 @@ pub fn daemonize(log_dir: &Path) -> Result<()> {
     std::mem::forget(devnull);
 
     Ok(())
+}
+
+/// Claude CLI stderr에서 토큰 사용량을 파싱한다.
+///
+/// Claude Code의 stderr에는 다양한 형식의 토큰 정보가 출력될 수 있다.
+/// 예: `"input_tokens": 1234`, `"output_tokens": 567`
+/// JSON 응답이 포함된 경우도 파싱한다.
+/// Claude CLI stderr에서 토큰 사용량을 파싱한다.
+fn parse_token_usage(
+    log_id: &str,
+    log: &crate::core::models::NewConsumerLog,
+) -> crate::core::models::NewTokenUsage {
+    let mut input_tokens: i64 = 0;
+    let mut output_tokens: i64 = 0;
+    let mut cache_write_tokens: i64 = 0;
+    let mut cache_read_tokens: i64 = 0;
+
+    // Parse JSON objects from stderr (Claude emits usage events as JSON lines)
+    for line in log.stderr.lines() {
+        if let Ok(obj) = serde_json::from_str::<serde_json::Value>(line.trim()) {
+            if let Some(v) = obj.get("input_tokens").and_then(|v| v.as_i64()) {
+                input_tokens += v;
+            }
+            if let Some(v) = obj.get("output_tokens").and_then(|v| v.as_i64()) {
+                output_tokens += v;
+            }
+            if let Some(v) = obj
+                .get("cache_creation_input_tokens")
+                .and_then(|v| v.as_i64())
+            {
+                cache_write_tokens += v;
+            }
+            if let Some(v) = obj.get("cache_read_input_tokens").and_then(|v| v.as_i64()) {
+                cache_read_tokens += v;
+            }
+        }
+    }
+
+    crate::core::models::NewTokenUsage {
+        log_id: log_id.to_string(),
+        repo_id: log.repo_id.clone(),
+        queue_type: log.queue_type.clone(),
+        queue_item_id: log.queue_item_id.clone(),
+        input_tokens,
+        output_tokens,
+        cache_write_tokens,
+        cache_read_tokens,
+    }
 }
 
 /// 데몬을 포그라운드 또는 백그라운드로 시작 (non-blocking event loop)


### PR DESCRIPTION
## Summary

토큰 사용량 추적 인프라가 구현되어 있지만 데몬 루프에서 호출되지 않아 `autodev usage`가 항상 빈 결과를 반환하는 문제 해결.

- `log_insert()` 반환값을 `Result<()>` → `Result<String>` (log_id)으로 변경하여 usage FK 연결
- 태스크 완료 후 Claude stderr에서 JSON 형식 토큰 사용량 파싱 (`serde_json`)
- `usage_insert()` 호출하여 token_usage 테이블에 기록

## Test plan
- [x] `cargo clippy --tests -- -D warnings` 통과
- [x] `cargo test` 전체 통과 (327+ tests, 0 failed)
- [ ] 데몬 실행 후 `autodev usage` → 실제 토큰 사용량 표시 확인

Closes #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)