### PR TITLE
fix(autodev): resolve HITL notification, escalation, and board progress bugs

### DIFF
--- a/plugins/autodev/cli/Cargo.lock
+++ b/plugins/autodev/cli/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autodev"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/plugins/autodev/cli/src/cli/convention.rs
+++ b/plugins/autodev/cli/src/cli/convention.rs
@@ -1145,7 +1145,8 @@ pub fn pattern_type_to_rule_file(pattern_type: &str) -> String {
 /// propose_updates의 결과: 출력 메시지와 생성된 HITL 이벤트 목록.
 pub struct ProposeResult {
     pub output: String,
-    pub hitl_events: Vec<crate::core::models::NewHitlEvent>,
+    /// Pairs of (HITL event, assigned hitl_id) for notification dispatch.
+    pub hitl_entries: Vec<(crate::core::models::NewHitlEvent, String)>,
 }
 
 /// Check actionable feedback patterns and create HITL events for convention updates.
@@ -1162,11 +1163,11 @@ pub fn propose_updates(db: &Database, repo_id: &str, threshold: i32) -> Result<P
     if patterns.is_empty() {
         return Ok(ProposeResult {
             output: "No actionable patterns found.\n".to_string(),
-            hitl_events: Vec::new(),
+            hitl_entries: Vec::new(),
         });
     }
 
-    let mut hitl_events = Vec::new();
+    let mut hitl_entries = Vec::new();
 
     for pattern in &patterns {
         let rule_file = pattern_type_to_rule_file(&pattern.pattern_type);
@@ -1188,14 +1189,14 @@ pub fn propose_updates(db: &Database, repo_id: &str, threshold: i32) -> Result<P
             ],
         };
 
-        db.hitl_create(&hitl_event)?;
+        let hitl_id = db.hitl_create(&hitl_event)?;
         db.feedback_set_status(&pattern.id, FeedbackPatternStatus::Proposed)?;
-        hitl_events.push(hitl_event);
+        hitl_entries.push((hitl_event, hitl_id));
     }
 
     Ok(ProposeResult {
-        output: format!("Proposed {} convention update(s)\n", hitl_events.len()),
-        hitl_events,
+        output: format!("Proposed {} convention update(s)\n", hitl_entries.len()),
+        hitl_entries,
     })
 }
 

--- a/plugins/autodev/cli/src/cli/queue.rs
+++ b/plugins/autodev/cli/src/cli/queue.rs
@@ -11,6 +11,8 @@ use crate::infra::db::Database;
 pub struct QueueAdvanceResult {
     pub output: String,
     pub hitl_event: Option<NewHitlEvent>,
+    /// The assigned hitl_id if a HITL event was created (for notification dispatch).
+    pub hitl_id: Option<String>,
 }
 
 /// 큐 아이템을 다음 phase로 전이한다.
@@ -38,16 +40,18 @@ pub fn queue_advance(
     record_decision(db, &item.repo_id, DecisionType::Advance, work_id, reason);
 
     // H3: PR review iteration 임계값 초과 시 HITL 자동 생성
-    let hitl_event = if item.queue_type == QueueType::Pr {
+    let (hitl_event, hitl_id) = if item.queue_type == QueueType::Pr {
         extract_review_iteration(&item.metadata_json)
             .and_then(|ri| check_review_overflow(db, &item.repo_id, work_id, ri))
+            .map_or((None, None), |(ev, id)| (Some(ev), id))
     } else {
-        None
+        (None, None)
     };
 
     Ok(QueueAdvanceResult {
         output: format!("advanced: {work_id} ({before} → {after})"),
         hitl_event,
+        hitl_id,
     })
 }
 
@@ -115,7 +119,7 @@ fn check_review_overflow(
     repo_id: &str,
     work_id: &str,
     review_iteration: u32,
-) -> Option<NewHitlEvent> {
+) -> Option<(NewHitlEvent, Option<String>)> {
     let max_iterations = crate::core::config::models::ReviewStage::default().max_iterations;
     if review_iteration >= max_iterations {
         let event = NewHitlEvent {
@@ -133,8 +137,8 @@ fn check_review_overflow(
                 "Merge as-is".to_string(),
             ],
         };
-        let _ = db.hitl_create(&event);
-        Some(event)
+        let hitl_id = db.hitl_create(&event).ok();
+        Some((event, hitl_id))
     } else {
         None
     }

--- a/plugins/autodev/cli/src/cli/spec.rs
+++ b/plugins/autodev/cli/src/cli/spec.rs
@@ -177,7 +177,7 @@ pub fn spec_check_completion(
     db: &Database,
     env: &dyn crate::core::config::Env,
     id: &str,
-) -> Result<(String, NewHitlEvent)> {
+) -> Result<(String, NewHitlEvent, String)> {
     let spec = db
         .spec_show(id)?
         .ok_or_else(|| anyhow::anyhow!("spec not found: {id}"))?;
@@ -309,6 +309,7 @@ pub fn spec_check_completion(
              Respond with 'autodev hitl respond {event_id} --choice 1' to confirm completion."
         ),
         hitl_event,
+        event_id,
     ))
 }
 
