### PR TITLE
fix(autodev): add report daily CLI subcommand

### DIFF
--- a/plugins/autodev/cli/src/cli/mod.rs
+++ b/plugins/autodev/cli/src/cli/mod.rs
@@ -4,6 +4,7 @@ pub mod cron;
 pub mod decisions;
 pub mod hitl;
 pub mod queue;
+pub mod report;
 pub mod spec;
 pub mod worktree;
 

--- a/plugins/autodev/cli/src/cli/report.rs
+++ b/plugins/autodev/cli/src/cli/report.rs
@@ -1,0 +1,56 @@
+use anyhow::Result;
+
+use crate::core::config;
+use crate::core::config::Env;
+use crate::core::repository::RepoRepository;
+use crate::infra::db::Database;
+use crate::infra::gh::Gh;
+use crate::service::tasks::helpers::git_ops_factory::resolve_gh_host;
+use crate::service::tasks::knowledge::daily;
+
+/// Generate and post a daily report for the given date.
+///
+/// This is a standalone CLI entry point that reuses the daemon's daily report
+/// logic without requiring the full daemon infrastructure (Claude, Git, SuggestWorkflow).
+/// It parses the daemon log, builds a report with detected patterns, and posts
+/// a GitHub issue for each enabled repository.
+pub async fn daily(
+    db: &Database,
+    env: &dyn Env,
+    gh: &dyn Gh,
+    home: &std::path::Path,
+    date: &str,
+) -> Result<String> {
+    let cfg = config::loader::load_merged(env, None);
+    let log_dir = config::resolve_log_dir(&cfg.daemon.log_dir, home);
+    let log_path = log_dir.join(format!("daemon.{date}.log"));
+
+    if !log_path.exists() {
+        anyhow::bail!("log file not found: {}", log_path.display());
+    }
+
+    let stats = daily::parse_daemon_log(&log_path);
+    if stats.task_count == 0 {
+        return Ok(format!("skip: no tasks found in {date} log"));
+    }
+
+    let patterns = daily::detect_patterns(&stats);
+    let report = daily::build_daily_report(date, &stats, patterns);
+
+    let enabled = db.repo_find_enabled()?;
+    if enabled.is_empty() {
+        anyhow::bail!("no enabled repositories found");
+    }
+
+    let mut posted = 0u32;
+    for repo in &enabled {
+        let gh_host = resolve_gh_host(env, &repo.name);
+        daily::post_daily_report(gh, &repo.name, &report, gh_host.as_deref()).await;
+        posted += 1;
+    }
+
+    Ok(format!(
+        "daily report for {date}: {} tasks ({} issues, {} PRs, {} failed) — posted to {posted} repo(s)",
+        stats.task_count, stats.issues_done, stats.prs_done, stats.failed
+    ))
+}

--- a/plugins/autodev/cli/src/main.rs
+++ b/plugins/autodev/cli/src/main.rs
@@ -132,6 +132,21 @@ enum Commands {
         #[command(subcommand)]
         action: ConventionAction,
     },
+    /// 리포트 생성
+    Report {
+        #[command(subcommand)]
+        action: ReportAction,
+    },
+}
+
+#[derive(Subcommand)]
+enum ReportAction {
+    /// 일일 리포트 생성 및 GitHub 이슈 게시
+    Daily {
+        /// 대상 날짜 (YYYY-MM-DD)
+        #[arg(long)]
+        date: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1157,6 +1172,12 @@ async fn main() -> Result<()> {
                 }
             }
         }
+        Commands::Report { action } => match action {
+            ReportAction::Daily { date } => {
+                let output = client::report::daily(&db, &env, &gh, &home, &date).await?;
+                println!("{output}");
+            }
+        },
         Commands::Convention { action } => match action {
             ConventionAction::Detect { repo_path } => {
                 let path = std::path::Path::new(&repo_path);


### PR DESCRIPTION
## Summary
- Add `Report` subcommand with `Daily` sub-action to the CLI (`autodev report daily --date YYYY-MM-DD`)
- Reuses daemon's `parse_daemon_log`, `detect_patterns`, `build_daily_report`, and `post_daily_report` functions
- Fixes the missing CLI entry point that `templates/crons/daily-report.sh` depends on

## Test plan
- [ ] Verify `autodev report daily --help` shows the `--date` flag
- [ ] Run `autodev report daily --date 2026-03-19` with a valid daemon log to confirm report generation
- [ ] Run with a missing log file to confirm proper error message
- [ ] Run with an empty log (no tasks) to confirm skip message
- [ ] Verify `cargo fmt --check`, `cargo clippy -- -D warnings`, and `cargo test` all pass

Closes #364

🤖 Generated with [Claude Code](https://claude.com/claude-code)