### PR TITLE
fix(autodev): use char-based truncation to prevent multibyte panic

### DIFF
--- a/plugins/autodev/cli/src/cli/spec.rs
+++ b/plugins/autodev/cli/src/cli/spec.rs
@@ -546,10 +546,12 @@ fn resolve_repo_name(db: &Database, repo_id: &str) -> Result<String> {
 /// Truncate output to a maximum length, appending "..." if truncated.
 fn truncate_output(s: &str, max_len: usize) -> String {
     let trimmed = s.trim();
-    if trimmed.len() <= max_len {
+    let char_count = trimmed.chars().count();
+    if char_count <= max_len {
         trimmed.replace('\n', " | ")
     } else {
-        format!("{}...", &trimmed[..max_len].replace('\n', " | "))
+        let truncated: String = trimmed.chars().take(max_len).collect();
+        format!("{}...", truncated.replace('\n', " | "))
     }
 }
 


### PR DESCRIPTION
## Summary
- Replace `&trimmed[..max_len]` byte slicing with `chars().take(max_len).collect()` in `truncate_output()`
- Prevents runtime panic on Korean/emoji characters in test command output

## Test plan
- [ ] Verify cargo test passes
- [ ] Verify multibyte strings don't cause panic

Closes #428

🤖 Generated with [Claude Code](https://claude.com/claude-code)