### PR TITLE
feat(autodev): collect feedback patterns from PR review comments

### DIFF
--- a/plugins/autodev/cli/src/cli/convention.rs
+++ b/plugins/autodev/cli/src/cli/convention.rs
@@ -930,6 +930,182 @@ pub fn collect_feedback_from_hitl(
     Ok(())
 }
 
+// ─── Feedback Collection from PR Reviews ───
+
+/// A single PR review comment extracted from the GitHub API response.
+#[derive(Debug)]
+struct PrReviewComment {
+    pub body: String,
+}
+
+/// Parse PR review comments from the raw JSON returned by `gh api --paginate`.
+///
+/// The GitHub API returns an array of review objects. Each review has a `body`
+/// field (the top-level review comment). We extract non-empty body fields.
+fn parse_review_comments(raw_json: &[u8]) -> Vec<PrReviewComment> {
+    let mut comments = Vec::new();
+
+    let Ok(parsed) = serde_json::from_slice::<serde_json::Value>(raw_json) else {
+        return comments;
+    };
+
+    // Handle both a single JSON array and concatenated arrays (from --paginate)
+    let items = match &parsed {
+        serde_json::Value::Array(arr) => arr.clone(),
+        _ => vec![parsed],
+    };
+
+    for item in &items {
+        if let Some(body) = item.get("body").and_then(|b| b.as_str()) {
+            let trimmed = body.trim();
+            if !trimmed.is_empty() {
+                comments.push(PrReviewComment {
+                    body: trimmed.to_string(),
+                });
+            }
+        }
+    }
+
+    comments
+}
+
+/// Classify a PR review comment body into a pattern type.
+///
+/// Extends `classify_pattern_type` with additional keywords commonly found
+/// in PR review comments (e.g., naming, documentation).
+pub fn classify_review_comment(body: &str) -> &'static str {
+    let lower = body.to_lowercase();
+
+    // Naming conventions
+    if lower.contains("naming")
+        || lower.contains("rename")
+        || lower.contains("variable name")
+        || lower.contains("snake_case")
+        || lower.contains("camelcase")
+    {
+        return "style";
+    }
+
+    // Documentation
+    if lower.contains("document")
+        || lower.contains("rustdoc")
+        || lower.contains("jsdoc")
+        || lower.contains("docstring")
+    {
+        return "style";
+    }
+
+    // Fall back to the existing classifier
+    classify_pattern_type(body)
+}
+
+/// Group review comments by their classified pattern type.
+/// Comments with the same pattern type are deduplicated by content.
+fn group_comments_by_theme(
+    comments: &[PrReviewComment],
+) -> std::collections::HashMap<String, Vec<String>> {
+    let mut groups: std::collections::HashMap<String, Vec<String>> =
+        std::collections::HashMap::new();
+
+    for comment in comments {
+        let pattern_type = classify_review_comment(&comment.body).to_string();
+        let suggestions = groups.entry(pattern_type).or_default();
+
+        // Deduplicate: skip if an identical suggestion already exists
+        if !suggestions.iter().any(|s| s == &comment.body) {
+            suggestions.push(comment.body.clone());
+        }
+    }
+
+    groups
+}
+
+/// Collect feedback patterns from PR review comments for a given repo.
+///
+/// Fetches recently closed PRs, then fetches review comments for each PR.
+/// Groups comments by theme/pattern and stores detected patterns in the
+/// `feedback_patterns` table.
+///
+/// Uses cursor-based pagination via `api_paginate` and batches requests
+/// to be mindful of API rate limits (max 30 recent PRs per run).
+///
+/// `repo_name` is the GitHub slug (e.g. "org/repo").
+/// `repo_id` is the internal UUID for feedback pattern storage.
+/// `gh_host` is an optional GitHub Enterprise hostname.
+pub async fn collect_feedback_from_pr_reviews(
+    db: &Database,
+    gh: &dyn crate::infra::gh::Gh,
+    repo_name: &str,
+    repo_id: &str,
+    gh_host: Option<&str>,
+) -> Result<String> {
+    // Fetch recently closed/merged PRs (limit to 30 to respect rate limits)
+    let pulls_json = gh
+        .api_paginate(
+            repo_name,
+            "pulls",
+            &[
+                ("state", "closed"),
+                ("sort", "updated"),
+                ("direction", "desc"),
+                ("per_page", "30"),
+            ],
+            gh_host,
+        )
+        .await?;
+
+    let pulls: Vec<serde_json::Value> = match serde_json::from_slice(&pulls_json) {
+        Ok(serde_json::Value::Array(arr)) => arr,
+        _ => return Ok("No closed PRs found.\n".to_string()),
+    };
+
+    let mut total_comments = 0u32;
+    let mut total_patterns = 0u32;
+
+    for pull in &pulls {
+        let Some(pr_number) = pull.get("number").and_then(|n| n.as_i64()) else {
+            continue;
+        };
+
+        // Fetch review comments for this PR
+        let reviews_json = match gh
+            .api_paginate(
+                repo_name,
+                &format!("pulls/{pr_number}/reviews"),
+                &[("per_page", "100")],
+                gh_host,
+            )
+            .await
+        {
+            Ok(data) => data,
+            Err(_) => continue, // Skip on API error (rate limit, etc.)
+        };
+
+        let comments = parse_review_comments(&reviews_json);
+        total_comments += comments.len() as u32;
+
+        let groups = group_comments_by_theme(&comments);
+
+        for (pattern_type, suggestions) in &groups {
+            for suggestion in suggestions {
+                let pattern = crate::core::models::NewFeedbackPattern {
+                    repo_id: repo_id.to_string(),
+                    pattern_type: pattern_type.clone(),
+                    suggestion: suggestion.clone(),
+                    source: "pr-review".to_string(),
+                };
+                db.feedback_upsert(&pattern)?;
+                total_patterns += 1;
+            }
+        }
+    }
+
+    Ok(format!(
+        "Collected {total_patterns} feedback pattern(s) from {total_comments} PR review comment(s) across {} PR(s)\n",
+        pulls.len()
+    ))
+}
+
 // ─── Convention Update Proposal ───
 
 /// Map pattern_type to a convention rule file path.

