### PR TITLE
feat(autodev): add HITL marker to GitHub comment notifications for reply scanning

### DIFF
--- a/plugins/autodev/cli/Cargo.lock
+++ b/plugins/autodev/cli/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autodev"
-version = "0.21.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/plugins/autodev/cli/src/core/notifier.rs
+++ b/plugins/autodev/cli/src/core/notifier.rs
@@ -14,6 +14,8 @@ pub struct NotificationEvent {
     pub work_id: Option<String>,
     pub spec_id: Option<String>,
     pub url: Option<String>,
+    /// HITL event ID (for reply-scanning markers in GitHub comments).
+    pub hitl_id: Option<String>,
 }
 
 impl NotificationEvent {
@@ -28,6 +30,7 @@ impl NotificationEvent {
             work_id: event.work_id.clone(),
             spec_id: event.spec_id.clone(),
             url: None,
+            hitl_id: Some(event.id.clone()),
         }
     }
 
@@ -42,6 +45,7 @@ impl NotificationEvent {
             work_id: event.work_id.clone(),
             spec_id: event.spec_id.clone(),
             url: None,
+            hitl_id: None, // ID not yet assigned at creation time
         }
     }
 
@@ -56,6 +60,7 @@ impl NotificationEvent {
             work_id: Some(work_id.to_string()),
             spec_id: None,
             url: None,
+            hitl_id: None,
         }
     }
 }

--- a/plugins/autodev/cli/src/service/daemon/notifiers/dispatcher.rs
+++ b/plugins/autodev/cli/src/service/daemon/notifiers/dispatcher.rs
@@ -89,6 +89,7 @@ mod tests {
             work_id: Some("issue:org/repo:42".to_string()),
             spec_id: None,
             url: None,
+            hitl_id: None,
         }
     }
 

--- a/plugins/autodev/cli/src/service/daemon/notifiers/github_comment.rs
+++ b/plugins/autodev/cli/src/service/daemon/notifiers/github_comment.rs
@@ -33,8 +33,16 @@ impl GitHubCommentNotifier {
     }
 
     /// 알림 마크다운 본문을 생성한다.
+    ///
+    /// HITL ID가 있으면 HTML 마커를 포함하여 reply-scanning이 가능하게 한다.
     fn format_comment(event: &NotificationEvent) -> String {
         let mut body = String::new();
+
+        // HITL reply-scanning marker (invisible in rendered markdown)
+        if let Some(ref hitl_id) = event.hitl_id {
+            body.push_str(&format!("<!-- autodev:hitl:{hitl_id} -->\n"));
+        }
+
         body.push_str("## \u{1f514} autodev: 사람 확인 필요\n\n");
         body.push_str(&format!("**상황**: {}\n\n", event.situation));
         body.push_str(&format!("**분석**: {}\n\n", event.context));
@@ -44,6 +52,7 @@ impl GitHubCommentNotifier {
             for (i, opt) in event.options.iter().enumerate() {
                 body.push_str(&format!("{}. {}\n", i + 1, opt));
             }
+            body.push_str("\n> 이 코멘트에 선택 번호(예: `1`)로 답글을 달면 자동 응답됩니다.\n");
         }
 
         body
@@ -93,6 +102,7 @@ mod tests {
             work_id: work_id.map(|s| s.to_string()),
             spec_id: None,
             url: None,
+            hitl_id: Some("hitl-test-001".to_string()),
         }
     }
 

--- a/plugins/autodev/cli/src/service/daemon/notifiers/webhook.rs
+++ b/plugins/autodev/cli/src/service/daemon/notifiers/webhook.rs
@@ -99,6 +99,7 @@ mod tests {
             work_id: Some("issue:org/repo:42".to_string()),
             spec_id: Some("spec-001".to_string()),
             url: Some("https://github.com/org/repo/issues/42".to_string()),
+            hitl_id: None,
         }
     }
 


### PR DESCRIPTION
## Summary

GitHub 코멘트 알림에 HITL 이벤트 마커를 추가하여 향후 reply-scanning의 기반을 구축.

- `NotificationEvent`에 `hitl_id: Option<String>` 필드 추가
- `GitHubCommentNotifier::format_comment()`에 `<!-- autodev:hitl:<id> -->` HTML 마커 삽입
- 코멘트 본문에 "이 코멘트에 선택 번호로 답글을 달면 자동 응답됩니다" 안내 추가
- `from_hitl_expired()`에서 HITL ID 전달, `from_hitl_created()`는 아직 ID 미할당 시점이므로 None

## Reply Scanning Flow (향후 구현)

```
1. GitHub 코멘트에 <!-- autodev:hitl:hitl-xxx --> 마커 포함 ← 이번 PR
2. 데몬 틱에서 GitHub API로 마커 코멘트의 답글 스캔 ← 향후
3. 답글 내용을 파싱하여 hitl_respond() 호출 ← 향후
```

## Test plan
- [x] `cargo clippy --tests -- -D warnings` 통과
- [x] `cargo test` 전체 통과 (327+ tests, 0 failed)
- [ ] `GitHubCommentNotifier`가 HITL 코멘트에 마커 포함 확인

Closes #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)