### PR TITLE
feat(autodev): add claw rules --json, spec decisions, and cron update --schedule

### DIFF
--- a/plugins/autodev/cli/src/cli/cron.rs
+++ b/plugins/autodev/cli/src/cli/cron.rs
@@ -103,10 +103,30 @@ pub fn cron_add(
     Ok(())
 }
 
-/// Update cron job interval
-pub fn cron_update(db: &Database, name: &str, repo: Option<&str>, interval: u64) -> Result<()> {
-    db.cron_update_interval(name, repo, interval)?;
-    println!("updated cron job: {name} (interval={interval}s)");
+/// Update cron job schedule (interval or cron expression)
+pub fn cron_update(
+    db: &Database,
+    name: &str,
+    repo: Option<&str>,
+    interval: Option<u64>,
+    schedule: Option<&str>,
+) -> Result<()> {
+    match (interval, schedule) {
+        (Some(secs), None) => {
+            db.cron_update_interval(name, repo, secs)?;
+            println!("updated cron job: {name} (interval={secs}s)");
+        }
+        (None, Some(expr)) => {
+            db.cron_update_schedule(name, repo, expr)?;
+            println!("updated cron job: {name} (schedule=\"{expr}\")");
+        }
+        (Some(_), Some(_)) => {
+            anyhow::bail!("specify either --interval or --schedule, not both");
+        }
+        (None, None) => {
+            anyhow::bail!("specify either --interval <secs> or --schedule \"<cron>\"");
+        }
+    }
     Ok(())
 }
 

--- a/plugins/autodev/cli/src/cli/spec.rs
+++ b/plugins/autodev/cli/src/cli/spec.rs
@@ -703,6 +703,41 @@ pub fn spec_status(db: &Database, id: &str, json: bool) -> Result<String> {
     Ok(output)
 }
 
+/// 스펙 관련 결정 이력 조회
+pub fn spec_decisions(db: &Database, spec_id: &str, limit: usize, json: bool) -> Result<String> {
+    // Verify spec exists
+    let _spec = db
+        .spec_show(spec_id)?
+        .ok_or_else(|| anyhow::anyhow!("spec not found: {spec_id}"))?;
+
+    let decisions = db.decision_list_by_spec(spec_id, limit)?;
+
+    if json {
+        return Ok(serde_json::to_string_pretty(&decisions)?);
+    }
+
+    let mut output = String::new();
+    if decisions.is_empty() {
+        output.push_str(&format!("No decisions found for spec {spec_id}.\n"));
+    } else {
+        output.push_str(&format!(
+            "Decisions for spec {spec_id} (showing up to {limit}):\n"
+        ));
+        for d in &decisions {
+            let target = d
+                .target_work_id
+                .as_deref()
+                .map(|w| format!(" target={w}"))
+                .unwrap_or_default();
+            output.push_str(&format!(
+                "  [{}] {} —{} {}\n",
+                d.decision_type, d.id, target, d.reasoning
+            ));
+        }
+    }
+    Ok(output)
+}
+
 /// 스펙의 repo에 대해 claw-evaluate를 즉시 트리거한다.
 pub fn spec_evaluate(db: &Database, id: &str) -> Result<String> {
     let spec = db

--- a/plugins/autodev/cli/src/core/repository.rs
+++ b/plugins/autodev/cli/src/core/repository.rs
@@ -120,6 +120,7 @@ pub trait CronRepository {
         repo: Option<&str>,
         interval_secs: u64,
     ) -> Result<()>;
+    fn cron_update_schedule(&self, name: &str, repo: Option<&str>, cron_expr: &str) -> Result<()>;
     fn cron_set_status(&self, name: &str, repo: Option<&str>, status: CronStatus) -> Result<()>;
     fn cron_remove(&self, name: &str, repo: Option<&str>) -> Result<()>;
     fn cron_update_last_run(&self, id: &str) -> Result<()>;

--- a/plugins/autodev/cli/src/infra/db/repository.rs
+++ b/plugins/autodev/cli/src/infra/db/repository.rs
@@ -1302,6 +1302,27 @@ impl CronRepository for Database {
         Ok(())
     }
 
+    fn cron_update_schedule(&self, name: &str, repo: Option<&str>, cron_expr: &str) -> Result<()> {
+        let conn = self.conn();
+        let rows_affected = if let Some(r) = repo {
+            conn.execute(
+                "UPDATE cron_jobs SET schedule_type = 'expression', schedule_value = ?1 \
+                 WHERE name = ?2 AND repo_id = (SELECT id FROM repositories WHERE name = ?3)",
+                rusqlite::params![cron_expr, name, r],
+            )?
+        } else {
+            conn.execute(
+                "UPDATE cron_jobs SET schedule_type = 'expression', schedule_value = ?1 \
+                 WHERE name = ?2 AND repo_id IS NULL",
+                rusqlite::params![cron_expr, name],
+            )?
+        };
+        if rows_affected == 0 {
+            anyhow::bail!("cron job not found: {name}");
+        }
+        Ok(())
+    }
+
     fn cron_set_status(&self, name: &str, repo: Option<&str>, status: CronStatus) -> Result<()> {
         let conn = self.conn();
         let status_str = status.to_string();

--- a/plugins/autodev/cli/src/main.rs
+++ b/plugins/autodev/cli/src/main.rs
@@ -194,6 +194,9 @@ enum ClawAction {
         /// 레포별 오버라이드 포함 (org/repo)
         #[arg(long)]
         repo: Option<String>,
+        /// JSON 출력
+        #[arg(long)]
+        json: bool,
     },
     /// 규칙/스킬 편집
     Edit {
@@ -309,7 +312,7 @@ enum CronAction {
         #[arg(long)]
         schedule: Option<String>,
     },
-    /// 크론 잡 간격 업데이트
+    /// 크론 잡 스케줄 업데이트
     Update {
         /// 잡 이름
         name: String,
@@ -318,7 +321,10 @@ enum CronAction {
         repo: Option<String>,
         /// 새 실행 간격 (초)
         #[arg(long)]
-        interval: u64,
+        interval: Option<u64>,
+        /// 크론 표현식
+        #[arg(long, conflicts_with = "interval")]
+        schedule: Option<String>,
     },
     /// 크론 잡 일시 정지
     Pause {
@@ -549,6 +555,17 @@ enum SpecAction {
     Evaluate {
         /// 스펙 ID
         id: String,
+    },
+    /// 스펙 관련 결정 이력 조회
+    Decisions {
+        /// 스펙 ID
+        spec_id: String,
+        /// JSON 출력
+        #[arg(long)]
+        json: bool,
+        /// 최근 N개 항목
+        #[arg(short = 'n', long, default_value = "20")]
+        limit: usize,
     },
 }
 
@@ -885,6 +902,14 @@ async fn main() -> Result<()> {
                 let output = client::spec::spec_evaluate(&db, &id)?;
                 println!("{output}");
             }
+            SpecAction::Decisions {
+                spec_id,
+                json,
+                limit,
+            } => {
+                let output = client::spec::spec_decisions(&db, &spec_id, limit, json)?;
+                println!("{output}");
+            }
         },
         Commands::Hitl { action } => match action {
             HitlAction::List { repo, json } => {
@@ -995,8 +1020,15 @@ async fn main() -> Result<()> {
                 name,
                 repo,
                 interval,
+                schedule,
             } => {
-                client::cron::cron_update(&db, &name, repo.as_deref(), interval)?;
+                client::cron::cron_update(
+                    &db,
+                    &name,
+                    repo.as_deref(),
+                    interval,
+                    schedule.as_deref(),
+                )?;
             }
             CronAction::Pause { name, repo } => {
                 client::cron::cron_pause(&db, &name, repo.as_deref())?;
@@ -1020,10 +1052,15 @@ async fn main() -> Result<()> {
                     client::claw::claw_init(&home)?;
                 }
             }
-            ClawAction::Rules { repo } => {
+            ClawAction::Rules { repo, json } => {
                 let rules = client::claw::claw_rules(&home, repo.as_deref())?;
-                for rule in &rules {
-                    println!("  {rule}");
+                if json {
+                    let json_str = serde_json::to_string_pretty(&rules)?;
+                    println!("{json_str}");
+                } else {
+                    for rule in &rules {
+                        println!("  {rule}");
+                    }
                 }
             }
             ClawAction::Edit { name, repo } => {


### PR DESCRIPTION
## Summary
- **claw rules --json** (#361): Add `--json` flag to `autodev claw rules` subcommand that outputs the rules list as a JSON array
- **spec decisions** (#360): Add `autodev spec decisions <spec_id> [--json] [-n <limit>]` subcommand that lists claw decisions associated with a spec via `decision_list_by_spec()`
- **cron update --schedule** (#363): Add `--schedule` flag to `autodev cron update` that accepts a cron expression string, mutually exclusive with `--interval` (enforced via clap `conflicts_with`)

## Test plan
- [ ] Verify `autodev claw rules --json` outputs a JSON array of rule strings
- [ ] Verify `autodev claw rules` (without --json) still outputs plain text
- [ ] Verify `autodev spec decisions <id> --json` outputs JSON array of decisions
- [ ] Verify `autodev spec decisions <id>` outputs human-readable list
- [ ] Verify `autodev cron update <name> --schedule "0 6 * * *"` updates schedule to expression type
- [ ] Verify `autodev cron update <name> --interval 300` still works for interval updates
- [ ] Verify `autodev cron update <name> --interval 300 --schedule "..."` fails with mutual exclusion error
- [ ] Verify `autodev cron update <name>` (no flags) fails with helpful error

Closes #361, Closes #360, Closes #363

🤖 Generated with [Claude Code](https://claude.com/claude-code)