### PR TITLE
feat(autodev): implement deterministic auto-approve for analyzed issues

### DIFF
--- a/plugins/autodev/cli/Cargo.lock
+++ b/plugins/autodev/cli/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autodev"
-version = "0.32.2"
+version = "0.35.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -637,9 +637,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
@@ -1900,18 +1900,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.42"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.42"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/plugins/autodev/cli/src/service/tasks/analyze.rs
+++ b/plugins/autodev/cli/src/service/tasks/analyze.rs
@@ -193,7 +193,69 @@ impl AnalyzeTask {
             return vec![QueueOp::Remove];
         }
 
-        // implement verdict → analyzed 라벨 (HITL 게이트)
+        // auto-approve: confidence가 임계값 이상이면 자동으로 구현 단계로 진행
+        if auto_approve && analysis.confidence >= auto_approve_threshold {
+            let comment = verdict::format_auto_approved_comment(analysis);
+            self.gh
+                .issue_comment(
+                    &self.item.repo_name,
+                    self.item.github_number,
+                    &comment,
+                    gh_host,
+                )
+                .await;
+
+            // add-first: implementing 라벨 추가 후 WIP 제거
+            self.gh
+                .label_add(
+                    &self.item.repo_name,
+                    self.item.github_number,
+                    labels::IMPLEMENTING,
+                    gh_host,
+                )
+                .await;
+            self.gh
+                .label_remove(
+                    &self.item.repo_name,
+                    self.item.github_number,
+                    labels::WIP,
+                    gh_host,
+                )
+                .await;
+
+            tracing::info!(
+                "issue #{}: auto-approved (confidence={:.2} >= threshold={:.2}), advancing to implement",
+                self.item.github_number,
+                analysis.confidence,
+                auto_approve_threshold,
+            );
+
+            // 직접 implement 큐에 추가하여 label-scan 대기 없이 즉시 진행
+            let repo_ref = crate::core::queue_item::RepoRef {
+                id: self.item.repo_id.clone(),
+                name: self.item.repo_name.clone(),
+                url: self.item.repo_url.clone(),
+                gh_host: self.item.gh_host.clone(),
+            };
+            let implement_item = QueueItem::new_issue(
+                &repo_ref,
+                self.item.github_number,
+                crate::core::phase::TaskKind::Implement,
+                self.item.title.clone(),
+                self.item.body().map(|s| s.to_string()),
+                self.item.labels().unwrap_or_default().to_vec(),
+                self.item.author().unwrap_or_default().to_string(),
+            );
+            return vec![
+                QueueOp::Remove,
+                QueueOp::Push {
+                    phase: crate::core::models::QueuePhase::Pending,
+                    item: Box::new(implement_item),
+                },
+            ];
+        }
+
+        // auto-approve 미충족 → analyzed 라벨 (HITL 게이트, 사람 리뷰 대기)
         let comment = verdict::format_analysis_comment(analysis);
         self.gh
             .issue_comment(
@@ -220,29 +282,11 @@ impl AnalyzeTask {
             )
             .await;
 
-        // auto-approve: confidence가 임계값 이상이면 approved-analysis 라벨도 추가
-        if auto_approve && analysis.confidence >= auto_approve_threshold {
-            self.gh
-                .label_add(
-                    &self.item.repo_name,
-                    self.item.github_number,
-                    labels::APPROVED_ANALYSIS,
-                    gh_host,
-                )
-                .await;
-            tracing::info!(
-                "issue #{}: auto-approved (confidence={:.2} >= threshold={:.2})",
-                self.item.github_number,
-                analysis.confidence,
-                auto_approve_threshold,
-            );
-        } else {
-            tracing::info!(
-                "issue #{}: Analyzing → analyzed (awaiting human review, confidence={:.2})",
-                self.item.github_number,
-                analysis.confidence
-            );
-        }
+        tracing::info!(
+            "issue #{}: Analyzing → analyzed (awaiting human review, confidence={:.2})",
+            self.item.github_number,
+            analysis.confidence
+        );
         vec![QueueOp::Remove]
     }
 
