### PR TITLE
feat(autodev): add spec auto-completion trigger on task completion

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"a513a6a7-10f8-4ef0-b1d3-00545579a16f","pid":39536,"acquiredAt":1773934832684}

--- a/plugins/autodev/cli/Cargo.lock
+++ b/plugins/autodev/cli/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autodev"
-version = "0.32.2"
+version = "0.35.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/plugins/autodev/cli/src/cli/spec.rs
+++ b/plugins/autodev/cli/src/cli/spec.rs
@@ -891,6 +891,85 @@ pub fn spec_decisions(db: &Database, spec_id: &str, limit: usize, json: bool) ->
     Ok(output)
 }
 
+/// Check all active specs and auto-trigger completion for those whose linked issues are all done.
+///
+/// Returns a list of (spec_id, NewHitlEvent) for each spec that was transitioned to Completing.
+/// Errors on individual specs are logged and skipped.
+pub fn check_completable_specs(
+    db: &Database,
+    env: &dyn crate::core::config::Env,
+) -> Vec<(String, NewHitlEvent)> {
+    let active_specs = match db.spec_list_by_status(SpecStatus::Active) {
+        Ok(specs) => specs,
+        Err(e) => {
+            tracing::warn!("check_completable_specs: failed to list active specs: {e}");
+            return Vec::new();
+        }
+    };
+
+    let queue_items = match db.queue_list_items(None) {
+        Ok(items) => items,
+        Err(e) => {
+            tracing::warn!("check_completable_specs: failed to list queue items: {e}");
+            return Vec::new();
+        }
+    };
+
+    let mut triggered = Vec::new();
+
+    for spec in &active_specs {
+        let issues = match db.spec_issues(&spec.id) {
+            Ok(issues) => issues,
+            Err(e) => {
+                tracing::warn!(
+                    "check_completable_specs: failed to load issues for spec {}: {e}",
+                    spec.id
+                );
+                continue;
+            }
+        };
+
+        // Skip specs with no linked issues
+        if issues.is_empty() {
+            continue;
+        }
+
+        // Check if ALL linked issues are done or skipped in the queue
+        let all_done = issues.iter().all(|issue| {
+            let matching_item = queue_items.iter().find(|q| {
+                q.work_id.ends_with(&format!(":{}", issue.issue_number))
+                    && q.work_id.starts_with("issue:")
+            });
+            match matching_item {
+                Some(item) => item.phase == QueuePhase::Done || item.skip_reason.is_some(),
+                None => false, // Not in queue yet = not done
+            }
+        });
+
+        if all_done {
+            tracing::info!(
+                "spec auto-completion: all issues done for spec {} ('{}')",
+                spec.id,
+                spec.title
+            );
+            match spec_check_completion(db, env, &spec.id) {
+                Ok((_output, hitl_event)) => {
+                    tracing::info!("spec auto-completion: triggered HITL for spec {}", spec.id);
+                    triggered.push((spec.id.clone(), hitl_event));
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "spec auto-completion: failed to trigger completion for spec {}: {e}",
+                        spec.id
+                    );
+                }
+            }
+        }
+    }
+
+    triggered
+}
+
 /// 스펙의 repo에 대해 claw-evaluate를 즉시 트리거한다.
 pub fn spec_evaluate(db: &Database, id: &str) -> Result<String> {
     let spec = db

--- a/plugins/autodev/cli/src/service/daemon/mod.rs
+++ b/plugins/autodev/cli/src/service/daemon/mod.rs
@@ -254,6 +254,19 @@ impl Daemon {
                             if let Some(ref cron) = self.cron_engine {
                                 cron.force_trigger(crate::cli::cron::CLAW_EVALUATE_JOB);
                             }
+
+                            // Auto-check spec completion on successful task completion
+                            if let TaskStatus::Completed = task_result.status {
+                                let env = crate::core::config::RealEnv;
+                                let completable =
+                                    crate::cli::spec::check_completable_specs(&self.log_db, &env);
+                                for (spec_id, hitl_event) in &completable {
+                                    info!("spec auto-completion triggered for {spec_id}");
+                                    let notif =
+                                        NotificationEvent::from_hitl_created(hitl_event);
+                                    dispatch_notification(&self.notifier, &notif).await;
+                                }
+                            }
                         }
                         Err(e) => {
                             tracing::error!("spawned task panicked: {e}");


### PR DESCRIPTION
## Summary
- Add `check_completable_specs(db)` function that scans all active specs, checks if their linked issues are all done/skipped in the queue, and auto-triggers `spec_check_completion()` to create a HITL event for human confirmation
- Call this function from the daemon's task completion handler (only on successful completion) for efficient event-driven triggering
- Dispatch notifications for any auto-created HITL events

## Test plan
- [ ] Verify `cargo fmt --check`, `cargo clippy -- -D warnings`, and `cargo test` all pass
- [ ] Create a spec with linked issues, complete all issues, and confirm HITL event is auto-created
- [ ] Verify specs with no linked issues are skipped
- [ ] Verify specs with partially-done issues are not triggered
- [ ] Verify failed tasks do not trigger the auto-completion check

Closes #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)