### PR TITLE
refactor(autodev): address v0.30-v0.32 review findings

### DIFF
--- a/plugins/autodev/cli/Cargo.lock
+++ b/plugins/autodev/cli/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autodev"
-version = "0.30.0"
+version = "0.32.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/plugins/autodev/cli/src/core/repository.rs
+++ b/plugins/autodev/cli/src/core/repository.rs
@@ -45,6 +45,8 @@ pub trait SpecRepository {
     ) -> Result<()>;
     fn spec_set_status(&self, id: &str, status: SpecStatus) -> Result<()>;
     fn spec_issues(&self, spec_id: &str) -> Result<Vec<SpecIssue>>;
+    /// Fetch all spec-issue mappings in a single query, grouped by spec_id.
+    fn spec_issues_all(&self) -> Result<std::collections::HashMap<String, Vec<SpecIssue>>>;
     fn spec_issue_counts(&self) -> Result<std::collections::HashMap<String, usize>>;
     fn spec_link_issue(&self, spec_id: &str, issue_number: i64) -> Result<()>;
     fn spec_unlink_issue(&self, spec_id: &str, issue_number: i64) -> Result<()>;

--- a/plugins/autodev/cli/src/infra/db/repository.rs
+++ b/plugins/autodev/cli/src/infra/db/repository.rs
@@ -352,6 +352,28 @@ impl SpecRepository for Database {
         rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
     }
 