@@ -899,7 +900,7 @@ pub fn spec_decisions(db: &Database, spec_id: &str, limit: usize, json: bool) ->
 pub fn check_completable_specs(
     db: &Database,
     env: &dyn crate::core::config::Env,
-) -> Vec<(String, NewHitlEvent)> {
+) -> Vec<(String, NewHitlEvent, String)> {
     let active_specs = match db.spec_list_by_status(SpecStatus::Active) {
         Ok(specs) => specs,
         Err(e) => {
@@ -954,9 +955,9 @@ pub fn check_completable_specs(
                 spec.title
             );
             match spec_check_completion(db, env, &spec.id) {
-                Ok((_output, hitl_event)) => {
+                Ok((_output, hitl_event, hitl_id)) => {
                     tracing::info!("spec auto-completion: triggered HITL for spec {}", spec.id);
-                    triggered.push((spec.id.clone(), hitl_event));
+                    triggered.push((spec.id.clone(), hitl_event, hitl_id));
                 }
                 Err(e) => {
                     tracing::warn!(

--- a/plugins/autodev/cli/src/core/notifier.rs
+++ b/plugins/autodev/cli/src/core/notifier.rs
@@ -50,7 +50,10 @@ impl NotificationEvent {
     }
 
     /// Create a notification for a newly created HITL event.
-    pub fn from_hitl_created(event: &NewHitlEvent) -> Self {
+    ///
+    /// `hitl_id` should be the ID returned from `hitl_create()` so that
+    /// the reply-scanner can correlate GitHub comment replies back to this event.
+    pub fn from_hitl_created(event: &NewHitlEvent, hitl_id: Option<String>) -> Self {
         Self {
             repo_name: event.repo_id.clone(),
             severity: event.severity.to_string(),
@@ -60,7 +63,7 @@ impl NotificationEvent {
             work_id: event.work_id.clone(),
             spec_id: event.spec_id.clone(),
             url: None,
-            hitl_id: None, // ID not yet assigned at creation time
+            hitl_id,
         }
     }
 

--- a/plugins/autodev/cli/src/main.rs
+++ b/plugins/autodev/cli/src/main.rs
@@ -821,6 +821,7 @@ async fn main() -> Result<()> {
                     if let Some(ref dispatcher) = build_cli_dispatcher(&cfg) {
                         let notif = autodev::core::notifier::NotificationEvent::from_hitl_created(
                             hitl_event,
+                            result.hitl_id.clone(),
                         );
                         dispatch_notification(dispatcher, &notif).await;
                     }
@@ -926,13 +927,16 @@ async fn main() -> Result<()> {
                 client::spec::spec_unlink(&db, &spec_id, issue)?;
             }
             SpecAction::Complete { id } => {
-                let (output, hitl_event) = client::spec::spec_check_completion(&db, &env, &id)?;
+                let (output, hitl_event, hitl_id) =
+                    client::spec::spec_check_completion(&db, &env, &id)?;
                 println!("{output}");
 
                 // Dispatch HITL creation notification if configured
                 if let Some(ref dispatcher) = build_cli_dispatcher(&cfg) {
-                    let notif =
-                        autodev::core::notifier::NotificationEvent::from_hitl_created(&hitl_event);
+                    let notif = autodev::core::notifier::NotificationEvent::from_hitl_created(
+                        &hitl_event,
+                        Some(hitl_id),
+                    );
                     dispatch_notification(dispatcher, &notif).await;
                 }
             }
@@ -1342,13 +1346,16 @@ async fn main() -> Result<()> {
                 print!("{}", result.output);
 
                 // Dispatch HITL notifications for proposed convention updates
-                if !result.hitl_events.is_empty() {
+                if !result.hitl_entries.is_empty() {
                     if let Some(ref dispatcher) =
                         autodev::service::daemon::notifiers::dispatcher::NotificationDispatcher::from_config(&cfg.daemon)
                     {
-                        for hitl_event in &result.hitl_events {
+                        for (hitl_event, hitl_id) in &result.hitl_entries {
                             let notif =
-                                autodev::core::notifier::NotificationEvent::from_hitl_created(hitl_event);
+                                autodev::core::notifier::NotificationEvent::from_hitl_created(
+                                    hitl_event,
+                                    Some(hitl_id.clone()),
+                                );
                             dispatch_notification(dispatcher, &notif).await;
                         }
                     }

--- a/plugins/autodev/cli/src/service/daemon/collectors/github.rs
+++ b/plugins/autodev/cli/src/service/daemon/collectors/github.rs
@@ -218,15 +218,18 @@ impl<DB: RepoRepository + ScanCursorRepository + QueueRepository + Send> GitHubT
     /// Claw(CLI)가 DB에서 Pending→Ready 전이 → daemon의 in-memory queue는 여전히 Pending.
     /// DB를 읽어 Ready 상태인 아이템을 in-memory에서도 Ready로 전이한다.
     fn sync_queue_phases(&mut self) {
-        if !self.claw_enabled {
-            return;
-        }
         for repo in self.repos.values_mut() {
             if let Ok(rows) = self.db.queue_load_active(repo.id()) {
                 for row in rows {
-                    if row.phase == QueuePhase::Ready {
+                    // Claw: DB Pending→Ready 전이를 in-memory에 반영
+                    if self.claw_enabled && row.phase == QueuePhase::Ready {
                         repo.queue
                             .transit(&row.work_id, QueuePhase::Pending, QueuePhase::Ready);
+                    }
+                    // Escalation retry: DB Running→Pending 복구를 in-memory에 반영
+                    if row.phase == QueuePhase::Pending {
+                        repo.queue
+                            .transit(&row.work_id, QueuePhase::Running, QueuePhase::Pending);
                     }
                 }
             }

--- a/plugins/autodev/cli/src/service/daemon/escalation.rs
+++ b/plugins/autodev/cli/src/service/daemon/escalation.rs
@@ -16,7 +16,8 @@ pub enum EscalationOutcome {
     /// 아이템을 제거한다. 기본 동작을 그대로 수행한다.
     Remove,
     /// HITL 이벤트를 생성하고 아이템을 제거한다. 알림 발송이 필요하다.
-    RemoveWithHitl(NewHitlEvent),
+    /// `String` is the assigned hitl_id from the database.
+    RemoveWithHitl(NewHitlEvent, String),
 }
 
 /// HITL 이벤트를 DB에 저장하고, 성공 시 RemoveWithHitl, 실패 시 Remove를 반환한다.
@@ -26,7 +27,7 @@ fn create_hitl_or_remove(
     hitl_event: NewHitlEvent,
 ) -> EscalationOutcome {
     match db.hitl_create(&hitl_event) {
-        Ok(_) => EscalationOutcome::RemoveWithHitl(hitl_event),
+        Ok(hitl_id) => EscalationOutcome::RemoveWithHitl(hitl_event, hitl_id),
         Err(e) => {
             tracing::warn!("failed to create HITL event for {work_id}: {e}");
             EscalationOutcome::Remove

--- a/plugins/autodev/cli/src/service/daemon/mod.rs
+++ b/plugins/autodev/cli/src/service/daemon/mod.rs
@@ -199,8 +199,8 @@ impl Daemon {
                                             ) {
                                                 escalation::EscalationOutcome::Retry => true,
                                                 escalation::EscalationOutcome::Remove => false,
-                                                escalation::EscalationOutcome::RemoveWithHitl(event) => {
-                                                    escalation_hitl = Some(event);
+                                                escalation::EscalationOutcome::RemoveWithHitl(event, hitl_id) => {
+                                                    escalation_hitl = Some((event, hitl_id));
                                                     false
                                                 }
                                             }
@@ -245,8 +245,8 @@ impl Daemon {
                             }
 
                             // Notify on escalation-generated HITL event
-                            if let Some(ref hitl_event) = escalation_hitl {
-                                let notif = NotificationEvent::from_hitl_created(hitl_event);
+                            if let Some((ref hitl_event, ref hitl_id)) = escalation_hitl {
+                                let notif = NotificationEvent::from_hitl_created(hitl_event, Some(hitl_id.clone()));
                                 dispatch_notification(&self.notifier, &notif).await;
                             }
 
@@ -260,10 +260,12 @@ impl Daemon {
                                 let env = crate::core::config::RealEnv;
                                 let completable =
                                     crate::cli::spec::check_completable_specs(&self.log_db, &env);
-                                for (spec_id, hitl_event) in &completable {
+                                for (spec_id, hitl_event, hitl_id) in &completable {
                                     info!("spec auto-completion triggered for {spec_id}");
-                                    let notif =
-                                        NotificationEvent::from_hitl_created(hitl_event);
+                                    let notif = NotificationEvent::from_hitl_created(
+                                        hitl_event,
+                                        Some(hitl_id.clone()),
+                                    );
                                     dispatch_notification(&self.notifier, &notif).await;
                                 }
                             }
@@ -339,8 +341,11 @@ impl Daemon {
                                     ) {
                                         escalation::EscalationOutcome::Retry => true,
                                         escalation::EscalationOutcome::Remove => false,
-                                        escalation::EscalationOutcome::RemoveWithHitl(event) => {
-                                            escalation_hitl = Some(event);
+                                        escalation::EscalationOutcome::RemoveWithHitl(
+                                            event,
+                                            hitl_id,
+                                        ) => {
+                                            escalation_hitl = Some((event, hitl_id));
                                             false
                                         }
                                     }
@@ -383,8 +388,11 @@ impl Daemon {
                         }
 
                         // Notify on escalation-generated HITL event
-                        if let Some(ref hitl_event) = escalation_hitl {
-                            let notif = NotificationEvent::from_hitl_created(hitl_event);
+                        if let Some((ref hitl_event, ref hitl_id)) = escalation_hitl {
+                            let notif = NotificationEvent::from_hitl_created(
+                                hitl_event,
+                                Some(hitl_id.clone()),
+                            );
                             dispatch_notification(&self.notifier, &notif).await;
                         }
                     }

--- a/plugins/autodev/cli/src/tui/board.rs
+++ b/plugins/autodev/cli/src/tui/board.rs
@@ -62,7 +62,8 @@ impl BoardStateBuilder {
                 let done_count = linked_issues
                     .iter()
                     .filter(|si| {
-                        let work_id = format!("{}#{}", repo.name, si.issue_number);
+                        // work_id format is "issue:<repo_name>:<number>"
+                        let work_id = format!("issue:{}:{}", repo.name, si.issue_number);
                         done_work_ids.contains(work_id.as_str())
                     })
                     .count();
@@ -633,10 +634,18 @@ mod tests {
         db.spec_link_issue(&spec_id, 3).unwrap();
 
         // Add queue items — #1 is done, #2 is running, #3 is pending
-        insert_queue_item(&db, "org/repo#1", &repo_id, "issue", "done", Some("Task 1"));
+        // work_id format: "issue:<repo_name>:<number>"
         insert_queue_item(
             &db,
-            "org/repo#2",
+            "issue:org/repo:1",
+            &repo_id,
+            "issue",
+            "done",
+            Some("Task 1"),
+        );
+        insert_queue_item(
+            &db,
+            "issue:org/repo:2",
             &repo_id,
             "issue",
             "running",
@@ -644,7 +653,7 @@ mod tests {
         );
         insert_queue_item(
             &db,
-            "org/repo#3",
+            "issue:org/repo:3",
             &repo_id,
             "issue",
             "pending",


### PR DESCRIPTION
## Summary
- **#381 / #377**: `NotificationEvent::from_hitl_created()` now accepts `hitl_id` returned from `hitl_create()`, enabling reply-scanner to correlate GitHub comment replies back to HITL events. All call sites (escalation, queue advance, spec completion, convention propose) updated to pass the assigned ID.
- **#379**: `sync_queue_phases()` now detects DB items reset to Pending (by escalation retry) while still Running in-memory, and transits them back to Pending to prevent state desync.
- **#392**: Board spec progress calculation now uses correct `issue:<repo>:<num>` work_id format instead of `<repo>#<num>`, which never matched `done_work_ids`.

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (332 lib + 5 integration tests, including updated `builder_includes_spec_progress` test with correct work_id format)

Closes #381, Closes #377, Closes #379, Closes #392

🤖 Generated with [Claude Code](https://claude.com/claude-code)