### PR TITLE
fix(autodev): add built-in cron removal guard and align decisions output fields

### DIFF
--- a/plugins/autodev/cli/src/cli/cron.rs
+++ b/plugins/autodev/cli/src/cli/cron.rs
@@ -126,6 +126,15 @@ pub fn cron_resume(db: &Database, name: &str, repo: Option<&str>) -> Result<()> 
 
 /// Remove a cron job
 pub fn cron_remove(db: &Database, name: &str, repo: Option<&str>) -> Result<()> {
+    // Guard: prevent removal of built-in cron jobs
+    if let Some(job) = db.cron_show(name, repo)? {
+        if job.builtin {
+            anyhow::bail!(
+                "cannot remove built-in cron job '{name}'. Use 'cron pause' / 'cron resume' instead."
+            );
+        }
+    }
+
     db.cron_remove(name, repo)?;
     println!("removed cron job: {name}");
     Ok(())

--- a/plugins/autodev/cli/src/core/models.rs
+++ b/plugins/autodev/cli/src/core/models.rs
@@ -797,11 +797,20 @@ pub struct ClawDecision {
     pub id: String,
     pub repo_id: String,
     pub spec_id: Option<String>,
+    #[serde(rename = "action")]
     pub decision_type: DecisionType,
     pub target_work_id: Option<String>,
     pub reasoning: String,
+    /// Spec 12 requires a confidence field in JSON output.
+    /// Not stored in DB; defaults to 1.0.
+    #[serde(default = "default_confidence")]
+    pub confidence: f64,
     pub context_json: Option<String>,
     pub created_at: String,
+}
+
+fn default_confidence() -> f64 {
+    1.0
 }
 
 pub struct NewClawDecision {

--- a/plugins/autodev/cli/src/infra/db/repository.rs
+++ b/plugins/autodev/cli/src/infra/db/repository.rs
@@ -1520,6 +1520,7 @@ fn map_decision_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<ClawDecision> {
         })?,
         target_work_id: row.get(4)?,
         reasoning: row.get(5)?,
+        confidence: 1.0,
         context_json: row.get(6)?,
         created_at: row.get(7)?,
     })

--- a/plugins/autodev/cli/tests/claw_decision_cli_tests.rs
+++ b/plugins/autodev/cli/tests/claw_decision_cli_tests.rs
@@ -63,7 +63,8 @@ fn cli_list_json_returns_valid_json() {
     let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
     assert!(parsed.is_array());
     assert_eq!(parsed.as_array().unwrap().len(), 1);
-    assert_eq!(parsed[0]["decision_type"], "skip");
+    assert_eq!(parsed[0]["action"], "skip");
+    assert_eq!(parsed[0]["confidence"], 1.0);
 }
 
 #[test]
@@ -131,7 +132,8 @@ fn cli_show_json_returns_valid_json() {
     let output = decisions::show(&db, &id, true).unwrap();
     let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
     assert_eq!(parsed["id"], id);
-    assert_eq!(parsed["decision_type"], "replan");
+    assert_eq!(parsed["action"], "replan");
+    assert_eq!(parsed["confidence"], 1.0);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- **#419**: Add a guard in `cron_remove()` that checks the `builtin` flag before deleting. Built-in cron jobs now return an error suggesting `cron pause` / `cron resume` instead.
- **#418**: Align `spec decisions --json` output with Spec 12 by renaming `decision_type` to `action` via `#[serde(rename)]` and adding a `confidence` field (default `1.0`) to `ClawDecision`.

## Test plan
- [x] Existing `claw_decision_cli_tests` updated and passing (assertions check `action` and `confidence` fields)
- [x] `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` all pass

Closes #419, Closes #418

🤖 Generated with [Claude Code](https://claude.com/claude-code)