+    fn spec_issues_all(&self) -> Result<std::collections::HashMap<String, Vec<SpecIssue>>> {
+        let conn = self.conn();
+        let mut stmt = conn.prepare(
+            "SELECT spec_id, issue_number, created_at FROM spec_issues \
+             ORDER BY spec_id, issue_number",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            Ok(SpecIssue {
+                spec_id: row.get(0)?,
+                issue_number: row.get(1)?,
+                created_at: row.get(2)?,
+            })
+        })?;
+        let mut map: std::collections::HashMap<String, Vec<SpecIssue>> =
+            std::collections::HashMap::new();
+        for row in rows {
+            let si = row?;
+            map.entry(si.spec_id.clone()).or_default().push(si);
+        }
+        Ok(map)
+    }
+
     fn spec_issue_counts(&self) -> Result<std::collections::HashMap<String, usize>> {
         let conn = self.conn();
         let mut stmt =

--- a/plugins/autodev/cli/src/service/daemon/notifiers/github_comment.rs
+++ b/plugins/autodev/cli/src/service/daemon/notifiers/github_comment.rs
@@ -21,7 +21,26 @@ impl GitHubCommentNotifier {
         Self {
             gh,
             gh_host,
-            mention,
+            mention: mention
+                .map(|m| Self::sanitize_mention(&m))
+                .filter(|m| !m.is_empty()),
+        }
+    }
+
+    /// Sanitize a GitHub mention handle to prevent markdown injection.
+    ///
+    /// Only allows characters valid in GitHub usernames: alphanumeric, hyphens,
+    /// and underscores. Strips all other characters (newlines, spaces, etc.).
+    fn sanitize_mention(raw: &str) -> String {
+        let stripped = raw.strip_prefix('@').unwrap_or(raw);
+        let sanitized: String = stripped
+            .chars()
+            .filter(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '_')
+            .collect();
+        if sanitized.is_empty() {
+            String::new()
+        } else {
+            format!("@{sanitized}")
         }
     }
 
@@ -50,7 +69,7 @@ impl GitHubCommentNotifier {
 
         body.push_str("## \u{1f514} autodev: 사람 확인 필요\n\n");
         if let Some(ref mention) = self.mention {
-            body.push_str(&format!("cc {mention}\n\n"));
+            body.push_str(&format!("cc {mention}\n\n")); // mention is pre-sanitized in new()
         }
         body.push_str(&format!("**상황**: {}\n\n", event.situation));
         body.push_str(&format!("**분석**: {}\n\n", event.context));
@@ -175,6 +194,46 @@ mod tests {
         assert_eq!(comments[0].0, "org/repo");
         assert_eq!(comments[0].1, 42);
         assert!(comments[0].2.contains("CI failure detected"));
+    }
+
+    #[test]
+    fn sanitize_mention_valid_handle() {
+        assert_eq!(
+            GitHubCommentNotifier::sanitize_mention("alice-bob_123"),
+            "@alice-bob_123"
+        );
+    }
+
+    #[test]
+    fn sanitize_mention_strips_at_prefix() {
+        assert_eq!(GitHubCommentNotifier::sanitize_mention("@alice"), "@alice");
+    }
+
+    #[test]
+    fn sanitize_mention_strips_injection() {
+        // Newline injection attempt
+        assert_eq!(
+            GitHubCommentNotifier::sanitize_mention("@user\n\nMALICIOUS"),
+            "@userMALICIOUS"
+        );
+    }
+
+    #[test]
+    fn sanitize_mention_empty_after_strip() {
+        assert_eq!(GitHubCommentNotifier::sanitize_mention("@!!!"), "");
+    }
+
+    #[test]
+    fn mention_injection_rejected_in_constructor() {
+        let gh: Arc<dyn Gh> = Arc::new(MockGh::new());
+        let notifier =
+            GitHubCommentNotifier::new(gh, None, Some("@user\n\n## INJECTED HEADER".to_string()));
+        let event = make_event(Some("issue:org/repo:42"));
+        let body = notifier.format_comment(&event);
+        // The injected header must not appear
+        assert!(!body.contains("## INJECTED HEADER"));
+        // The sanitized mention should be present (only alphanumeric chars kept)
+        assert!(body.contains("cc @userINJECTEDHEADER"));
     }
 
     #[tokio::test]

--- a/plugins/autodev/cli/src/tui/board.rs
+++ b/plugins/autodev/cli/src/tui/board.rs
@@ -24,6 +24,7 @@ impl BoardStateBuilder {
         let all_repos = db.repo_find_enabled()?;
         let all_items = db.queue_list_items(repo_filter)?;
         let all_specs = db.spec_list(repo_filter)?;
+        let all_spec_issues = db.spec_issues_all()?;
 
         let mut board_repos = Vec::new();
 
@@ -55,7 +56,8 @@ impl BoardStateBuilder {
             // Build spec entries
             let mut spec_entries = Vec::new();
             for spec in &repo_specs {
-                let linked_issues = db.spec_issues(&spec.id)?;
+                let empty_vec = Vec::new();
+                let linked_issues = all_spec_issues.get(&spec.id).unwrap_or(&empty_vec);
                 let total = linked_issues.len();
                 let done_count = linked_issues
                     .iter()
@@ -99,7 +101,7 @@ impl BoardStateBuilder {
             // Orphan issues: queue items not linked to any spec
             let linked_issue_numbers: std::collections::HashSet<i64> = repo_specs
                 .iter()
-                .flat_map(|s| db.spec_issues(&s.id).unwrap_or_default())
+                .flat_map(|s| all_spec_issues.get(&s.id).cloned().unwrap_or_default())
                 .map(|si| si.issue_number)
                 .collect();
             let orphan_issues: Vec<BoardItem> = repo_items


### PR DESCRIPTION
## Summary

- **Mention injection (security):** Sanitize GitHub mention handles in `GitHubCommentNotifier::new()` to only allow alphanumeric, hyphens, and underscores — prevents markdown injection via newlines or special characters
- **N+1 query in board.rs:** Add `spec_issues_all()` batch method to `SpecRepository` trait and `Database` impl; `BoardStateBuilder` now fetches all spec-issue mappings in a single query instead of per-spec `db.spec_issues()` calls
- **Git diff error context:** Already addressed in commit 1e3b4d5 (prior PR #353), no additional changes needed

Closes #336

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` — all 337+ tests pass, including 5 new mention sanitization tests
- [ ] Verify board rendering still works correctly with batch-loaded spec issues
- [ ] Verify GitHub comment notifier rejects injection payloads in mention field

🤖 Generated with [Claude Code](https://claude.com/claude-code)