### PR TITLE
refactor(autodev): address v0.32 review findings

### DIFF
--- a/plugins/autodev/cli/src/cli/cron.rs
+++ b/plugins/autodev/cli/src/cli/cron.rs
@@ -165,7 +165,8 @@ pub fn cron_trigger(db: &Database, env: &dyn Env, name: &str, repo: Option<&str>
                 "AUTODEV_REPO_ROOT",
                 workspace.join("main").to_string_lossy().as_ref(),
             );
-            cmd.env("AUTODEV_REPO_DEFAULT_BRANCH", "main");
+            let default_branch = detect_default_branch(&workspace);
+            cmd.env("AUTODEV_REPO_DEFAULT_BRANCH", &default_branch);
         }
     }
 
@@ -350,4 +351,47 @@ pub fn seed_global_crons(db: &Database, home: &std::path::Path) -> Result<u32> {
 fn find_repo_info(db: &Database, repo_name: &str) -> Result<Option<EnabledRepo>> {
     let repos = db.repo_find_enabled()?;
     Ok(repos.into_iter().find(|r| r.name == repo_name))
+}
+
+/// Detect the default branch for a repo workspace via `git symbolic-ref`.
+/// Falls back to "main" with a warning if detection fails.
+pub fn detect_default_branch(workspace: &std::path::Path) -> String {
+    let repo_dir = workspace.join("main");
+    let output = std::process::Command::new("git")
+        .args(["symbolic-ref", "refs/remotes/origin/HEAD", "--short"])
+        .current_dir(&repo_dir)
+        .output();
+
+    match output {
+        Ok(o) if o.status.success() => {
+            let full_ref = String::from_utf8_lossy(&o.stdout).trim().to_string();
+            let branch = full_ref
+                .strip_prefix("origin/")
+                .unwrap_or(&full_ref)
+                .to_string();
+            if branch.is_empty() {
+                tracing::warn!(
+                    "git symbolic-ref returned empty for {}, falling back to 'main'",
+                    repo_dir.display()
+                );
+                "main".to_string()
+            } else {
+                branch
+            }
+        }
+        Ok(_) => {
+            tracing::warn!(
+                "could not detect default branch for {}, falling back to 'main'",
+                repo_dir.display()
+            );
+            "main".to_string()
+        }
+        Err(e) => {
+            tracing::warn!(
+                "failed to run git symbolic-ref for {}: {e}, falling back to 'main'",
+                repo_dir.display()
+            );
+            "main".to_string()
+        }
+    }
 }

--- a/plugins/autodev/cli/src/cli/mod.rs
+++ b/plugins/autodev/cli/src/cli/mod.rs
@@ -317,7 +317,19 @@ pub fn repo_remove(db: &Database, env: &dyn Env, name: &str) -> Result<()> {
     db.repo_remove(name)?;
 
     // Clean up per-repo workspace directory (includes claw override)
-    let ws_dir = config::workspaces_path(env).join(config::sanitize_repo_name(name));
+    let workspaces = config::workspaces_path(env);
+    let ws_dir = workspaces.join(config::sanitize_repo_name(name));
+
+    // Safety: verify the path is actually under the expected workspaces directory
+    // before performing recursive deletion.
+    if !ws_dir.starts_with(&workspaces) {
+        anyhow::bail!(
+            "refusing to delete {}: not under workspaces directory {}",
+            ws_dir.display(),
+            workspaces.display()
+        );
+    }
+
     match std::fs::remove_dir_all(&ws_dir) {
         Ok(()) => {}
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}

--- a/plugins/autodev/cli/src/service/daemon/cron/runner.rs
+++ b/plugins/autodev/cli/src/service/daemon/cron/runner.rs
@@ -110,11 +110,9 @@ impl ScriptRunner {
                 "AUTODEV_REPO_ROOT".to_string(),
                 workspace.join("main").to_string_lossy().to_string(),
             );
-            // Default branch — convention: "main" (git default)
-            vars.insert(
-                "AUTODEV_REPO_DEFAULT_BRANCH".to_string(),
-                "main".to_string(),
-            );
+            // Default branch — detect from git, fall back to "main"
+            let default_branch = crate::cli::cron::detect_default_branch(&workspace);
+            vars.insert("AUTODEV_REPO_DEFAULT_BRANCH".to_string(), default_branch);
         }
 
         if let Some(ref repo_id) = job.repo_id {

--- a/plugins/autodev/cli/src/service/daemon/reply_scanner.rs
+++ b/plugins/autodev/cli/src/service/daemon/reply_scanner.rs
@@ -103,7 +103,9 @@ pub async fn scan_replies(db: &Database, gh: &Arc<dyn Gh>, gh_host: Option<&str>
 
     // Force-trigger claw-evaluate once per repo (deduplicated)
     for repo_id in &triggered_repo_ids {
-        let _ = db.cron_reset_last_run(crate::cli::cron::CLAW_EVALUATE_JOB, Some(repo_id));
+        if let Err(e) = db.cron_reset_last_run(crate::cli::cron::CLAW_EVALUATE_JOB, Some(repo_id)) {
+            tracing::warn!("failed to reset last_run for claw-evaluate (repo_id={repo_id}): {e}");
+        }
     }
 
     responses


### PR DESCRIPTION
## Summary
- **Default branch hardcoding**: Replace hardcoded `"main"` in `cron_trigger` (CLI) and `build_env_vars` (daemon runner) with `git symbolic-ref` detection, falling back to `"main"` with `tracing::warn`
- **cron_reset_last_run error silently ignored**: Add `tracing::warn!` in `reply_scanner.rs` when `cron_reset_last_run` fails instead of silently discarding the error
- **remove_dir_all path safety**: Verify the workspace path is under the expected workspaces directory before performing recursive deletion in `repo_remove`

## Test plan
- [ ] Verify `cargo fmt --check`, `cargo clippy -- -D warnings`, and `cargo test` all pass
- [ ] Confirm `cron trigger` with a repo that uses a non-main default branch picks up the correct branch
- [ ] Confirm `repo remove` with a path-traversal repo name is rejected
- [ ] Confirm reply scanner logs a warning when `cron_reset_last_run` fails

Closes #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)