@@ -504,6 +548,7 @@ mod tests {
     use std::time::Duration;
 
     use crate::core::config::models::WorkflowConfig;
+    use crate::core::models::QueuePhase;
     use crate::core::phase::TaskKind;
     use crate::core::queue_item::testing::test_repo;
     use crate::infra::gh::mock::MockGh;
@@ -928,7 +973,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn after_auto_approve_adds_approved_label() {
+    async fn after_auto_approve_adds_implementing_and_pushes_to_implement() {
         let gh = Arc::new(MockGh::new());
         gh.set_field("org/repo", "issues/42", ".state", "open");
 
@@ -944,9 +989,25 @@ mod tests {
         let result = task.after_invoke(make_implement_response()).await;
 
         assert!(matches!(result.status, TaskStatus::Completed));
+
+        // implementing 라벨 추가, analyzed/approved-analysis 라벨 아님
         let added = gh.added_labels.lock().unwrap();
-        assert!(added.iter().any(|(_, _, l)| l == labels::ANALYZED));
-        assert!(added.iter().any(|(_, _, l)| l == labels::APPROVED_ANALYSIS));
+        assert!(added.iter().any(|(_, _, l)| l == labels::IMPLEMENTING));
+        assert!(!added.iter().any(|(_, _, l)| l == labels::ANALYZED));
+        assert!(!added.iter().any(|(_, _, l)| l == labels::APPROVED_ANALYSIS));
+
+        // WIP 라벨 제거
+        let removed = gh.removed_labels.lock().unwrap();
+        assert!(removed.iter().any(|(_, _, l)| l == labels::WIP));
+
+        // auto-approved 코멘트 포함
+        let comments = gh.posted_comments.lock().unwrap();
+        assert!(comments[0].2.contains("Auto-approved"));
+
+        // implement 큐에 Push 됨
+        assert!(result.queue_ops.iter().any(
+            |op| matches!(op, QueueOp::Push { phase, item } if *phase == QueuePhase::Pending && item.task_kind == TaskKind::Implement)
+        ));
     }
 
     #[tokio::test]
@@ -967,7 +1028,12 @@ mod tests {
         assert!(matches!(result.status, TaskStatus::Completed));
         let added = gh.added_labels.lock().unwrap();
         assert!(added.iter().any(|(_, _, l)| l == labels::ANALYZED));
-        assert!(!added.iter().any(|(_, _, l)| l == labels::APPROVED_ANALYSIS));
+        assert!(!added.iter().any(|(_, _, l)| l == labels::IMPLEMENTING));
+        // No Push to implement queue
+        assert!(!result
+            .queue_ops
+            .iter()
+            .any(|op| matches!(op, QueueOp::Push { .. })));
     }
 
     #[tokio::test]
@@ -988,7 +1054,12 @@ mod tests {
         assert!(matches!(result.status, TaskStatus::Completed));
         let added = gh.added_labels.lock().unwrap();
         assert!(added.iter().any(|(_, _, l)| l == labels::ANALYZED));
-        assert!(!added.iter().any(|(_, _, l)| l == labels::APPROVED_ANALYSIS));
+        assert!(!added.iter().any(|(_, _, l)| l == labels::IMPLEMENTING));
+        // No Push to implement queue
+        assert!(!result
+            .queue_ops
+            .iter()
+            .any(|op| matches!(op, QueueOp::Push { .. })));
     }
 
     #[tokio::test]

--- a/plugins/autodev/cli/src/service/tasks/helpers/verdict.rs
+++ b/plugins/autodev/cli/src/service/tasks/helpers/verdict.rs
@@ -74,6 +74,40 @@ pub fn format_analysis_comment(a: &AnalysisResult) -> String {
     comment
 }
 
+/// auto-approve 된 분석 리포트를 이슈 코멘트로 포맷
+///
+/// `format_analysis_comment`와 동일한 마커/헤더를 사용하되,
+/// 사람 승인 대신 자동 승인 안내를 표시한다.
+pub fn format_auto_approved_comment(a: &AnalysisResult) -> String {
+    let mut comment = format!(
+        "<!-- autodev:analysis -->\n\
+         ## 🤖 Autodev Analysis Report\n\n\
+         **Verdict**: `{}` | **Confidence**: {:.0}%\n\n\
+         ✅ **Auto-approved** — confidence meets threshold. Proceeding to implementation.\n\n\
+         <details>\n<summary>Analysis Report</summary>\n\n\
+         {}\n\
+         </details>",
+        a.verdict,
+        a.confidence * 100.0,
+        a.report
+    );
+
+    if !a.related_issues.is_empty() {
+        comment.push_str("\n\n### Related Issues\n\n| # | Relation | Confidence | Summary |\n|---|----------|------------|---------|");
+        for ri in &a.related_issues {
+            comment.push_str(&format!(
+                "\n| #{} | {} | {:.0}% | {} |",
+                ri.number,
+                ri.relation,
+                ri.confidence * 100.0,
+                ri.summary
+            ));
+        }
+    }
+
+    comment
+}
+
 /// 파싱 실패 시 raw report를 분석 코멘트로 포맷
 ///
 /// `format_analysis_comment`와 동일한 마커/헤더/푸터를 사용하여 일관성을 유지한다.
@@ -192,5 +226,25 @@ mod tests {
         };
         let comment = format_analysis_comment(&a);
         assert!(!comment.contains("Related Issues"));
+    }
+
+    #[test]
+    fn format_auto_approved_comment_contains_marker_and_auto_approved() {
+        let a = AnalysisResult {
+            verdict: Verdict::Implement,
+            confidence: 0.92,
+            summary: "Clear issue".to_string(),
+            questions: vec![],
+            reason: None,
+            report: "Affected files: src/main.rs".to_string(),
+            related_issues: vec![],
+        };
+        let comment = format_auto_approved_comment(&a);
+        assert!(comment.contains("<!-- autodev:analysis -->"));
+        assert!(comment.contains("Auto-approved"));
+        assert!(comment.contains("92%"));
+        assert!(comment.contains("src/main.rs"));
+        // Should NOT contain manual approval instructions
+        assert!(!comment.contains("autodev:approved-analysis"));
     }
 }


### PR DESCRIPTION
## Summary
- Add auto-approve logic to `AnalyzeTask.handle_analysis()` that checks `auto_approve` and `auto_approve_threshold` config
- When enabled and confidence >= threshold, issues advance directly to implement phase (skip HITL gate)
- When disabled or below threshold, existing behavior preserved (analyzed label + HITL wait)
- Add `format_auto_approved_comment()` to verdict helpers
- Add 3 tests: auto-approve enabled, disabled, below threshold

## Test plan
- [ ] Verify `cargo test` passes (all 335 tests)
- [ ] Verify auto-approve path adds `implementing` label and pushes to implement queue
- [ ] Verify auto-approve disabled path adds `analyzed` label (existing behavior)

Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)