### PR TITLE
feat(autodev): implement git-diff-based file conflict detection for cross-spec analysis

### DIFF
--- a/plugins/autodev/cli/src/cli/spec.rs
+++ b/plugins/autodev/cli/src/cli/spec.rs
@@ -442,6 +442,41 @@ pub fn spec_conflicts(db: &Database, spec_id: &str) -> Result<String> {
         }
     }
 
+    // 3. Git-diff-based file overlap: compare modified files across active specs
+    {
+        let env = crate::core::config::RealEnv;
+        let ws_root = crate::core::config::workspaces_path(&env);
+        let my_files = collect_spec_files(db, &spec, &all_items, &ws_root);
+
+        if !my_files.is_empty() {
+            for other_spec in &active_specs {
+                if other_spec.id == spec.id || other_spec.repo_id != spec.repo_id {
+                    continue;
+                }
+                let other_files = collect_spec_files(db, other_spec, &all_items, &ws_root);
+                let overlap: Vec<&String> = my_files.intersection(&other_files).collect();
+                if !overlap.is_empty() {
+                    conflict_count += 1;
+                    let mut file_list = overlap.clone();
+                    file_list.sort();
+                    output.push_str(&format!(
+                        "File conflict with spec {} ({}):\n  {} overlapping file(s):\n",
+                        other_spec.id,
+                        other_spec.title,
+                        file_list.len()
+                    ));
+                    for f in file_list.iter().take(10) {
+                        output.push_str(&format!("    {f}\n"));
+                    }
+                    if overlap.len() > 10 {
+                        output.push_str(&format!("    ... and {} more\n", overlap.len() - 10));
+                    }
+                    output.push('\n');
+                }
+            }
+        }
+    }
+
     if conflict_count == 0 {
         return Ok(format!("No conflicts detected for spec {spec_id}.\n"));
     }
@@ -450,6 +485,65 @@ pub fn spec_conflicts(db: &Database, spec_id: &str) -> Result<String> {
         "⚠ {conflict_count} conflict(s) detected for spec {spec_id}:\n\n{output}\
          Consider sequencing these specs or resolving file overlaps.\n"
     ))
+}
+
+/// Collect modified files for a spec by running `git diff --name-only` on its PR branches.
+fn collect_spec_files(
+    db: &Database,
+    spec: &Spec,
+    all_items: &[QueueItemRow],
+    ws_root: &std::path::Path,
+) -> std::collections::HashSet<String> {
+    use crate::core::queue_item::QueueItem;
+
+    let mut files = std::collections::HashSet::new();
+    let issues = db.spec_issues(&spec.id).unwrap_or_default();
+
+    for issue in &issues {
+        // Find PR queue items for this issue
+        for item in all_items {
+            if !item.work_id.ends_with(&format!(":{}", issue.issue_number)) {
+                continue;
+            }
+            // Extract head_branch from PR metadata
+            if let Some(ref json) = item.metadata_json {
+                if let Some(crate::core::queue_item::ItemMetadata::Pr(pr)) =
+                    QueueItem::metadata_from_json(json)
+                {
+                    if pr.head_branch.is_empty() {
+                        continue;
+                    }
+                    let repo_name = crate::core::config::sanitize_repo_name(
+                        item.work_id.split(':').nth(1).unwrap_or(""),
+                    );
+                    let repo_dir = ws_root.join(&repo_name).join("main");
+                    if let Ok(diff_files) = git_diff_name_only(&repo_dir, &pr.head_branch) {
+                        files.extend(diff_files);
+                    }
+                }
+            }
+        }
+    }
+
+    files
+}
+
+/// Run `git diff --name-only HEAD...<branch>` and return the set of modified files.
+fn git_diff_name_only(repo_dir: &std::path::Path, branch: &str) -> Result<Vec<String>> {
+    let output = std::process::Command::new("git")
+        .args(["diff", "--name-only", &format!("HEAD...{branch}")])
+        .current_dir(repo_dir)
+        .output()?;
+
+    if !output.status.success() {
+        anyhow::bail!("git diff failed");
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|l| l.to_string())
+        .collect())
 }
 
 /// Find active specs whose source_path overlaps with the given path, excluding `exclude_id`.


### PR DESCRIPTION
## Summary

`spec_conflicts`에 3번째 충돌 감지 전략 추가: **git diff 기반 파일 레벨 오버랩 분석**.

### 3가지 충돌 감지 전략
1. **Path-based** (기존): source_path 필드 겹침
2. **Queue-based** (기존): 동일 repo의 동시 running/ready 항목
3. **Git-diff-based** (신규): PR branch의 실제 변경 파일 교집합 분석

### 동작
- PR 큐 아이템의 `head_branch` 메타데이터 추출
- workspace clone에서 `git diff --name-only HEAD...{branch}` 실행
- spec 간 파일 집합 교집합 계산
- 오버랩 파일 목록을 HITL 컨텍스트에 포함

## Test plan
- [x] `cargo clippy --tests -- -D warnings` 통과
- [x] `cargo test` 전체 통과 (327+ tests, 0 failed)
- [ ] 2개 spec이 같은 파일 수정하는 PR 있을 때 충돌 감지 확인

Closes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)