### PR TITLE
fix(autodev): correct claw workspace template deployment and state names

### DIFF
--- a/plugins/autodev/cli/src/cli/claw.rs
+++ b/plugins/autodev/cli/src/cli/claw.rs
@@ -45,12 +45,14 @@ pub fn claw_init(home: &Path) -> Result<()> {
             TPL_DECOMPOSE_STRATEGY_MD,
         ),
         (".claude/rules/hitl-policy.md", TPL_HITL_POLICY_MD),
+        (".claude/rules/operations.md", TPL_OPERATIONS_MD),
         ("commands/status.md", DEFAULT_STATUS_MD),
         ("commands/board.md", DEFAULT_BOARD_MD),
         ("commands/hitl.md", DEFAULT_HITL_MD),
         ("commands/spec.md", DEFAULT_SPEC_MD),
         ("commands/repo.md", DEFAULT_REPO_MD),
         ("commands/decisions.md", DEFAULT_DECISIONS_MD),
+        ("commands/cron.md", DEFAULT_CRON_MD),
         ("skills/decompose/SKILL.md", TPL_DECOMPOSE_SKILL_MD),
         ("skills/gap-detect/SKILL.md", TPL_GAP_DETECT_SKILL_MD),
         ("skills/prioritize/SKILL.md", TPL_PRIORITIZE_SKILL_MD),
@@ -238,12 +240,16 @@ const TPL_DECOMPOSE_STRATEGY_MD: &str =
     include_str!("../../../templates/claw-workspace/.claude/rules/decompose-strategy.md");
 const TPL_HITL_POLICY_MD: &str =
     include_str!("../../../templates/claw-workspace/.claude/rules/hitl-policy.md");
+const TPL_OPERATIONS_MD: &str =
+    include_str!("../../../templates/claw-workspace/.claude/rules/operations.md");
 const TPL_DECOMPOSE_SKILL_MD: &str =
     include_str!("../../../templates/claw-workspace/skills/decompose/SKILL.md");
 const TPL_GAP_DETECT_SKILL_MD: &str =
     include_str!("../../../templates/claw-workspace/skills/gap-detect/SKILL.md");
 const TPL_PRIORITIZE_SKILL_MD: &str =
     include_str!("../../../templates/claw-workspace/skills/prioritize/SKILL.md");
+
+const DEFAULT_CRON_MD: &str = include_str!("../../../commands/cron.md");
 
 // ─── Hardcoded content (no template file) ───
 

--- a/plugins/autodev/templates/claw-workspace/.claude/rules/operations.md
+++ b/plugins/autodev/templates/claw-workspace/.claude/rules/operations.md
@@ -3,25 +3,25 @@
 ## 큐 상태 전이 흐름
 
 ```
-pending → in_progress → review → done
-                ↓          ↓
-              failed     failed
+Pending → Ready → Running → Done
+                      ↓
+                   Skipped
 ```
 
 ### 각 상태에서의 처리
 
 | 상태 | Claw 동작 |
 |------|----------|
-| pending | `autodev queue advance <work-id>` → in_progress로 전이 후 구현 시작 |
-| in_progress | 구현 완료 시 `autodev queue advance <work-id>` → review로 전이 |
-| review | 리뷰 통과 시 `autodev queue advance <work-id>` → done |
-| failed | 원인 분석 후 재시도 또는 HITL 에스컬레이션 |
-| done | 다음 큐 아이템 처리로 진행 |
+| Pending | 대기 중. `autodev queue advance <work-id>` → Ready로 전이 |
+| Ready | 실행 준비 완료. `autodev queue advance <work-id>` → Running으로 전이 후 구현 시작 |
+| Running | 구현/리뷰 진행 중. 완료 시 `autodev queue advance <work-id>` → Done |
+| Skipped | 건너뜀. 원인 분석 후 재시도 또는 HITL 에스컬레이션 |
+| Done | 다음 큐 아이템 처리로 진행 |
 
 ### 전이 전 확인 사항
 
 - advance 전에 `autodev queue show <work-id> --json`으로 현재 상태 확인
-- 이미 done/failed인 아이템은 advance 불가
+- 이미 Done/Skipped인 아이템은 advance 불가
 - skip은 `autodev queue skip <work-id> --reason "사유"` 사용
 
 ---


### PR DESCRIPTION
## Summary
- Fix queue state names in operations.md to match actual `QueuePhase` enum (`Pending`, `Ready`, `Running`, `Done`, `Skipped`)
- Include `operations.md` in `claw_init()` template deployment via `include_str!`
- Install `cron.md` slash command into claw-workspace on init

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (all tests green)
- [ ] Verify `autodev claw init` deploys operations.md and cron.md

Closes #365, Closes #356, Closes #359

🤖 Generated with [Claude Code](https://claude.com/claude-code)