### PR TITLE
fix(autodev): add orphan_issues to board and worktree path in analyze failure

### DIFF
--- a/plugins/autodev/cli/src/core/board.rs
+++ b/plugins/autodev/cli/src/core/board.rs
@@ -38,6 +38,8 @@ pub struct RepoBoardState {
     pub repo_name: String,
     pub specs: Vec<SpecBoardEntry>,
     pub columns: Vec<BoardColumn>,
+    /// Issues not linked to any spec.
+    pub orphan_issues: Vec<BoardItem>,
 }
 
 /// Summary of a spec for board display.

--- a/plugins/autodev/cli/src/service/tasks/analyze.rs
+++ b/plugins/autodev/cli/src/service/tasks/analyze.rs
@@ -444,7 +444,8 @@ impl Task for AnalyzeTask {
             let fail_comment = format!(
                 "<!-- autodev:analyze-failed -->\n\
                  ⚠️ Analysis agent failed (exit_code={}).\n\n\
-                 Check the agent logs for details.",
+                 Worktree preserved for debugging:\n\
+                 ```\nautodev worktree list\n```",
                 response.exit_code
             );
             self.gh

--- a/plugins/autodev/cli/src/tui/board.rs
+++ b/plugins/autodev/cli/src/tui/board.rs
@@ -96,10 +96,35 @@ impl BoardStateBuilder {
                 })
                 .collect();
 
+            // Orphan issues: queue items not linked to any spec
+            let linked_issue_numbers: std::collections::HashSet<i64> = repo_specs
+                .iter()
+                .flat_map(|s| db.spec_issues(&s.id).unwrap_or_default())
+                .map(|si| si.issue_number)
+                .collect();
+            let orphan_issues: Vec<BoardItem> = repo_items
+                .iter()
+                .filter(|qi| qi.queue_type == crate::core::models::QueueType::Issue)
+                .filter(|qi| {
+                    // Extract issue number from work_id and check if not linked
+                    !qi.work_id
+                        .rsplit(':')
+                        .next()
+                        .and_then(|n| n.parse::<i64>().ok())
+                        .is_some_and(|n| linked_issue_numbers.contains(&n))
+                })
+                .map(|qi| BoardItem {
+                    work_id: qi.work_id.clone(),
+                    title: qi.title.clone().unwrap_or_default(),
+                    queue_type: qi.queue_type.to_string(),
+                })
+                .collect();
+
             board_repos.push(RepoBoardState {
                 repo_name: repo.name.clone(),
                 specs: spec_entries,
                 columns,
+                orphan_issues,
             });
         }
 
@@ -365,6 +390,7 @@ mod tests {
                         items: vec![],
                     },
                 ],
+                orphan_issues: vec![],
             }],
             ..Default::default()
         };
@@ -406,6 +432,7 @@ mod tests {
                         items: vec![],
                     },
                 ],
+                orphan_issues: vec![],
             }],
             ..Default::default()
         };
@@ -433,6 +460,7 @@ mod tests {
                             queue_type: "issue".to_string(),
                         }],
                     }],
+                    orphan_issues: vec![],
                 },
                 RepoBoardState {
                     repo_name: "org/repo-b".to_string(),
@@ -445,6 +473,7 @@ mod tests {
                             queue_type: "pr".to_string(),
                         }],
                     }],
+                    orphan_issues: vec![],
                 },
             ],
             ..Default::default()
@@ -472,6 +501,7 @@ mod tests {
                     acceptance_criteria: None,
                 }],
                 columns: vec![],
+                orphan_issues: vec![],
             }],
             ..Default::default()
         };


### PR DESCRIPTION
## Summary

### #326 sub-gaps 해결:
1. **AnalyzeTask 실패 코멘트에 worktree 디버깅 힌트 추가** (다른 태스크와 일관성)
2. **RepoBoardState에 orphan_issues 필드 추가** — 어떤 spec에도 연결되지 않은 큐 이슈 감지
3. BoardStateBuilder가 orphan issues를 자동으로 계산

## Test plan
- [x] `cargo clippy --tests -- -D warnings` 통과
- [x] `cargo test` 전체 통과 (327+ tests, 0 failed)

Closes #326

🤖 Generated with [Claude Code](https://claude.com/claude-code)