### PR TITLE
feat(autodev): implement cross-spec conflict detection with queue-based analysis

### DIFF
--- a/plugins/autodev/cli/Cargo.lock
+++ b/plugins/autodev/cli/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autodev"
-version = "0.21.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/plugins/autodev/cli/src/cli/spec.rs
+++ b/plugins/autodev/cli/src/cli/spec.rs
@@ -301,28 +301,81 @@ fn resolve_conflicts(db: &Database, spec_id: &str) -> Result<(Spec, Option<Confl
     Ok((spec, result))
 }
 
-/// Detect specs that share the same source_path (potential file conflicts).
+/// Detect specs that share the same source_path or have concurrent queue items (potential conflicts).
 pub fn spec_conflicts(db: &Database, spec_id: &str) -> Result<String> {
-    let (spec, resolved) = resolve_conflicts(db, spec_id)?;
+    let spec = db
+        .spec_show(spec_id)?
+        .ok_or_else(|| anyhow::anyhow!("spec not found: {spec_id}"))?;
 
-    if spec.source_path.is_none() {
-        return Ok(format!(
-            "Spec {spec_id} has no source_path — cannot detect conflicts.\n"
-        ));
+    let mut output = String::new();
+    let mut conflict_count = 0;
+
+    // 1. Path-based conflicts (existing logic)
+    if let Some(ref source_path) = spec.source_path {
+        let path_conflicts = find_path_conflicts(db, &spec.id, source_path)?;
+        if !path_conflicts.is_empty() {
+            conflict_count += path_conflicts.len();
+            output.push_str(&format!(
+                "Path conflicts (shared source_path: {source_path}):\n"
+            ));
+            output.push_str(&format_conflict_list(&path_conflicts));
+            output.push('\n');
+        }
     }
 
-    let Some((source_path, conflicts)) = resolved else {
-        return Ok(format!("No conflicts detected for spec {spec_id}.\n"));
-    };
+    // 2. Queue-based conflicts: detect specs with concurrent running/ready items in same repo
+    let spec_issues = db.spec_issues(spec_id)?;
+    let all_items = db.queue_list_items(None)?;
+    let active_specs = db.spec_list_by_status(SpecStatus::Active)?;
 
-    let mut output = format!(
-        "⚠ {} conflict(s) detected for spec {spec_id} ({}):\n\n",
-        conflicts.len(),
-        source_path
-    );
-    output.push_str(&format_conflict_list(&conflicts));
-    output.push_str("\nConsider sequencing these specs or resolving file overlaps.\n");
-    Ok(output)
+    // Find running/ready items belonging to THIS spec's issues
+    let my_active_work_ids: std::collections::HashSet<_> = spec_issues
+        .iter()
+        .filter_map(|si| {
+            all_items.iter().find(|q| {
+                q.work_id.ends_with(&format!(":{}", si.issue_number))
+                    && (q.phase == QueuePhase::Running || q.phase == QueuePhase::Ready)
+            })
+        })
+        .map(|q| q.work_id.as_str())
+        .collect();
+
+    if !my_active_work_ids.is_empty() {
+        // Check other active specs for concurrent items in the same repo
+        for other_spec in &active_specs {
+            if other_spec.id == spec.id || other_spec.repo_id != spec.repo_id {
+                continue;
+            }
+            let other_issues = db.spec_issues(&other_spec.id)?;
+            let concurrent: Vec<_> = other_issues
+                .iter()
+                .filter_map(|si| {
+                    all_items.iter().find(|q| {
+                        q.work_id.ends_with(&format!(":{}", si.issue_number))
+                            && (q.phase == QueuePhase::Running || q.phase == QueuePhase::Ready)
+                    })
+                })
+                .collect();
+            if !concurrent.is_empty() {
+                conflict_count += 1;
+                output.push_str(&format!(
+                    "Queue conflict with spec {} ({}):\n  {} concurrent active item(s)\n\n",
+                    other_spec.id,
+                    other_spec.title,
+                    concurrent.len()
+                ));
+            }
+        }
+    }
+
+    if conflict_count == 0 {
+        return Ok(format!("No conflicts detected for spec {spec_id}.\n"));
+    }
+
+    Ok(format!(
+        "⚠ {conflict_count} conflict(s) detected for spec {spec_id}:\n\n{output}\
+         Consider sequencing these specs or resolving file overlaps.\n"
+    ))
 }
 
 /// Find active specs whose source_path overlaps with the given path, excluding `exclude_id`.


### PR DESCRIPTION
## Summary

`spec_conflicts`를 확장하여 2가지 충돌 감지:

1. **Path conflicts** (기존): source_path 겹침 기반
2. **Queue conflicts** (신규): 같은 repo에서 여러 spec의 이슈가 동시에 running/ready 상태일 때 감지

Claw 스케줄러가 충돌 spec 간 병렬 실행을 방지할 수 있는 기반.

## Test plan
- [x] `cargo clippy --tests -- -D warnings` 통과
- [x] `cargo test` 전체 통과 (327+ tests, 0 failed)
- [ ] 동일 repo에 2개 active spec → concurrent items 있을 때 충돌 감지 확인

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)