### PR TITLE
refactor(autodev): improve git diff error context and logging

### DIFF
--- a/plugins/autodev/cli/src/cli/spec.rs
+++ b/plugins/autodev/cli/src/cli/spec.rs
@@ -517,8 +517,9 @@ fn collect_spec_files(
                         item.work_id.split(':').nth(1).unwrap_or(""),
                     );
                     let repo_dir = ws_root.join(&repo_name).join("main");
-                    if let Ok(diff_files) = git_diff_name_only(&repo_dir, &pr.head_branch) {
-                        files.extend(diff_files);
+                    match git_diff_name_only(&repo_dir, &pr.head_branch) {
+                        Ok(diff_files) => files.extend(diff_files),
+                        Err(e) => tracing::warn!("git diff skipped for {}: {e}", pr.head_branch),
                     }
                 }
             }
@@ -536,7 +537,13 @@ fn git_diff_name_only(repo_dir: &std::path::Path, branch: &str) -> Result<Vec<St
         .output()?;
 
     if !output.status.success() {
-        anyhow::bail!("git diff failed");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!(
+            "git diff failed in {} for branch {}: {}",
+            repo_dir.display(),
+            branch,
+            stderr.trim()
+        );
     }
 
     Ok(String::from_utf8_lossy(&output.stdout)


### PR DESCRIPTION
## Summary

- `git_diff_name_only` 에러 메시지에 repo 경로, 브랜치 이름, stderr 포함하여 디버깅 용이성 개선
- `collect_spec_files`에서 git diff 실패 시 silent skip 대신 `tracing::warn!` 로깅 추가

Partial fix for #336 (review finding: git diff 에러 메시지 부족)

> #336의 나머지 항목들은 이미 외부 변경으로 해결됨:
> - mention injection: `mention` 필드가 제거되어 해당 없음
> - orphan work_id 파싱: board.rs에서 orphan 섹션이 제거됨
> - empty reply: reply_scanner가 재구조화됨

## Test plan

- [x] `cargo fmt --check` 통과
- [x] `cargo clippy -- -D warnings` 통과
- [x] `cargo test` 전체 통과 (327+ tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)