### PR TITLE
fix(autodev): add spec update --file flag, align cron trigger env vars, and wire reply-scanner evaluate

### DIFF
--- a/plugins/autodev/cli/src/cli/cron.rs
+++ b/plugins/autodev/cli/src/cli/cron.rs
@@ -142,21 +142,30 @@ pub fn cron_trigger(db: &Database, env: &dyn Env, name: &str, repo: Option<&str>
 
     let mut cmd = std::process::Command::new(&job.script_path);
 
-    // Always-present env vars
+    // Global env vars (aligned with daemon cron runner)
     cmd.env("AUTODEV_HOME", home.to_string_lossy().as_ref());
     cmd.env("AUTODEV_DB", db_path.to_string_lossy().as_ref());
     cmd.env(
         "AUTODEV_CLAW_WORKSPACE",
-        config::workspaces_path(env).to_string_lossy().as_ref(),
+        home.join("claw-workspace").to_string_lossy().as_ref(),
     );
+    cmd.env("AUTODEV_JOB_NAME", &job.name);
+    cmd.env("AUTODEV_JOB_ID", &job.id);
 
-    // Per-repo env vars
+    // Per-repo env vars (aligned with daemon cron runner)
     if let Some(repo_name) = repo {
         if let Some(repo_info) = find_repo_info(db, repo_name)? {
             cmd.env("AUTODEV_REPO_NAME", &repo_info.name);
-            // Derive repo root from workspace path
-            let ws = config::workspaces_path(env).join(config::sanitize_repo_name(&repo_info.name));
-            cmd.env("AUTODEV_REPO_ROOT", ws.to_string_lossy().as_ref());
+            cmd.env("AUTODEV_REPO_URL", &repo_info.url);
+            cmd.env("AUTODEV_REPO_ID", &repo_info.id);
+            let workspace =
+                config::workspaces_path(env).join(config::sanitize_repo_name(&repo_info.name));
+            cmd.env("AUTODEV_WORKSPACE", workspace.to_string_lossy().as_ref());
+            cmd.env(
+                "AUTODEV_REPO_ROOT",
+                workspace.join("main").to_string_lossy().as_ref(),
+            );
+            cmd.env("AUTODEV_REPO_DEFAULT_BRANCH", "main");
         }
     }
 

--- a/plugins/autodev/cli/src/cli/mod.rs
+++ b/plugins/autodev/cli/src/cli/mod.rs
@@ -201,7 +201,7 @@ pub fn repo_list(db: &Database) -> Result<String> {
 }
 
 /// 레포 상세 조회
-pub fn repo_show(db: &Database, name: &str, json: bool) -> Result<String> {
+pub fn repo_show(db: &Database, env: &dyn Env, name: &str, json: bool) -> Result<String> {
     let repos = db.repo_list()?;
     let repo = repos
         .iter()
@@ -209,11 +209,17 @@ pub fn repo_show(db: &Database, name: &str, json: bool) -> Result<String> {
         .ok_or_else(|| anyhow::anyhow!("repository not found: {name}"))?;
 
     if json {
-        let value = serde_json::json!({
+        let ws_dir = config::workspaces_path(env).join(config::sanitize_repo_name(name));
+        let effective = config::loader::load_merged(env, Some(&ws_dir));
+        let mut value = serde_json::json!({
             "name": repo.name,
             "url": repo.url,
             "enabled": repo.enabled,
         });
+        match serde_json::to_value(&effective) {
+            Ok(cfg_value) => value["config"] = cfg_value,
+            Err(e) => eprintln!("warning: failed to serialize config: {e}"),
+        }
         return Ok(serde_json::to_string_pretty(&value)?);
     }
 

--- a/plugins/autodev/cli/src/main.rs
+++ b/plugins/autodev/cli/src/main.rs
@@ -486,6 +486,9 @@ enum SpecAction {
         /// 스펙 본문
         #[arg(long)]
         body: Option<String>,
+        /// 스펙 본문을 파일에서 읽기
+        #[arg(long)]
+        file: Option<String>,
         /// 테스트 커맨드 (JSON 배열)
         #[arg(long)]
         test_commands: Option<String>,
@@ -690,7 +693,7 @@ async fn main() -> Result<()> {
                 println!("{list}");
             }
             RepoAction::Show { name, json } => {
-                let output = client::repo_show(&db, &name, json)?;
+                let output = client::repo_show(&db, &env, &name, json)?;
                 println!("{output}");
             }
             RepoAction::Config { name } => {
@@ -813,13 +816,21 @@ async fn main() -> Result<()> {
             SpecAction::Update {
                 id,
                 body,
+                file,
                 test_commands,
                 acceptance_criteria,
             } => {
+                let body_content = match (&body, &file) {
+                    (Some(_), Some(_)) => {
+                        anyhow::bail!("cannot specify both --body and --file");
+                    }
+                    (_, Some(path)) => Some(std::fs::read_to_string(path)?),
+                    (b, None) => b.clone(),
+                };
                 client::spec::spec_update(
                     &db,
                     &id,
-                    body.as_deref(),
+                    body_content.as_deref(),
                     test_commands.as_deref(),
                     acceptance_criteria.as_deref(),
                 )?;

--- a/plugins/autodev/cli/src/service/daemon/reply_scanner.rs
+++ b/plugins/autodev/cli/src/service/daemon/reply_scanner.rs
@@ -6,7 +6,7 @@
 use std::sync::Arc;
 
 use crate::core::models::*;
-use crate::core::repository::HitlRepository;
+use crate::core::repository::{CronRepository, HitlRepository};
 use crate::infra::db::Database;
 use crate::infra::gh::Gh;
 
@@ -23,6 +23,7 @@ const HITL_MARKER_PREFIX: &str = "<!-- autodev:hitl:";
 /// 5. Save as HITL response
 pub async fn scan_replies(db: &Database, gh: &Arc<dyn Gh>, gh_host: Option<&str>) -> Vec<String> {
     let mut responses = Vec::new();
+    let mut triggered_repo_ids = std::collections::HashSet::<String>::new();
 
     let pending = match db.hitl_list(None) {
         Ok(events) => events
@@ -88,6 +89,7 @@ pub async fn scan_replies(db: &Database, gh: &Arc<dyn Gh>, gh_host: Option<&str>
                 if let Err(e) = db.hitl_respond(&response) {
                     tracing::warn!("failed to save reply for HITL {}: {e}", event.id);
                 } else {
+                    triggered_repo_ids.insert(event.repo_id.clone());
                     responses.push(format!(
                         "HITL {} responded via GitHub comment by @{author}",
                         event.id
@@ -97,6 +99,11 @@ pub async fn scan_replies(db: &Database, gh: &Arc<dyn Gh>, gh_host: Option<&str>
                 break; // Only process first reply
             }
         }
+    }
+
+    // Force-trigger claw-evaluate once per repo (deduplicated)
+    for repo_id in &triggered_repo_ids {
+        let _ = db.cron_reset_last_run(crate::cli::cron::CLAW_EVALUATE_JOB, Some(repo_id));
     }
 
     responses


### PR DESCRIPTION
## Summary

- **#346** (bug, HIGH): `spec update`에 `--file` 플래그 추가 — `/update-spec` 플러그인 커맨드가 동작하도록 수정. `--body`와 상호배제 검증 포함
- **#347** (bug): CLI `cron trigger`의 `AUTODEV_CLAW_WORKSPACE` 경로를 `~/.autodev/workspaces/` → `~/.autodev/claw-workspace/`로 수정
- **#348** (bug): CLI `cron trigger` 환경변수를 daemon cron runner와 정렬 (`AUTODEV_REPO_URL`, `AUTODEV_WORKSPACE`, `AUTODEV_JOB_NAME`, `AUTODEV_JOB_ID`, `AUTODEV_REPO_DEFAULT_BRANCH` 추가)
- **#340** (feat): reply-scanner가 HITL 응답 감지 후 `claw-evaluate` cron을 즉시 트리거 (repo별 중복제거)
- **#350** (feat): `repo show --json` 출력에 effective merged config 포함

Closes #340, #346, #347, #348, #350

## Test plan

- [x] `cargo fmt --check` 통과
- [x] `cargo clippy -- -D warnings` 통과
- [x] `cargo test` 전체 통과 (332+ tests)
- [ ] `autodev spec update <id> --file spec.md` 실행하여 파일 내용 반영 확인
- [ ] `autodev cron trigger claw-evaluate --repo <name>` 후 환경변수 정상 주입 확인
- [ ] `autodev repo show <name> --json` 출력에 config 필드 포함 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)