### PR TITLE
fix(validate): add plugin-marketplace sync check

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -137,6 +137,22 @@
       "name": "openclaw-docker",
       "source": "./plugins/openclaw-docker",
       "version": "0.2.0"
+    },
+    {
+      "category": "productivity",
+      "description": "스펙 문서와 구현 코드 간 갭을 체계적으로 분석 — 행위 커버리지, 보안, 성능 관점 리포트",
+      "keywords": [
+        "spec",
+        "analysis",
+        "coverage",
+        "gap",
+        "compliance",
+        "security",
+        "performance"
+      ],
+      "name": "spec-analyzer",
+      "source": "./plugins/spec-analyzer",
+      "version": "0.1.0"
     }
   ]
 }

--- a/tools/validate/internal/spec/validator.go
+++ b/tools/validate/internal/spec/validator.go
@@ -65,6 +65,16 @@ func Validate(repoRoot string) (*Results, error) {
 		} else {
 			results.Failed = append(results.Failed, result)
 		}
+
+		// 2-1. Cross-validate: every plugin.json in plugins/ must have a marketplace entry
+		crossResults := validatePluginMarketplaceSync(repoRoot, pluginFiles, marketplaceFile)
+		for _, r := range crossResults {
+			if r.Valid {
+				results.Passed = append(results.Passed, r)
+			} else {
+				results.Failed = append(results.Failed, r)
+			}
+		}
 	}
 
 	// 3. SKILL.md validation
@@ -254,6 +264,72 @@ func validateMarketplaceJSON(filePath string) Result {
 
 	result.Valid = len(result.Errors) == 0
 	return result
+}
+
+// validatePluginMarketplaceSync checks that every plugin.json under plugins/ has a corresponding entry in marketplace.json
+func validatePluginMarketplaceSync(repoRoot string, pluginFiles []string, marketplaceFile string) []Result {
+	var results []Result
+
+	// Read marketplace.json and collect registered plugin names
+	content, err := os.ReadFile(marketplaceFile)
+	if err != nil {
+		return results
+	}
+
+	var marketplace map[string]interface{}
+	if err := json.Unmarshal(content, &marketplace); err != nil {
+		return results
+	}
+
+	registeredNames := make(map[string]bool)
+	if plugins, ok := marketplace["plugins"].([]interface{}); ok {
+		for _, p := range plugins {
+			if plugin, ok := p.(map[string]interface{}); ok {
+				if name, ok := plugin["name"].(string); ok {
+					registeredNames[name] = true
+				}
+			}
+		}
+	}
+
+	// Check each plugin.json under plugins/ directory
+	for _, file := range pluginFiles {
+		// Only check plugins/ directory (skip .claude-plugin/plugin.json etc)
+		if !strings.Contains(file, "plugins/") {
+			continue
+		}
+
+		fullPath := repoRoot + "/" + file
+		pluginContent, err := os.ReadFile(fullPath)
+		if err != nil {
+			continue
+		}
+
+		var pluginData map[string]interface{}
+		if err := json.Unmarshal(pluginContent, &pluginData); err != nil {
+			continue
+		}
+
+		pluginName, ok := pluginData["name"].(string)
+		if !ok || pluginName == "" {
+			continue
+		}
+
+		result := Result{
+			File: fullPath,
+			Type: "marketplace-sync",
+		}
+
+		if registeredNames[pluginName] {
+			result.Valid = true
+		} else {
+			result.Errors = append(result.Errors, fmt.Sprintf("Plugin '%s' has plugin.json but is not registered in marketplace.json", pluginName))
+		}
+
+		results = append(results, result)
+	}
+
+	return results
 }
 
 func validateSkillMD(filePath string, results *Results) Result {

--- a/tools/validate/internal/spec/validator_test.go
+++ b/tools/validate/internal/spec/validator_test.go
@@ -231,6 +231,65 @@ allowed-tools: "Task"
 	}
 }
 
+func TestValidatePluginMarketplaceSync(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Setup: plugins/my-plugin/.claude-plugin/plugin.json
+	pluginDir := filepath.Join(tmpDir, "plugins", "my-plugin", ".claude-plugin")
+	os.MkdirAll(pluginDir, 0755)
+	os.WriteFile(filepath.Join(pluginDir, "plugin.json"), []byte(`{"name": "my-plugin", "version": "1.0.0"}`), 0644)
+
+	// Setup: plugins/orphan-plugin/.claude-plugin/plugin.json (not in marketplace)
+	orphanDir := filepath.Join(tmpDir, "plugins", "orphan-plugin", ".claude-plugin")
+	os.MkdirAll(orphanDir, 0755)
+	os.WriteFile(filepath.Join(orphanDir, "plugin.json"), []byte(`{"name": "orphan-plugin", "version": "0.1.0"}`), 0644)
+
+	// Setup: .claude-plugin/marketplace.json (only has my-plugin)
+	marketDir := filepath.Join(tmpDir, ".claude-plugin")
+	os.MkdirAll(marketDir, 0755)
+	marketplaceFile := filepath.Join(marketDir, "marketplace.json")
+	os.WriteFile(marketplaceFile, []byte(`{
+		"name": "test-repo",
+		"owner": {"name": "test"},
+		"plugins": [
+			{"name": "my-plugin", "source": "./plugins/my-plugin", "version": "1.0.0"}
+		]
+	}`), 0644)
+
+	pluginFiles := []string{
+		"plugins/my-plugin/.claude-plugin/plugin.json",
+		"plugins/orphan-plugin/.claude-plugin/plugin.json",
+	}
+
+	results := validatePluginMarketplaceSync(tmpDir, pluginFiles, marketplaceFile)
+
+	if len(results) != 2 {
+		t.Fatalf("Expected 2 results, got %d", len(results))
+	}
+
+	// Find results by plugin
+	var myPluginResult, orphanResult Result
+	for _, r := range results {
+		if strings.Contains(r.File, "my-plugin") {
+			myPluginResult = r
+		}
+		if strings.Contains(r.File, "orphan-plugin") {
+			orphanResult = r
+		}
+	}
+
+	if !myPluginResult.Valid {
+		t.Errorf("my-plugin should pass: %v", myPluginResult.Errors)
+	}
+
+	if orphanResult.Valid {
+		t.Errorf("orphan-plugin should fail (not in marketplace)")
+	}
+	if len(orphanResult.Errors) != 1 || !strings.Contains(orphanResult.Errors[0], "not registered in marketplace.json") {
+		t.Errorf("Expected marketplace sync error, got: %v", orphanResult.Errors)
+	}
+}
+
 func TestValidateSkillMD(t *testing.T) {
 	tmpDir := t.TempDir()
 


### PR DESCRIPTION
## Summary
- `plugin.json`이 있는데 `marketplace.json`에 등록되지 않은 플러그인을 CI에서 잡는 cross-validation 추가
- spec-analyzer 플러그인을 marketplace.json에 등록

## 변경 내용
- `tools/validate/internal/spec/validator.go`: `validatePluginMarketplaceSync` 함수 추가 — plugins/ 하위의 모든 plugin.json 이름이 marketplace.json에 존재하는지 검증
- `tools/validate/internal/spec/validator_test.go`: 등록된 플러그인(pass) / 미등록 플러그인(fail) 테스트 케이스
- `.claude-plugin/marketplace.json`: spec-analyzer 엔트리 추가

## Test plan
- [x] `TestValidatePluginMarketplaceSync` 통과 확인
- [x] `make validate-ci` 전체 통과 확인
- [ ] CI에서 검증 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)