### PR TITLE
fix(autodev): validate date input, optional body, and add CLI flags

### DIFF
--- a/plugins/autodev/cli/src/cli/mod.rs
+++ b/plugins/autodev/cli/src/cli/mod.rs
@@ -202,8 +202,23 @@ pub fn repo_add(
 }
 
 /// 레포 목록
-pub fn repo_list(db: &Database) -> Result<String> {
+pub fn repo_list(db: &Database, json: bool) -> Result<String> {
     let repos = db.repo_list()?;
+
+    if json {
+        let value: Vec<serde_json::Value> = repos
+            .iter()
+            .map(|r| {
+                serde_json::json!({
+                    "name": r.name,
+                    "url": r.url,
+                    "enabled": r.enabled,
+                })
+            })
+            .collect();
+        return Ok(serde_json::to_string_pretty(&value)?);
+    }
+
     let mut output = String::new();
 
     for r in &repos {

--- a/plugins/autodev/cli/src/cli/report.rs
+++ b/plugins/autodev/cli/src/cli/report.rs
@@ -21,6 +21,11 @@ pub async fn daily(
     home: &std::path::Path,
     date: &str,
 ) -> Result<String> {
+    // Validate date format to prevent path traversal (e.g. "../../etc/passwd")
+    if chrono::NaiveDate::parse_from_str(date, "%Y-%m-%d").is_err() {
+        anyhow::bail!("invalid date format: {date} (expected YYYY-MM-DD)");
+    }
+
     let cfg = config::loader::load_merged(env, None);
     let log_dir = config::resolve_log_dir(&cfg.daemon.log_dir, home);
     let log_path = log_dir.join(format!("daemon.{date}.log"));

--- a/plugins/autodev/cli/src/main.rs
+++ b/plugins/autodev/cli/src/main.rs
@@ -44,7 +44,11 @@ enum Commands {
         json: bool,
     },
     /// TUI 대시보드
-    Dashboard,
+    Dashboard {
+        /// 레포 이름으로 필터 (org/repo)
+        #[arg(long)]
+        repo: Option<String>,
+    },
     /// 레포 관리
     Repo {
         #[command(subcommand)]
@@ -443,7 +447,11 @@ enum RepoAction {
         config: Option<String>,
     },
     /// 등록된 레포 목록
-    List,
+    List {
+        /// JSON 출력
+        #[arg(long)]
+        json: bool,
+    },
     /// 레포 상세 조회
     Show {
         /// 레포 이름 (org/repo)
@@ -479,13 +487,13 @@ enum SpecAction {
         /// 스펙 제목
         #[arg(long)]
         title: String,
-        /// 스펙 본문
-        #[arg(long)]
+        /// 스펙 본문 (--file 사용 시 생략 가능)
+        #[arg(long, default_value = "")]
         body: String,
         /// 레포 이름 (org/repo)
         #[arg(long)]
         repo: String,
-        /// 소스 파일 경로
+        /// 소스 파일 경로 (body 대신 파일 내용 사용)
         #[arg(long)]
         file: Option<String>,
         /// 테스트 커맨드 (JSON 배열)
@@ -750,13 +758,13 @@ async fn main() -> Result<()> {
             let status = client::status(&db, &env, json)?;
             println!("{status}");
         }
-        Commands::Dashboard => tui::run(&db).await?,
+        Commands::Dashboard { repo } => tui::run(&db, repo.as_deref()).await?,
         Commands::Repo { action } => match action {
             RepoAction::Add { url, config } => {
                 client::repo_add(&db, &env, &url, config.as_deref())?;
             }
-            RepoAction::List => {
-                let list = client::repo_list(&db)?;
+            RepoAction::List { json } => {
+                let list = client::repo_list(&db, json)?;
                 println!("{list}");
             }
             RepoAction::Show { name, json } => {
@@ -855,7 +863,7 @@ async fn main() -> Result<()> {
                         std::fs::read_to_string(path)
                             .map_err(|e| anyhow::anyhow!("failed to read file {path}: {e}"))?
                     } else {
-                        body
+                        anyhow::bail!("--body or --file is required");
                     }
                 } else {
                     body

--- a/plugins/autodev/cli/src/tui/mod.rs
+++ b/plugins/autodev/cli/src/tui/mod.rs
@@ -18,7 +18,7 @@ use events::LogTailer;
 
 const LOG_TAIL_MAX_LINES: usize = 200;
 
-pub async fn run(db: &Database) -> Result<()> {
+pub async fn run(db: &Database, repo_filter: Option<&str>) -> Result<()> {
     enable_raw_mode()?;
     let mut stdout = io::stdout();
     execute!(stdout, EnterAlternateScreen)?;
@@ -26,6 +26,7 @@ pub async fn run(db: &Database) -> Result<()> {
     let mut terminal = Terminal::new(backend)?;
 
     let mut state = views::AppState::new();
+    state.repo_filter = repo_filter.map(|s| s.to_string());
 
     // Initialize log tailer
     let home = config::autodev_home(&config::RealEnv);

--- a/plugins/autodev/cli/src/tui/views.rs
+++ b/plugins/autodev/cli/src/tui/views.rs
@@ -81,6 +81,7 @@ pub struct AppState {
     pub repo_names: Vec<String>,
     /// Detail overlay (shown on top of the current view)
     pub detail_overlay: Option<DetailOverlay>,
+    pub repo_filter: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -111,6 +112,7 @@ impl Default for AppState {
             focused_repo_index: 0,
             repo_names: Vec::new(),
             detail_overlay: None,
+            repo_filter: None,
         }
     }
 }
@@ -826,7 +828,15 @@ fn render_active_items_panel(
     status_path: &std::path::Path,
     state: &AppState,
 ) {
-    let active_items = query_active_items(status_path);
+    let all_items = query_active_items(status_path);
+    let active_items: Vec<&ActiveItem> = if let Some(ref filter) = state.repo_filter {
+        all_items
+            .iter()
+            .filter(|i| i.repo_name == *filter)
+            .collect()
+    } else {
+        all_items.iter().collect()
+    };
 
     let items: Vec<ListItem> = active_items
         .iter()


### PR DESCRIPTION
## Summary
- Validate `date` parameter in `report daily` with `chrono::NaiveDate` parsing to prevent path traversal attacks (#389)
- Make `--body` optional in `spec add` when `--file` is provided; error if neither is given (#376)
- Add `--json` flag to `repo list` subcommand for machine-readable output (#374)
- Add `--repo` flag to `dashboard` subcommand to filter the TUI view to a specific repository (#375)

## Test plan
- [ ] `autodev report daily --date "../../etc/passwd"` returns validation error
- [ ] `autodev report daily --date 2026-03-20` works normally
- [ ] `autodev spec add --title t --file spec.md --repo org/repo` works without `--body`
- [ ] `autodev spec add --title t --repo org/repo` fails with "body or file required"
- [ ] `autodev repo list --json` returns JSON array
- [ ] `autodev dashboard --repo org/repo` filters active items to that repo

Closes #389, Closes #376, Closes #374, Closes #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)