### PR TITLE
refactor(autodev): separate collector drain from poll — wire drain_tasks() into daemon tick

### DIFF
--- a/plugins/autodev/cli/Cargo.lock
+++ b/plugins/autodev/cli/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autodev"
-version = "0.21.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/plugins/autodev/cli/src/service/daemon/task_manager_impl.rs
+++ b/plugins/autodev/cli/src/service/daemon/task_manager_impl.rs
@@ -29,8 +29,13 @@ impl DefaultTaskManager {
 impl TaskManager for DefaultTaskManager {
     async fn tick(&mut self) {
         for source in &mut self.sources {
-            let tasks = source.poll().await;
-            self.ready_tasks.extend(tasks);
+            // poll: 외부 소스 스캔 + 큐 동기화 (수집만, 태스크 반환 안 함)
+            let poll_tasks = source.poll().await;
+            self.ready_tasks.extend(poll_tasks);
+
+            // drain_tasks: Ready→Running 전이 + Task 객체 생성
+            let drained = source.drain_tasks();
+            self.ready_tasks.extend(drained);
         }
     }
 


### PR DESCRIPTION
## Summary

불완전했던 리팩토링 완성: `poll()`이 `Vec::new()`를 반환하고 `drain_tasks()`는 구현되어 있지만 호출되지 않던 문제 해결.

### 변경 전
```
tick() → source.poll() → Vec::new() → ready_tasks 항상 빈 상태
```

### 변경 후
```
tick() → source.poll() (수집/동기화)
       → source.drain_tasks() (Ready→Running 전이 + Task 생성)
       → ready_tasks에 추가
```

Claw가 `queue advance`로 Pending→Ready 전이를 제어하고, drain_tasks()가 Ready→Running을 처리하는 2단계 흐름.

## Test plan
- [x] `cargo clippy --tests -- -D warnings` 통과
- [x] `cargo test` 전체 통과 (327+ tests, 0 failed)
- [ ] 데몬 실행 → 이슈 등록 → 태스크 실제 스폰 확인

Closes #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)