--- a/plugins/autodev/cli/src/main.rs
+++ b/plugins/autodev/cli/src/main.rs
@@ -1237,6 +1237,16 @@ async fn main() -> Result<()> {
                 let repo_id = client::resolve_repo_id(&db, &repo)?;
                 let output = client::convention::collect_feedback(&db, &repo, &repo_id)?;
                 print!("{output}");
+
+                // Also collect from PR review comments
+                let gh: std::sync::Arc<dyn autodev::infra::gh::Gh> =
+                    std::sync::Arc::new(autodev::infra::gh::RealGh);
+                let gh_host = cfg.sources.github.gh_host.as_deref();
+                let pr_output = client::convention::collect_feedback_from_pr_reviews(
+                    &db, &*gh, &repo, &repo_id, gh_host,
+                )
+                .await?;
+                print!("{pr_output}");
             }
             ConventionAction::Propose { repo, threshold } => {
                 let repo_id = client::resolve_repo_id(&db, &repo)?;

--- a/plugins/autodev/cli/tests/feedback_pattern_tests.rs
+++ b/plugins/autodev/cli/tests/feedback_pattern_tests.rs
@@ -610,3 +610,231 @@ fn propose_updates_idempotent() {
     let result2 = autodev::cli::convention::propose_updates(&db, &repo_id, 3).unwrap();
     assert!(result2.output.contains("No actionable patterns found."));
 }
+
+// ═══════════════════════════════════════════════
+// 25. classify_review_comment detects naming patterns
+// ═══════════════════════════════════════════════
+
+#[test]
+fn classify_review_comment_naming() {
+    use autodev::cli::convention::classify_review_comment;
+    assert_eq!(
+        classify_review_comment("Please rename this variable"),
+        "style"
+    );
+    assert_eq!(
+        classify_review_comment("Use snake_case for fields"),
+        "style"
+    );
+    assert_eq!(classify_review_comment("Naming convention issue"), "style");
+}
+
+// ═══════════════════════════════════════════════
+// 26. classify_review_comment detects documentation patterns
+// ═══════════════════════════════════════════════
+
+#[test]
+fn classify_review_comment_documentation() {
+    use autodev::cli::convention::classify_review_comment;
+    assert_eq!(
+        classify_review_comment("Add rustdoc for this function"),
+        "style"
+    );
+    assert_eq!(classify_review_comment("Missing docstring here"), "style");
+    assert_eq!(
+        classify_review_comment("Please document this module"),
+        "style"
+    );
+}
+
+// ═══════════════════════════════════════════════
+// 27. classify_review_comment falls back to classify_pattern_type
+// ═══════════════════════════════════════════════
+
+#[test]
+fn classify_review_comment_fallback() {
+    use autodev::cli::convention::classify_review_comment;
+    // Should fall back to classify_pattern_type behavior
+    assert_eq!(classify_review_comment("Add unit test for this"), "testing");
+    assert_eq!(
+        classify_review_comment("Handle the error case"),
+        "error-handling"
+    );
+    assert_eq!(classify_review_comment("Something generic"), "general");
+}
+
+// ═══════════════════════════════════════════════
+// 28. collect_feedback_from_pr_reviews with mock Gh
+// ═══════════════════════════════════════════════
+
+#[tokio::test]
+async fn collect_feedback_from_pr_reviews_processes_comments() {
+    use autodev::infra::gh::mock::MockGh;
+
+    let db = open_memory_db();
+    let repo_id = add_test_repo(&db, "org/pr-review-test");
+
+    let mock_gh = MockGh::new();
+
+    // Set up mock: closed PRs list
+    let pulls_json = serde_json::json!([
+        {"number": 1, "state": "closed", "title": "PR 1"},
+        {"number": 2, "state": "closed", "title": "PR 2"}
+    ]);
+    mock_gh.set_paginate(
+        "org/pr-review-test",
+        "pulls",
+        serde_json::to_vec(&pulls_json).unwrap(),
+    );
+
+    // Set up mock: reviews for PR #1
+    let reviews_1 = serde_json::json!([
+        {"body": "Please add error handling here", "state": "COMMENTED"},
+        {"body": "Use snake_case for naming", "state": "CHANGES_REQUESTED"},
+        {"body": "", "state": "APPROVED"}
+    ]);
+    mock_gh.set_paginate(
+        "org/pr-review-test",
+        "pulls/1/reviews",
+        serde_json::to_vec(&reviews_1).unwrap(),
+    );
+
+    // Set up mock: reviews for PR #2
+    let reviews_2 = serde_json::json!([
+        {"body": "Add test coverage for this function", "state": "COMMENTED"}
+    ]);
+    mock_gh.set_paginate(
+        "org/pr-review-test",
+        "pulls/2/reviews",
+        serde_json::to_vec(&reviews_2).unwrap(),
+    );
+
+    let output = autodev::cli::convention::collect_feedback_from_pr_reviews(
+        &db,
+        &mock_gh,
+        "org/pr-review-test",
+        &repo_id,
+        None,
+    )
+    .await
+    .unwrap();
+
+    // Should collect 3 non-empty comments across 2 PRs
+    assert!(output.contains("3 feedback pattern(s)"));
+    assert!(output.contains("3 PR review comment(s)"));
+    assert!(output.contains("2 PR(s)"));
+
+    // Verify patterns were stored
+    let patterns = db.feedback_list(&repo_id).unwrap();
+    assert_eq!(patterns.len(), 3);
+
+    // Verify sources
+    assert!(patterns.iter().all(|p| p.source == "pr-review"));
+
+    // Verify classifications
+    let types: Vec<&str> = patterns.iter().map(|p| p.pattern_type.as_str()).collect();
+    assert!(types.contains(&"error-handling")); // "error handling"
+    assert!(types.contains(&"style")); // "snake_case" naming
+    assert!(types.contains(&"testing")); // "test coverage"
+}
+
+// ═══════════════════════════════════════════════
+// 29. collect_feedback_from_pr_reviews skips empty reviews
+// ═══════════════════════════════════════════════
+
+#[tokio::test]
+async fn collect_feedback_from_pr_reviews_skips_empty_bodies() {
+    use autodev::infra::gh::mock::MockGh;
+
+    let db = open_memory_db();
+    let repo_id = add_test_repo(&db, "org/empty-review-test");
+
+    let mock_gh = MockGh::new();
+
+    let pulls_json = serde_json::json!([
+        {"number": 1, "state": "closed", "title": "PR 1"}
+    ]);
+    mock_gh.set_paginate(
+        "org/empty-review-test",
+        "pulls",
+        serde_json::to_vec(&pulls_json).unwrap(),
+    );
+
+    // All empty or whitespace bodies
+    let reviews = serde_json::json!([
+        {"body": "", "state": "APPROVED"},
+        {"body": "   ", "state": "COMMENTED"},
+        {"body": null, "state": "COMMENTED"}
+    ]);
+    mock_gh.set_paginate(
+        "org/empty-review-test",
+        "pulls/1/reviews",
+        serde_json::to_vec(&reviews).unwrap(),
+    );
+
+    let output = autodev::cli::convention::collect_feedback_from_pr_reviews(
+        &db,
+        &mock_gh,
+        "org/empty-review-test",
+        &repo_id,
+        None,
+    )
+    .await
+    .unwrap();
+
+    assert!(output.contains("0 feedback pattern(s)"));
+
+    let patterns = db.feedback_list(&repo_id).unwrap();
+    assert!(patterns.is_empty());
+}
+
+// ═══════════════════════════════════════════════
+// 30. collect_feedback_from_pr_reviews deduplicates same comments
+// ═══════════════════════════════════════════════
+
+#[tokio::test]
+async fn collect_feedback_from_pr_reviews_deduplicates() {
+    use autodev::infra::gh::mock::MockGh;
+
+    let db = open_memory_db();
+    let repo_id = add_test_repo(&db, "org/dedup-review-test");
+
+    let mock_gh = MockGh::new();
+
+    let pulls_json = serde_json::json!([
+        {"number": 1, "state": "closed", "title": "PR 1"}
+    ]);
+    mock_gh.set_paginate(
+        "org/dedup-review-test",
+        "pulls",
+        serde_json::to_vec(&pulls_json).unwrap(),
+    );
+
+    // Two identical review comments in the same PR
+    let reviews = serde_json::json!([
+        {"body": "Please add tests", "state": "COMMENTED"},
+        {"body": "Please add tests", "state": "COMMENTED"}
+    ]);
+    mock_gh.set_paginate(
+        "org/dedup-review-test",
+        "pulls/1/reviews",
+        serde_json::to_vec(&reviews).unwrap(),
+    );
+
+    let output = autodev::cli::convention::collect_feedback_from_pr_reviews(
+        &db,
+        &mock_gh,
+        "org/dedup-review-test",
+        &repo_id,
+        None,
+    )
+    .await
+    .unwrap();
+
+    // Only 1 pattern should be stored (deduplicated within same PR)
+    assert!(output.contains("1 feedback pattern(s)"));
+
+    let patterns = db.feedback_list(&repo_id).unwrap();
+    assert_eq!(patterns.len(), 1);
+    assert_eq!(patterns[0].suggestion, "Please add tests");
+}


### PR DESCRIPTION
## Summary
- Add `collect_feedback_from_pr_reviews()` async function that fetches recent closed PRs via GitHub API, extracts review comment bodies, classifies them by theme (style, testing, error-handling, etc.), and stores detected patterns in the `feedback_patterns` table with source `"pr-review"`
- Add `classify_review_comment()` that extends the existing `classify_pattern_type()` with PR review-specific keywords (naming, documentation)
- Wire PR review feedback collection into the existing `convention collect-feedback` CLI command alongside HITL collection
- Batch API requests (max 30 PRs per run) and gracefully skip on API errors to respect rate limits

## Test plan
- [x] `classify_review_comment` correctly classifies naming patterns as "style"
- [x] `classify_review_comment` correctly classifies documentation patterns as "style"
- [x] `classify_review_comment` falls back to `classify_pattern_type` for other patterns
- [x] `collect_feedback_from_pr_reviews` processes review comments from multiple PRs via MockGh
- [x] Empty/whitespace review bodies are skipped
- [x] Duplicate review comments within the same PR are deduplicated
- [x] All existing feedback pattern tests continue to pass (35 total)
- [x] `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` all pass

Closes #344

🤖 Generated with [Claude Code](https://claude.com/claude-code)