### PR TITLE
fix(autodev): preserve worktree on AnalyzeTask failure for debugging

### DIFF
--- a/plugins/autodev/cli/Cargo.lock
+++ b/plugins/autodev/cli/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autodev"
-version = "0.21.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/plugins/autodev/cli/src/service/tasks/analyze.rs
+++ b/plugins/autodev/cli/src/service/tasks/analyze.rs
@@ -456,7 +456,8 @@ impl Task for AnalyzeTask {
                 )
                 .await;
 
-            self.cleanup_worktree().await;
+            // Worktree preserved for debugging — use `autodev worktree list` to inspect.
+            tracing::warn!("worktree preserved for debugging: {}", self.work_id());
             return TaskResult {
                 work_id: self.item.work_id.clone(),
                 repo_name: self.item.repo_name.clone(),


### PR DESCRIPTION
## Summary

AnalyzeTask가 유일하게 실패 시 worktree를 정리하고 있었음. 다른 모든 태스크(Implement, Review, Improve)는 이미 실패 시 worktree를 보존.

- `cleanup_worktree()` 호출 제거 → 실패 경로에서 worktree 보존
- `autodev worktree list`로 보존된 worktree 확인 가능

## Test plan
- [x] `cargo clippy --tests -- -D warnings` 통과
- [x] `cargo test` 전체 통과 (327+ tests, 0 failed)
- [ ] AnalyzeTask 실패 시 worktree가 `~/.autodev/workspaces/<repo>/` 에 남아있는지 확인

Closes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)