### PR TITLE
feat(autodev): add queue show subcommand and status --json flag

### DIFF
--- a/plugins/autodev/cli/src/cli/mod.rs
+++ b/plugins/autodev/cli/src/cli/mod.rs
@@ -55,12 +55,31 @@ fn print_effective_config(env: &dyn Env, ws_dir: Option<&Path>, name: &str) -> R
 }
 
 /// 상태 요약
-pub fn status(db: &Database, env: &dyn Env) -> Result<String> {
+pub fn status(db: &Database, env: &dyn Env, json: bool) -> Result<String> {
+    let home = config::autodev_home(env);
+    let running = crate::service::daemon::pid::is_running(&home);
+    let rows = db.repo_status_summary()?;
+
+    if json {
+        let repos: Vec<serde_json::Value> = rows
+            .iter()
+            .map(|r| {
+                serde_json::json!({
+                    "name": r.name,
+                    "enabled": r.enabled,
+                })
+            })
+            .collect();
+        let value = serde_json::json!({
+            "daemon": if running { "running" } else { "stopped" },
+            "repositories": repos,
+        });
+        return Ok(serde_json::to_string_pretty(&value)?);
+    }
+
     let mut output = String::new();
 
     // 데몬 상태
-    let home = config::autodev_home(env);
-    let running = crate::service::daemon::pid::is_running(&home);
     output.push_str(&format!(
         "autodev daemon: {}\n\n",
         if running {
@@ -71,8 +90,6 @@ pub fn status(db: &Database, env: &dyn Env) -> Result<String> {
     ));
 
     // 레포 목록
-    let rows = db.repo_status_summary()?;
-
     output.push_str("Repositories:\n");
     if rows.is_empty() {
         output.push_str("  (no repositories registered)\n");

--- a/plugins/autodev/cli/src/cli/queue.rs
+++ b/plugins/autodev/cli/src/cli/queue.rs
@@ -140,6 +140,42 @@ fn check_review_overflow(
     }
 }
 
+/// 단일 큐 아이템 상세 조회
+pub fn queue_show(db: &Database, work_id: &str, json: bool) -> Result<String> {
+    let item = db
+        .queue_get_item(work_id)?
+        .ok_or_else(|| anyhow::anyhow!("queue item not found: {work_id}"))?;
+
+    if json {
+        return Ok(serde_json::to_string_pretty(&item)?);
+    }
+
+    let title = item.title.as_deref().unwrap_or("-");
+    let skip = item
+        .skip_reason
+        .as_ref()
+        .map(|r| format!("\nSkip reason: {r}"))
+        .unwrap_or_default();
+    let metadata = item.metadata_json.as_deref().unwrap_or("-");
+
+    Ok(format!(
+        "Work ID:    {}\nRepo ID:    {}\nType:       {}\nPhase:      {}\nTitle:      {}\nTask kind:  {}\nGH number:  #{}\nFailures:   {}\nEscalation: {}\nCreated:    {}\nUpdated:    {}\nMetadata:   {}{}\n",
+        item.work_id,
+        item.repo_id,
+        item.queue_type,
+        item.phase,
+        title,
+        item.task_kind,
+        item.github_number,
+        item.failure_count,
+        item.escalation_level,
+        item.created_at,
+        item.updated_at,
+        metadata,
+        skip,
+    ))
+}
+
 /// DB 기반 큐 아이템 목록 조회
 pub fn queue_list_db(
     db: &Database,

--- a/plugins/autodev/cli/src/main.rs
+++ b/plugins/autodev/cli/src/main.rs
@@ -38,7 +38,11 @@ enum Commands {
         daemon: bool,
     },
     /// 상태 요약 출력
-    Status,
+    Status {
+        /// JSON 출력
+        #[arg(long)]
+        json: bool,
+    },
     /// TUI 대시보드
     Dashboard,
     /// 레포 관리
@@ -237,6 +241,14 @@ enum QueueAction {
         /// skip 사유
         #[arg(long)]
         reason: Option<String>,
+    },
+    /// 큐 아이템 상세 조회
+    Show {
+        /// 작업 ID
+        work_id: String,
+        /// JSON 출력
+        #[arg(long)]
+        json: bool,
     },
 }
 
@@ -691,8 +703,8 @@ async fn main() -> Result<()> {
             daemon::stop(&home).ok();
             start_daemon(daemonize_flag, &cfg, &home, env, gh, git, claude, sw).await?;
         }
-        Commands::Status => {
-            let status = client::status(&db, &env)?;
+        Commands::Status { json } => {
+            let status = client::status(&db, &env, json)?;
             println!("{status}");
         }
         Commands::Dashboard => tui::run(&db).await?,
@@ -765,6 +777,10 @@ async fn main() -> Result<()> {
             }
             QueueAction::Skip { work_id, reason } => {
                 let output = client::queue::queue_skip(&db, &work_id, reason.as_deref())?;
+                println!("{output}");
+            }
+            QueueAction::Show { work_id, json } => {
+                let output = client::queue::queue_show(&db, &work_id, json)?;
                 println!("{output}");
             }
         },


### PR DESCRIPTION
## Summary
- Add `autodev queue show <work-id> [--json]` subcommand that exposes the existing `queue_get_item()` repository method via CLI, displaying detailed info for a single queue item
- Add `--json` flag to `autodev status` command for machine-readable JSON output containing daemon state and repository list

## Test plan
- [ ] Run `autodev queue show <work-id>` and verify human-readable detail output
- [ ] Run `autodev queue show <work-id> --json` and verify valid JSON output with all QueueItemRow fields
- [ ] Run `autodev queue show nonexistent-id` and verify error message
- [ ] Run `autodev status` and verify existing text output is unchanged
- [ ] Run `autodev status --json` and verify JSON output with `daemon` and `repositories` fields
- [ ] Verify `cargo fmt --check`, `cargo clippy -- -D warnings`, and `cargo test` all pass

Closes #357, Closes #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)