### PR TITLE
fix(autodev): prevent PR feedback re-processing and HITL duplicate application

### DIFF
--- a/plugins/autodev/cli/src/cli/convention.rs
+++ b/plugins/autodev/cli/src/cli/convention.rs
@@ -883,19 +883,43 @@ fn build_hitl_feedback(
 ///
 /// `repo_name` is the human-readable name (e.g. "org/repo") used to query HITL events.
 /// `repo_id` is the internal UUID used for feedback pattern storage.
+///
+/// Uses `scan_cursors` with target `"feedback-hitl"` to track the last processed
+/// event's `created_at` timestamp, ensuring each HITL response is only processed once.
 pub fn collect_feedback(db: &Database, repo_name: &str, repo_id: &str) -> Result<String> {
     use crate::core::models::HitlStatus;
-    use crate::core::repository::HitlRepository;
+    use crate::core::repository::{HitlRepository, ScanCursorRepository};
+
+    let cursor_target = "feedback-hitl";
+    let last_seen = db.cursor_get_last_seen(repo_id, cursor_target)?;
 
     let events = db.hitl_list(Some(repo_name))?;
     let mut collected = 0;
     let mut total_responded = 0;
+    let mut max_created_at: Option<String> = None;
 
     for event in &events {
         if !matches!(event.status, HitlStatus::Responded) {
             continue;
         }
+
+        // Skip events already processed in a previous run
+        if let Some(ref cursor) = last_seen {
+            if event.created_at <= *cursor {
+                continue;
+            }
+        }
+
         total_responded += 1;
+
+        // Track the latest event timestamp for cursor update
+        match max_created_at {
+            None => max_created_at = Some(event.created_at.clone()),
+            Some(ref current) if event.created_at > *current => {
+                max_created_at = Some(event.created_at.clone());
+            }
+            _ => {}
+        }
 
         let responses = db.hitl_responses(&event.id)?;
         for resp in &responses {
@@ -907,6 +931,11 @@ pub fn collect_feedback(db: &Database, repo_name: &str, repo_id: &str) -> Result
                 collected += 1;
             }
         }
+    }
+
+    // Persist cursor so next run skips these events
+    if let Some(ref ts) = max_created_at {
+        db.cursor_upsert(repo_id, cursor_target, ts)?;
     }
 
     Ok(format!(
@@ -1210,6 +1239,9 @@ pub fn parse_convention_context(context: &str) -> Option<(String, String)> {
 /// - choice=2 ("Edit and apply"): use the response message as content
 /// - choice=3 ("Reject"): skip, mark pattern as Rejected
 ///
+/// After processing each event, its status is set to `Applied` so it is not
+/// re-processed on subsequent invocations.
+///
 /// Returns a summary string.
 pub fn apply_approved(
     db: &Database,
@@ -1259,6 +1291,7 @@ pub fn apply_approved(
                         &event.situation,
                         FeedbackPatternStatus::Applied,
                     )?;
+                    db.hitl_set_status(&event.id, HitlStatus::Applied)?;
                     applied += 1;
                 } else {
                     skipped += 1;
@@ -1278,6 +1311,7 @@ pub fn apply_approved(
                             &event.situation,
                             FeedbackPatternStatus::Applied,
                         )?;
+                        db.hitl_set_status(&event.id, HitlStatus::Applied)?;
                         applied += 1;
                     }
                 } else {
@@ -1292,6 +1326,7 @@ pub fn apply_approved(
                     &event.situation,
                     FeedbackPatternStatus::Rejected,
                 )?;
+                db.hitl_set_status(&event.id, HitlStatus::Applied)?;
                 rejected += 1;
             }
             _ => {

--- a/plugins/autodev/cli/src/cli/hitl.rs
+++ b/plugins/autodev/cli/src/cli/hitl.rs
@@ -114,7 +114,7 @@ pub fn respond(
         .hitl_show(id)?
         .ok_or_else(|| anyhow::anyhow!("HITL event not found: {id}"))?;
 
-    if matches!(event.status, HitlStatus::Responded) {
+    if matches!(event.status, HitlStatus::Responded | HitlStatus::Applied) {
         anyhow::bail!("HITL event already responded: {id}");
     }
 

--- a/plugins/autodev/cli/src/core/models.rs
+++ b/plugins/autodev/cli/src/core/models.rs
@@ -525,11 +525,13 @@ impl std::str::FromStr for HitlSeverity {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum HitlStatus {
     Pending,
     Responded,
     Expired,
+    /// The HITL response has been consumed/applied (e.g., convention rule written).
+    Applied,
 }
 
 impl fmt::Display for HitlStatus {
@@ -538,6 +540,7 @@ impl fmt::Display for HitlStatus {
             HitlStatus::Pending => write!(f, "pending"),
             HitlStatus::Responded => write!(f, "responded"),
             HitlStatus::Expired => write!(f, "expired"),
+            HitlStatus::Applied => write!(f, "applied"),
         }
     }
 }
@@ -550,6 +553,7 @@ impl std::str::FromStr for HitlStatus {
             "pending" => Ok(Self::Pending),
             "responded" => Ok(Self::Responded),
             "expired" => Ok(Self::Expired),
+            "applied" => Ok(Self::Applied),
             _ => Err(format!("invalid hitl status: {s}")),
         }
     }

--- a/plugins/autodev/cli/tests/convention_apply_tests.rs
+++ b/plugins/autodev/cli/tests/convention_apply_tests.rs
@@ -217,7 +217,7 @@ fn apply_approved_updates_pattern_status_to_rejected() {
 }
 
 // ═══════════════════════════════════════════════
-// 7. Idempotency: already-applied patterns are skipped
+// 7. Idempotency: already-applied events are skipped on second run
 // ═══════════════════════════════════════════════
 
 #[test]
@@ -233,10 +233,11 @@ fn apply_approved_idempotent_already_applied() {
     let output1 = apply_approved(&db, "org/idempotent-test", &repo_id, tmp.path()).unwrap();
     assert!(output1.contains("1 applied"));
 
-    // Second apply - same events are still responded, so it applies again (appending)
-    // but the key behavior is that it doesn't error out
+    // Second apply - HITL event is now marked as Applied, so it is skipped
     let output2 = apply_approved(&db, "org/idempotent-test", &repo_id, tmp.path()).unwrap();
-    assert!(output2.contains("applied"));
+    assert!(output2.contains("0 applied"));
+    assert!(output2.contains("0 rejected"));
+    assert!(output2.contains("0 skipped"));
 }
 
 // ═══════════════════════════════════════════════
@@ -302,4 +303,50 @@ fn apply_approved_choice_2_empty_message_skips() {
 
     let rule_path = tmp.path().join(".claude/rules/testing.md");
     assert!(!rule_path.exists());
+}
+
+// ═══════════════════════════════════════════════
+// 11. apply_approved marks HITL event status to Applied
+// ═══════════════════════════════════════════════
+
+#[test]
+fn apply_approved_marks_hitl_event_as_applied() {
+    use autodev::core::models::HitlStatus;
+    use autodev::core::repository::HitlRepository;
+
+    let db = open_memory_db();
+    let repo_id = add_test_repo(&db, "org/hitl-status-test");
+    let tmp = TempDir::new().unwrap();
+
+    let event_id = create_convention_hitl(&db, &repo_id, "error-handling");
+    respond_hitl(&db, &event_id, 1, None);
+
+    apply_approved(&db, "org/hitl-status-test", &repo_id, tmp.path()).unwrap();
+
+    // HITL event should now have Applied status
+    let event = db.hitl_show(&event_id).unwrap().unwrap();
+    assert_eq!(event.status, HitlStatus::Applied);
+}
+
+// ═══════════════════════════════════════════════
+// 12. apply_approved marks rejected HITL event as Applied too
+// ═══════════════════════════════════════════════
+
+#[test]
+fn apply_approved_marks_rejected_hitl_event_as_applied() {
+    use autodev::core::models::HitlStatus;
+    use autodev::core::repository::HitlRepository;
+
+    let db = open_memory_db();
+    let repo_id = add_test_repo(&db, "org/hitl-reject-status-test");
+    let tmp = TempDir::new().unwrap();
+
+    let event_id = create_convention_hitl(&db, &repo_id, "style");
+    respond_hitl(&db, &event_id, 3, None);
+
+    apply_approved(&db, "org/hitl-reject-status-test", &repo_id, tmp.path()).unwrap();
+
+    // HITL event should be Applied (consumed), regardless of rejection
+    let event = db.hitl_show(&event_id).unwrap().unwrap();
+    assert_eq!(event.status, HitlStatus::Applied);
 }

--- a/plugins/autodev/cli/tests/feedback_pattern_tests.rs
+++ b/plugins/autodev/cli/tests/feedback_pattern_tests.rs
@@ -838,3 +838,42 @@ async fn collect_feedback_from_pr_reviews_deduplicates() {
     assert_eq!(patterns.len(), 1);
     assert_eq!(patterns[0].suggestion, "Please add tests");
 }
+
+// ═══════════════════════════════════════════════
+// 31. collect_feedback does not re-process already-seen events (cursor-based dedup)
+// ═══════════════════════════════════════════════
+
+#[test]
+fn collect_feedback_skips_already_processed_events() {
+    use autodev::core::models::NewHitlResponse;
+
+    let db = open_memory_db();
+    let repo_id = add_test_repo(&db, "org/dedup-test");
+
+    // Create and respond to a HITL event
+    let event_id = create_hitl_event(&db, &repo_id, "Build error in CI");
+    db.hitl_respond(&NewHitlResponse {
+        event_id: event_id.clone(),
+        choice: Some(1),
+        message: Some("Use anyhow for error handling".to_string()),
+        source: "cli".to_string(),
+    })
+    .unwrap();
+
+    // First collection
+    let output1 =
+        autodev::cli::convention::collect_feedback(&db, "org/dedup-test", &repo_id).unwrap();
+    assert!(output1.contains("Collected 1 feedback pattern(s) from 1 HITL responses"));
+
+    let patterns = db.feedback_list(&repo_id).unwrap();
+    assert_eq!(patterns[0].occurrence_count, 1);
+
+    // Second collection should skip the already-processed event
+    let output2 =
+        autodev::cli::convention::collect_feedback(&db, "org/dedup-test", &repo_id).unwrap();
+    assert!(output2.contains("Collected 0 feedback pattern(s) from 0 HITL responses"));
+
+    // occurrence_count should NOT have been incremented
+    let patterns = db.feedback_list(&repo_id).unwrap();
+    assert_eq!(patterns[0].occurrence_count, 1);
+}


### PR DESCRIPTION
## Summary
- **#402**: `collect_feedback()` now tracks a cursor via `scan_cursors` (target `"feedback-hitl"`) to skip already-processed HITL events, preventing `occurrence_count` inflation on repeated runs
- **#380**: `apply_approved()` now marks consumed HITL events with a new `HitlStatus::Applied` status, preventing duplicate convention rule creation on re-invocation
- Adds `HitlStatus::Applied` variant and blocks responding to already-applied HITL events

## Test plan
- [x] New test: `collect_feedback_skips_already_processed_events` — verifies second run yields 0 collected and occurrence_count stays at 1
- [x] Updated test: `apply_approved_idempotent_already_applied` — verifies second run yields 0 applied/rejected/skipped
- [x] New tests: `apply_approved_marks_hitl_event_as_applied` and `apply_approved_marks_rejected_hitl_event_as_applied` — verifies HITL event status transitions
- [x] All existing tests pass (613 total, 0 failures)
- [x] `cargo fmt --check`, `cargo clippy -- -D warnings` pass

Closes #402, Closes #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)