### PR TITLE
docs(autodev): add v5 spec draft — DataSource + AgentRuntime architecture

### DIFF
--- a/plugins/autodev/spec/draft/00-agent-runtime/flow.md
+++ b/plugins/autodev/spec/draft/00-agent-runtime/flow.md
@@ -1,0 +1,165 @@
+# Flow 0: AgentRuntime trait
+
+### 시나리오
+
+LLM 실행 시스템(Claude, Gemini, Codex, ...)을 추상화한다.
+새 LLM 추가 = 새 AgentRuntime impl, 코어 변경 0 (OCP).
+
+### 현재 구조의 문제
+
+```
+core/task.rs:
+  AgentRequest { session_opts: SessionOptions }  ← Claude 전용
+
+infra/claude/:
+  trait Claude → RealClaude                      ← Claude 하드코딩
+
+main.rs:
+  autodev agent → claude --print -p "..."        ← Claude 하드코딩
+```
+
+core가 infra(Claude)에 의존하고 있다.
+
+### trait 정의
+
+autodev가 **실제로 필요한 기능**에서 도출한 인터페이스:
+
+```rust
+/// core/runtime.rs
+
+#[async_trait]
+pub trait AgentRuntime: Send + Sync {
+    fn name(&self) -> &str;
+    async fn invoke(&self, request: RuntimeRequest) -> RuntimeResponse;
+    fn capabilities(&self) -> RuntimeCapabilities;
+}
+
+pub struct RuntimeRequest {
+    pub working_dir: PathBuf,
+    pub prompt: String,
+    pub system_prompt: Option<String>,
+    pub structured_output: Option<StructuredOutput>,
+    pub session_id: Option<String>,
+}
+
+pub struct StructuredOutput {
+    pub schema: String,
+}
+
+pub struct RuntimeResponse {
+    pub exit_code: i32,
+    pub stdout: String,
+    pub stderr: String,
+    pub duration: Duration,
+    pub token_usage: Option<TokenUsage>,
+    pub session_id: Option<String>,
+}
+
+pub struct RuntimeCapabilities {
+    pub can_edit_files: bool,
+    pub supports_structured_output: bool,
+    pub supports_system_prompt: bool,
+    pub supports_session_resume: bool,
+    pub max_context_tokens: usize,
+}
+```
+
+### 의존성 방향
+
+```
+core/runtime.rs (trait + DTO)
+     ↑ impl
+infra/runtimes/
+  ├── claude.rs
+  ├── gemini.rs
+  ├── codex.rs
+  └── custom.rs
+
+core → infra 방향 의존 없음.
+```
+
+### core 옵션 → CLI 매핑 (각 런타임의 책임)
+
+| core 옵션 | Claude | Gemini | Codex |
+|-----------|--------|--------|-------|
+| `system_prompt` | `--append-system-prompt` | prompt prepend | prompt prepend |
+| `structured_output` | `--output-format json` + `--json-schema` | `--output-format json` | `--output-schema <file>` + `--json` |
+| `working_dir` | `current_dir()` | `current_dir()` | `--cd <dir>` |
+| `session_id` | `--resume <uuid>` | `--resume <id>` | `codex exec resume <id>` |
+
+기능 미지원 시 각 런타임이 폴백 처리 (예: system_prompt → prompt prepend).
+
+### RuntimeRegistry
+
+```rust
+pub struct RuntimeRegistry {
+    runtimes: HashMap<String, Arc<dyn AgentRuntime>>,
+    default_name: String,
+    overrides: HashMap<TaskKind, String>,
+}
+
+impl RuntimeRegistry {
+    pub fn resolve(&self, task_kind: TaskKind) -> Arc<dyn AgentRuntime> {
+        let name = self.overrides.get(&task_kind).unwrap_or(&self.default_name);
+        self.runtimes[name].clone()
+    }
+}
+```
+
+### 설정
+
+```yaml
+# .autodev.yaml
+runtime:
+  default: claude
+  claude:
+    model: sonnet
+  overrides:
+    analyze: claude
+    implement: claude
+    review: gemini
+    claw_evaluate: claude
+```
+
+### 멀티턴 세션
+
+```
+요청 시 session_id: None   → 새 세션 시작
+응답에  session_id: Some()  → 다음 턴에서 재사용
+
+활용: Claw가 큐 평가 → advance 판단 → 같은 세션에서 후속 조치
+```
+
+### 확장 시나리오
+
+```yaml
+# Multi-LLM 리뷰
+runtime:
+  overrides:
+    review: multi
+  multi:
+    runtimes: [claude, gemini, codex]
+    strategy: consensus
+
+# 비용 최적화
+runtime:
+  overrides:
+    analyze: haiku
+    implement: sonnet
+    claw_evaluate: opus
+
+# 로컬 LLM
+runtime:
+  default: ollama
+  custom:
+    ollama:
+      command: "ollama"
+      args_template: "run codellama {prompt}"
+```
+
+---
+
+### 관련 플로우
+
+- [Flow 0: DataSource](../00-datasource/flow.md)
+- [Flow 10: Claw 워크스페이스](../10-claw-workspace/flow.md)

--- a/plugins/autodev/spec/draft/00-datasource/flow.md
+++ b/plugins/autodev/spec/draft/00-datasource/flow.md
@@ -1,0 +1,191 @@
+# Flow 0: DataSource trait
+
+### 시나리오
+
+외부 시스템(GitHub, Slack, Jira, ...)의 lifecycle을 하나의 trait으로 캡슐화한다.
+새 외부 시스템 추가 = 새 DataSource impl, 코어 변경 0 (OCP).
+
+### 역할 분리
+
+```
+코어    = DB 전이, 의존성 분석, 스펙 링크, decision 기록 (내부 로직)
+DataSource = 수집, 라벨 동기화, 코멘트, 알림, escalation (외부 시스템)
+```
+
+코어는 "무엇을 해야 하는지", DataSource는 "외부 시스템에 어떻게 반영하는지".
+
+### trait 정의
+
+```rust
+#[async_trait]
+pub trait DataSource: Send + Sync {
+    fn name(&self) -> &str;
+
+    // ── 수집 ──
+    async fn collect(&mut self, repo: &RepoConfig) -> Result<Vec<QueueItem>>;
+
+    // ── 큐 상태 전이 hook ──
+    async fn on_phase_enter(&self, phase: QueuePhase, item: &QueueItem, ctx: &HookContext) -> Result<()>;
+    async fn on_phase_exit(&self, phase: QueuePhase, item: &QueueItem, ctx: &HookContext) -> Result<()>;
+
+    // ── Task 실행 hook ──
+    async fn before_task(&self, kind: TaskKind, item: &QueueItem, ctx: &HookContext) -> Result<()>;
+    async fn after_task(&self, kind: TaskKind, item: &QueueItem, result: &TaskOutcome, ctx: &HookContext) -> Result<()>;
+
+    // ── 완료/실패/skip ──
+    async fn on_done(&self, item: &QueueItem, ctx: &HookContext) -> Result<()>;
+    async fn on_failed(&self, item: &QueueItem, failure_count: u32, ctx: &HookContext) -> Result<EscalationAction>;
+    async fn on_skip(&self, item: &QueueItem, reason: &str, ctx: &HookContext) -> Result<()>;
+
+    // ── HITL 알림 (선택적) ──
+    async fn after_hitl_created(&self, event: &HitlEvent, ctx: &HookContext) -> Result<()> { Ok(()) }
+}
+```
+
+### HookContext
+
+```rust
+pub struct HookContext<'a> {
+    pub db: &'a dyn Database,
+    pub repo: &'a RepoConfig,
+    pub decisions: &'a dyn ClawDecisionRepository,
+}
+```
+
+### EscalationAction
+
+DataSource가 실패 정책을 결정하고, 코어가 실행한다.
+
+```rust
+pub enum EscalationAction {
+    Retry,
+    CommentAndRetry { comment: String },
+    Hitl { event: NewHitlEvent },
+    Skip { reason: String },
+    Replan { event: NewHitlEvent },
+}
+```
+
+### GitHubDataSource 구현
+
+```rust
+impl DataSource for GitHubDataSource {
+    fn name(&self) -> &str { "github" }
+
+    async fn collect(&mut self, repo: &RepoConfig) -> Result<Vec<QueueItem>> {
+        // autodev:analyze 라벨이 붙은 이슈/PR 감지 → QueueItem 반환
+    }
+
+    async fn on_phase_enter(&self, phase: QueuePhase, item: &QueueItem, _ctx: &HookContext) -> Result<()> {
+        match phase {
+            Pending  => self.gh.add_label(item, "autodev:queued").await,
+            Ready    => self.gh.replace_label(item, "autodev:queued", "autodev:ready").await,
+            Running  => self.gh.replace_label(item, "autodev:ready", "autodev:wip").await,
+            Done     => self.gh.replace_label(item, "autodev:wip", "autodev:done").await,
+            Skipped  => self.gh.add_label(item, "autodev:skip").await,
+        }
+    }
+
+    async fn before_task(&self, kind: TaskKind, item: &QueueItem, ctx: &HookContext) -> Result<()> {
+        match kind {
+            TaskKind::Analyze => {
+                self.gh.comment(item, "🔍 분석을 시작합니다...").await?;
+            }
+            TaskKind::Implement => {
+                let branch = ctx.repo.convention.branch_name(item);
+                self.gh.comment(item, &format!("🔨 구현 시작: `{branch}`")).await?;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    async fn on_done(&self, item: &QueueItem, _ctx: &HookContext) -> Result<()> {
+        self.gh.comment(item, "✅ 완료되었습니다.").await
+    }
+
+    async fn on_failed(&self, item: &QueueItem, failure_count: u32, _ctx: &HookContext) -> Result<EscalationAction> {
+        match failure_count {
+            1     => Ok(EscalationAction::Retry),
+            2     => Ok(EscalationAction::CommentAndRetry { comment: "⚠️ 2회 실패".into() }),
+            3     => Ok(EscalationAction::Hitl { event: escalation_hitl(item, Level3) }),
+            4     => Ok(EscalationAction::Skip { reason: "4회 실패 자동 스킵".into() }),
+            _     => Ok(EscalationAction::Replan { event: replan_hitl(item) }),
+        }
+    }
+
+    async fn on_skip(&self, item: &QueueItem, reason: &str, _ctx: &HookContext) -> Result<()> {
+        self.gh.comment(item, &format!("⏭️ 건너뜁니다: {reason}")).await
+    }
+
+    async fn after_hitl_created(&self, event: &HitlEvent, _ctx: &HookContext) -> Result<()> {
+        // 이슈에 HITL 코멘트 (선택지 포함)
+        self.gh.comment_hitl(event).await
+    }
+}
+```
+
+### 향후 확장 예시
+
+```rust
+// Slack
+impl DataSource for SlackDataSource {
+    async fn on_phase_enter(&self, phase, item, _ctx) -> Result<()> {
+        match phase {
+            Running => self.slack.react(item.thread_ts, "👀").await,
+            Done    => self.slack.react(item.thread_ts, "✅").await,
+            _       => Ok(())
+        }
+    }
+}
+
+// Jira
+impl DataSource for JiraDataSource {
+    async fn on_phase_enter(&self, phase, item, _ctx) -> Result<()> {
+        match phase {
+            Running => self.jira.transition(item.jira_key, "In Progress").await,
+            Done    => self.jira.transition(item.jira_key, "Done").await,
+            _       => Ok(())
+        }
+    }
+}
+```
+
+### 레포 설정에서 바인딩
+
+```yaml
+# .autodev.yaml
+sources:
+  github:
+    scan_interval_secs: 300
+    issue_concurrency: 1
+    pr_concurrency: 1
+```
+
+하나의 레포에 여러 DataSource 바인딩 가능:
+
+```yaml
+sources:
+  github:
+    scan_interval_secs: 300
+  slack:
+    channel: "#dev-autodev"
+```
+
+### 트랜잭션 정책
+
+```
+1. DB 전이 (코어, atomic)          ← 필수, 실패 시 롤백
+2. DataSource hook (best-effort)    ← 실패해도 전이는 유효
+   → 실패 시 보상 큐에 추가 → 다음 tick에서 재시도 (최대 3회)
+   → 3회 실패 시 로그 경고 (다음 collect에서 보정 가능)
+```
+
+---
+
+### 관련 플로우
+
+- [Flow 0: AgentRuntime](../00-agent-runtime/flow.md)
+- [Flow 1: 레포 등록](../01-repo-registration/flow.md)
+- [Flow 2: 이슈 등록](../02-issue-registration/flow.md)
+- [Flow 9: 실패 복구](../09-failure-recovery/flow.md)

--- a/plugins/autodev/spec/draft/01-repo-registration/flow.md
+++ b/plugins/autodev/spec/draft/01-repo-registration/flow.md
@@ -1,0 +1,120 @@
+# Flow 1: 레포 등록/변경/제거
+
+## 레포 등록
+
+### 시나리오
+
+사용자가 autodev로 관리할 레포를 등록한다.
+
+### 입력
+
+```bash
+autodev repo add <github-url> [--config '<JSON>']
+```
+
+### 설정 필드
+
+```yaml
+sources:
+  github:
+    scan_interval_secs: 300
+    scan_targets: [issues, pulls]
+    issue_concurrency: 1
+    pr_concurrency: 1
+    filter_labels: null
+    ignore_authors: [dependabot, renovate]
+    gh_host: null
+    auto_approve: false
+    auto_approve_threshold: 0.8
+    knowledge_extraction: true
+
+runtime:
+  default: claude
+  claude:
+    model: sonnet
+  overrides: {}
+```
+
+### 기대 동작
+
+```
+1. URL에서 org/repo 이름 추출
+2. DB에 레포 등록 (UUID 생성, enabled=1)
+3. workspace 디렉토리 생성 (~/.autodev/workspaces/org-repo/)
+4. --config 제공 시 → workspace YAML에 deep merge 저장
+5. DataSource 바인딩:
+   → sources 섹션 파싱 → GitHubDataSource 인스턴스 생성
+   → Daemon에 등록 (collect, hook 호출 대상)
+6. AgentRuntime 바인딩:
+   → runtime 섹션 파싱 → RuntimeRegistry 구성
+7. per-repo cron seed (claw-evaluate, gap-detection, knowledge-extract)
+```
+
+### 저장 구조
+
+```
+~/.autodev/
+├── autodev.db
+├── .autodev.yaml                  # 글로벌 설정
+└── workspaces/
+    └── org-repo/
+        ├── .autodev.yaml          # 레포별 설정 오버라이드
+        └── claw/                  # Claw per-repo 오버라이드
+```
+
+설정은 2-level merge: 글로벌 + 레포별 → 유효 설정
+
+### Claw 활성화 시 추가 단계
+
+```
+8. Claw 워크스페이스 초기화 확인
+   → ~/.autodev/claw-workspace/ 없으면 autodev claw init
+9. 레포의 .claude/rules/ 확인
+   → 비어있으면 → Flow 11: 컨벤션 부트스트랩 제안
+10. 레포별 Claw 오버라이드 초기화
+```
+
+---
+
+## 레포 설정 변경
+
+```bash
+autodev repo update <name> --config '<JSON>'
+autodev repo config <name>    # 유효 설정 조회
+```
+
+---
+
+## 레포 제거
+
+```bash
+autodev repo remove <name>
+```
+
+```
+1. 연관 데이터 cascade 삭제 (token_usage, scan_cursors, specs, queue_items, cron_jobs)
+2. repositories 레코드 삭제
+3. GitHub 이슈/PR/라벨은 유지 (로컬 데이터만 삭제)
+```
+
+---
+
+## Daemon의 레포 활용
+
+Daemon tick마다:
+
+```
+1. repo_find_enabled() → 활성 레포 목록
+2. 레포별 DataSource 인스턴스로 collect()
+3. issue_concurrency, pr_concurrency로 동시 Task 수 제한
+4. RuntimeRegistry.resolve(task_kind)로 적절한 AgentRuntime 선택
+```
+
+---
+
+### 관련 플로우
+
+- [Flow 0: DataSource](../00-datasource/flow.md)
+- [Flow 0: AgentRuntime](../00-agent-runtime/flow.md)
+- [Flow 10: Claw 워크스페이스](../10-claw-workspace/flow.md)
+- [Flow 11: 컨벤션 부트스트랩](../11-convention-bootstrap/flow.md)

--- a/plugins/autodev/spec/draft/02-issue-registration/flow.md
+++ b/plugins/autodev/spec/draft/02-issue-registration/flow.md
@@ -1,0 +1,69 @@
+# Flow 2: 이슈 등록 (Issue 모드)
+
+### 시나리오
+
+사람이 GitHub에 이슈를 만들고 `autodev:analyze` 라벨을 추가한다.
+
+### 기대 동작
+
+```
+1. DataSource.collect(): 라벨 감지 → QueueItem 생성
+2. Daemon: DB에 Pending 저장
+3. 코어 on_enter_pending:
+   a. DependencyAnalyzer: 파일 단위 의존성 분석
+   b. SpecLinker: spec_issues 자동 링크
+   c. DecisionRecorder: 수집 기록
+4. DataSource.on_phase_enter(Pending): 라벨 부착 (autodev:queued)
+5. Claw evaluate: advance 판단 → Pending → Ready
+6. Daemon drain: Ready → Running
+   → DataSource.before_task(): 시작 코멘트
+   → AgentRuntime.invoke(): Task 실행
+   → DataSource.after_task(): 결과 코멘트
+7. 완료 시 → 코어 on_done + DataSource.on_done()
+8. 실패 시 → DataSource.on_failed() → EscalationAction → 코어 처리
+```
+
+### DependencyAnalyzer (코어, on_enter_pending)
+
+파일 단위 의존성 분석. DataSource 무관, 모든 소스에 공통 적용.
+
+```
+1. 이슈 본문에서 파일 경로 추출
+   - 코드 블록 내 경로
+   - 명시적 경로 (src/auth/login.rs)
+   - 스펙 참조 내 파일 목록
+2. 큐의 다른 Pending/Running 아이템과 파일 경로 비교
+3. 겹침 발견 → dependency 메타데이터에 선행 work_id 기록
+```
+
+Claw가 다음 evaluate에서 의미론적 보정 (같은 모듈이지만 다른 파일 등).
+
+### SpecLinker (코어, on_enter_pending)
+
+```
+1. 이슈 라벨에서 [XX-spec-name] 패턴 매칭
+2. 이슈 본문에서 스펙 참조 추출
+3. 매칭 시 spec_issues 테이블 링크
+4. 실패 시 로그만 (Claw가 보정)
+```
+
+### DataSource hook 예시 (GitHub)
+
+```
+on_phase_enter(Pending)  → autodev:queued 라벨
+on_phase_enter(Ready)    → autodev:ready 라벨
+on_phase_enter(Running)  → autodev:wip 라벨
+before_task(Analyze)     → "🔍 분석을 시작합니다..." 코멘트
+after_task(Analyze, Ok)  → 분석 리포트 코멘트
+on_done()                → "✅ 완료" 코멘트 + autodev:done 라벨
+on_failed(count=3)       → HITL 이벤트 생성 + GitHub 코멘트
+```
+
+---
+
+### 관련 플로우
+
+- [Flow 0: DataSource](../00-datasource/flow.md)
+- [Flow 4: 다중 스펙 우선순위](../04-spec-priority/flow.md)
+- [Flow 5: HITL 알림](../05-hitl-notification/flow.md)
+- [Flow 9: 실패 복구](../09-failure-recovery/flow.md)

--- a/plugins/autodev/spec/draft/03-spec-registration/flow.md
+++ b/plugins/autodev/spec/draft/03-spec-registration/flow.md
@@ -1,0 +1,77 @@
+# Flow 3: 스펙 등록 (Spec 모드)
+
+### 시나리오
+
+사용자가 디자인 스펙을 등록하여 자율 구현 루프를 시작한다.
+
+### 입력
+
+```
+/spec add [file]            # Plugin command (대화형 보완)
+autodev spec add --title ... --file ...   # CLI (경고만)
+```
+
+### Spec Lifecycle
+
+```
+Draft ──→ Active ←──→ Paused
+              │
+              ▼
+          Completing
+              │
+              ▼
+          Completed (terminal)
+
+Any ──→ Archived (soft delete)
+Archived ──resume──→ Active (복구)
+```
+
+| 상태 | 가능한 전이 | CLI |
+|------|------------|-----|
+| Draft | → Active | `spec add` (등록 시 바로 Active) |
+| Active | → Paused, → Completing(자동), → Archived | `spec pause`, `spec remove` |
+| Paused | → Active, → Archived | `spec resume`, `spec remove` |
+| Completing | → Active(테스트 실패), → Completed(HITL 승인) | 자동 |
+| Completed | → Archived | `spec remove` |
+| Archived | → Active | `spec resume` (복구) |
+
+### 기대 동작
+
+```
+1. 스펙 본문 파싱 → 필수 섹션 검증
+   필수 섹션: 개요, 요구사항, 아키텍처, 테스트 환경, 수용 기준
+   CLI: 누락 시 경고 (--force로 진행 가능)
+   Plugin: 누락 시 대화형 보완 (레포 컨텍스트 기반 자동 제안)
+
+2. DB에 저장 (status: Active)
+
+3. 코어 on_spec_active 이벤트:
+   → ForceClawEvaluate: claw-evaluate cron 즉시 트리거
+
+4. Claw evaluate:
+   → decompose skill로 스펙 분해 → 이슈 자동 생성
+   → 각 이슈에 autodev:analyze 라벨
+   → convention 기반 이슈 템플릿 적용
+
+5. 생성된 이슈들이 큐에 진입 → Flow 2 파이프라인
+```
+
+### /spec 통합 커맨드
+
+```
+/spec                → 목록 (autodev spec list)
+/spec add [file]     → 등록 (기존 /add-spec)
+/spec update <id>    → 수정 (기존 /update-spec, Flow 7)
+/spec status <id>    → 진행도 상세
+/spec remove <id>    → Archived
+/spec pause <id>     → 일시정지
+/spec resume <id>    → 재개 (Archived에서도 복구)
+```
+
+---
+
+### 관련 플로우
+
+- [Flow 7: 피드백 루프](../07-feedback-loop/flow.md) — /spec update
+- [Flow 8: 스펙 완료 판정](../08-spec-completion/flow.md)
+- [Flow 11: 컨벤션 부트스트랩](../11-convention-bootstrap/flow.md) — 이슈 템플릿

--- a/plugins/autodev/spec/draft/04-spec-priority/flow.md
+++ b/plugins/autodev/spec/draft/04-spec-priority/flow.md
@@ -1,0 +1,40 @@
+# Flow 4: 다중 스펙 우선순위
+
+### 시나리오
+
+하나의 레포에 여러 스펙이 Active 상태로 존재한다.
+
+### Claw의 판단
+
+```
+독립 스펙: 병렬 실행 (concurrency 제한 내)
+의존 스펙: 선행 스펙 먼저 처리 (Claw가 순서 결정)
+충돌 스펙: 같은 파일/모듈 → HITL 요청 (사용자가 우선순위 결정)
+```
+
+### DependencyGuard (코어, advance 시)
+
+Claw가 의존성을 판단하면, 코어의 DependencyGuard가 실행 순서를 강제한다.
+
+```
+queue advance B 요청 시:
+  1. B의 dependency 메타데이터 확인
+  2. 선행 아이템 A가 Done 아니면 → advance 차단
+  3. A가 Done이면 → 통과 → DataSource.on_phase_enter(Ready)
+```
+
+Claw는 "A가 B보다 먼저"라는 판단만 기록. 나머지는 상태 머신이 강제.
+
+### CLI
+
+```bash
+autodev spec prioritize <id1> <id2> ...   # 순서 지정
+autodev queue dependency add <work_id> --depends-on <work_id>
+```
+
+---
+
+### 관련 플로우
+
+- [Flow 2: 이슈 등록](../02-issue-registration/flow.md) — DependencyAnalyzer
+- [Flow 5: HITL 알림](../05-hitl-notification/flow.md) — 충돌 시 HITL

--- a/plugins/autodev/spec/draft/05-hitl-notification/flow.md
+++ b/plugins/autodev/spec/draft/05-hitl-notification/flow.md
@@ -1,0 +1,86 @@
+# Flow 5: HITL 알림
+
+### 시나리오
+
+자동 처리 중 사람의 판단이 필요한 상황이 발생한다.
+
+### HITL 생성 경로
+
+| 생성자 | 트리거 |
+|--------|--------|
+| DataSource.on_failed() | EscalationAction::Hitl/Replan 반환 시 |
+| 코어 on_spec_completing | 최종 확인 요청 시 |
+| 코어 DependencyGuard | 스펙 충돌 감지 시 |
+
+### 이벤트 유형별 선택지 (고정)
+
+```rust
+pub struct HitlOption {
+    pub key: String,      // "retry", "skip" 등
+    pub label: String,    // 사용자 표시용
+    pub action: String,   // 라우팅 대상: "advance", "skip", "replan"
+}
+```
+
+| 유형 | 선택지 |
+|------|--------|
+| Escalation Level 3 | retry→advance, skip→skip, reassign→replan |
+| Escalation Level 5 | replan→replan, force-retry→advance, abandon→skip |
+| Spec Completion | approve→spec_completed, request-changes→spec_active |
+| Conflict | prioritize-A→advance, prioritize-B→advance, pause-both→pause |
+
+### HITL 생성 흐름
+
+```
+1. DataSource.on_failed(item, count=3)
+   → return EscalationAction::Hitl { event }
+2. 코어: db.hitl_create(event)
+3. DataSource.after_hitl_created(event)
+   → GitHub: 이슈에 HITL 코멘트 (선택지 포함)
+   → Slack: 채널에 알림 메시지
+   → Webhook: payload 전송
+```
+
+### 응답 경로
+
+```
+사용자 응답 (TUI / CLI / GitHub 코멘트)
+  → autodev hitl respond <id> --choice N
+  → DB: hitl_response 저장
+  → 코어 on_hitl_responded:
+    1. HitlResponseRouter:
+       "advance"        → queue advance
+       "skip"           → queue skip
+       "replan"         → Claw에게 스펙 수정 제안 위임
+       "spec_completed" → on_spec_completed
+       "spec_active"    → spec Active 복귀
+    2. ForceClawEvaluate
+```
+
+### 타임아웃
+
+```
+기본: 24시간
+초과 시: hitl-timeout cron job이 처리
+  → 설정에 따라: remind / skip / pause_spec
+```
+
+### /claw 세션에서 처리
+
+```
+사용자: "HITL 대기 목록 보여줘"
+Claw: autodev hitl list --json → 포맷팅
+
+사용자: "첫 번째 항목 proceed"
+Claw: autodev hitl respond <id> --choice 1
+  → on_hitl_responded 이벤트 자동 발행
+```
+
+---
+
+### 관련 플로우
+
+- [Flow 0: DataSource](../00-datasource/flow.md) — on_failed, after_hitl_created
+- [Flow 7: 피드백 루프](../07-feedback-loop/flow.md) — replan 경로
+- [Flow 8: 스펙 완료 판정](../08-spec-completion/flow.md) — 최종 확인
+- [Flow 9: 실패 복구](../09-failure-recovery/flow.md) — escalation

--- a/plugins/autodev/spec/draft/06-kanban-board/flow.md
+++ b/plugins/autodev/spec/draft/06-kanban-board/flow.md
@@ -1,0 +1,115 @@
+# Flow 6: 진행 상태 확인 (칸반 보드)
+
+### 시나리오
+
+사용자가 다수 레포 × 다수 스펙의 전체 진행 상황을 한눈에 확인한다.
+
+### 인터페이스 3개 레이어
+
+| 레이어 | 진입 | 특징 |
+|--------|------|------|
+| TUI Dashboard | `autodev dashboard` | ratatui, 실시간 갱신, 키보드 네비게이션 |
+| CLI 출력 | `autodev board --format rich` | 정적 스냅샷, 진행률 바 |
+| Claw 세션 | `/claw` → "보드 보여줘" | 자연어, autodev board --json 파싱 |
+
+### TUI Dashboard
+
+#### AllRepos 뷰 (기본)
+
+```
+┌─ Repos ──────┐┌─ Active Items ─────┐┌─ Runtime ─────────────┐
+│ ● org/repo-a ││ 🔄 #42 Analyze     ││ claude/sonnet  12 OK  │
+│ ○ org/repo-b ││ 🔄 #44 Implement   ││ Tokens: 45.2K / 1h   │
+│              ││                    ││ Avg: 4m 32s          │
+├──────────────┤├────────────────────┤├───────────────────────┤
+│ Logs         ││ DataSource         ││ Hooks (1h)            │
+│ 14:30 adv #42││ github ● connected ││ on_phase_enter 24 ok  │
+│ 14:25 dec .. ││   scan: 30s ago    ││ before_task     8 ok  │
+│ 14:20 skip   ││   compensation: 0  ││ ⚠ LabelSyncer: 1     │
+└──────────────┘└────────────────────┘└───────────────────────┘
+```
+
+#### PerRepo 뷰 (Tab 전환)
+
+```
+┌─ Board ──────────────────────────────┐┌─ Active ──────────┐
+│ auth-v2  ████████░░ 60% (3/5)        ││ 🔄 #44 Implement  │
+│   ✅ #42 JWT middleware               ││   claude/sonnet    │
+│   ✅ #43 Token API                    ││   3m elapsed       │
+│   🔄 #44 Session adapter (running)   ││                    │
+│   ⏳ #45 Error handling (dep: #44)   ││                    │
+│   ⏳ #46 Missing tests               ││                    │
+├──────────────────────────────────────┤├────────────────────┤
+│ Orphan: 0 | HITL: 1 pending         ││ Logs               │
+│ Kanban: 0P | 0R | 1R | 2D | 0S     ││ ...                │
+└──────────────────────────────────────┘└────────────────────┘
+```
+
+#### 전이 타임라인 (ItemDetail 오버레이, Enter)
+
+```
+┌─ #42 JWT middleware ─────────────────────────┐
+│ Phase: Done | Runtime: claude/sonnet         │
+│                                               │
+│ Timeline:                                     │
+│  14:00 ○ Pending  ← github.collect()         │
+│         └ SpecLinker: linked to auth-v2       │
+│  14:05 ○ Ready    ← Claw advance             │
+│  14:06 ○ Running  ← AnalyzeTask              │
+│         └ claude/sonnet (1.2K tokens, 6m)    │
+│  14:12 ● Done                                 │
+│         └ SpecCompletionCheck: 3/5            │
+└───────────────────────────────────────────────┘
+```
+
+#### 키보드
+
+| 키 | 동작 |
+|----|------|
+| j/k, ↑/↓ | 아이템 이동 |
+| ←/→ | 레포 전환 |
+| Tab | AllRepos ↔ PerRepo |
+| Enter | 상세 / 전이 타임라인 |
+| h | HITL 오버레이 |
+| s | Spec 상세 |
+| d | Claw 판단 이력 |
+| R | 새로고침 |
+
+### CLI 출력 (`--format rich`)
+
+```
+autodev board --format rich
+
+auth-v2  Auth Module v2                    ████████░░░░ 60% (3/5)
+  ✅ #42 JWT middleware
+  ✅ #43 Token API
+  🔄 #44 Session adapter (running, claude/sonnet)
+  ⏳ #45 Error handling (dep: #44)
+  ⏳ #46 Missing tests
+```
+
+### `--format` 옵션 (CLI 공통)
+
+| 값 | 용도 |
+|---|------|
+| `text` | 기본 텍스트 (기존 호환) |
+| `json` | 구조화된 JSON (Claw 파싱용) |
+| `rich` | 색상 + 박스 + 진행률 바 |
+
+### 추가 테이블 (시각화용)
+
+```sql
+transition_events (
+    id          TEXT PRIMARY KEY,
+    work_id     TEXT NOT NULL,
+    event_type  TEXT NOT NULL,
+    detail      TEXT,
+    created_at  TEXT NOT NULL
+)
+```
+
+---
+
+### 관련 플로우
+
+- [Flow 14: 시각화](../14-visualization/flow.md) — 전체 시각화 설계

--- a/plugins/autodev/spec/draft/07-feedback-loop/flow.md
+++ b/plugins/autodev/spec/draft/07-feedback-loop/flow.md
@@ -1,0 +1,52 @@
+# Flow 7: 피드백 루프
+
+### 시나리오
+
+사용자가 구현 결과를 확인하고 수정이 필요하다고 판단한다.
+
+### 3가지 경로
+
+#### Case 1: PR review comment
+
+```
+GitHub에서 changes-requested
+  → DataSource.collect(): 큐에 Review/Improve 아이템 추가
+  → 표준 파이프라인 (DataSource hook + AgentRuntime 실행)
+```
+
+기존 v3 흐름과 동일. DataSource hook이 자동 적용.
+
+#### Case 2: /spec update
+
+```
+/spec update <id>
+  → 현재 스펙 + 진행 상태 로드
+  → 대화형 impact analysis (어떤 이슈가 영향받는지)
+  → 사용자가 변경 승인
+  → autodev spec update CLI 실행
+  → 코어 on_spec_active 이벤트 재발행
+  → ForceClawEvaluate → Claw 재평가
+```
+
+#### Case 3: Replan (HITL 응답)
+
+```
+on_failed Level 5 → DataSource.on_failed() → EscalationAction::Replan
+  → 코어: HITL 생성
+  → DataSource.after_hitl_created(): 알림
+  → 사용자 "replan" 응답
+  → 코어 on_hitl_responded → Claw에게 스펙 수정 제안 위임
+  → 사용자 승인 → spec update → on_spec_active
+```
+
+### 핵심 원칙
+
+**스펙 = 계약**. 계약이 바뀌어야 하면 `/spec update`. 계약 범위 내 작업이면 이슈 등록.
+
+---
+
+### 관련 플로우
+
+- [Flow 3: 스펙 등록](../03-spec-registration/flow.md) — spec lifecycle
+- [Flow 5: HITL 알림](../05-hitl-notification/flow.md) — replan 경로
+- [Flow 9: 실패 복구](../09-failure-recovery/flow.md) — Level 5 replan

--- a/plugins/autodev/spec/draft/08-spec-completion/flow.md
+++ b/plugins/autodev/spec/draft/08-spec-completion/flow.md
@@ -1,0 +1,57 @@
+# Flow 8: 스펙 완료 판정
+
+### 시나리오
+
+스펙에 연결된 모든 이슈가 완료되어 스펙의 목표 달성 여부를 판정한다.
+
+### 자동 감지 (코어 on_done)
+
+```
+Task 완료 → 코어 on_done:
+  → SpecCompletionCheck:
+    1. 이 아이템에 linked spec이 있는가?
+    2. 해당 spec의 모든 linked issues가 Done인가?
+    3. 모두 Done → on_spec_completing 이벤트
+```
+
+### on_spec_completing 파이프라인
+
+```
+1. TestRunner: spec.test_commands 순차 실행
+   → "cargo test -p auth", "cargo test -p auth --test integration" 등
+   → 각 명령의 exit code + stdout/stderr 수집
+   → 실패 항목: 이슈 자동 생성 → on_enter_pending → DataSource hook
+   → 모두 성공: 다음 단계
+
+2. ForceClawEvaluate: gap detection (Claw에게 위임)
+   → Claw가 스펙 vs 현재 코드 비교
+   → gap 발견: 이슈 생성 → 루프 계속
+   → gap 없음: 다음 단계
+
+3. HitlCreator: 최종 확인 HITL (Low severity)
+   → 선택지:
+     approve → on_spec_completed
+     request-changes → Active로 복귀
+```
+
+### on_spec_completed
+
+```
+1. spec.status = Completed
+2. ReportGenerator: 완료 리포트
+   → 소요 시간, 토큰 사용량, 완료 이슈 목록, 생성된 PR 목록
+```
+
+### linked issues 없는 스펙 처리
+
+```
+spec remove <id>              → Archived (소프트 삭제)
+spec complete <id> --force    → HITL 없이 직접 완료
+```
+
+---
+
+### 관련 플로우
+
+- [Flow 3: 스펙 등록](../03-spec-registration/flow.md) — spec lifecycle
+- [Flow 5: HITL 알림](../05-hitl-notification/flow.md) — 최종 확인

--- a/plugins/autodev/spec/draft/09-failure-recovery/flow.md
+++ b/plugins/autodev/spec/draft/09-failure-recovery/flow.md
@@ -1,0 +1,82 @@
+# Flow 9: 실패 복구
+
+### 시나리오
+
+자동 처리 중 실패가 발생하여 복구 또는 사용자 개입이 필요하다.
+
+### Escalation 정책 (DataSource 소유)
+
+각 DataSource가 자신의 escalation 전략을 결정하고, 코어가 실행한다.
+
+```
+Task 실패 → Daemon on_task_complete(Failed):
+  → DataSource.after_task(kind, item, Failed): 실패 코멘트
+  → DataSource.on_failed(item, failure_count):
+    → return EscalationAction (DataSource가 결정)
+  → 코어.apply_escalation(action):
+    Retry           → db.queue_transit(Running, Pending)
+    CommentAndRetry → db.queue_transit(Running, Pending)
+    Hitl { event }  → db.hitl_create + DataSource.after_hitl_created()
+    Skip { reason } → db.queue_skip + DataSource.on_skip()
+    Replan { event }→ db.hitl_create + DataSource.after_hitl_created()
+  → 코어.force_claw_evaluate()
+```
+
+### GitHubDataSource 5단계
+
+| failure_count | Level | 동작 |
+|---------------|-------|------|
+| 1 | Retry | Pending 롤백 (재시도) |
+| 2 | Comment+Retry | GitHub 코멘트 + Pending 롤백 |
+| 3 | HITL | HitlEvent 생성 (High severity) |
+| 4 | Skip | Skipped 전이 |
+| 5+ | Replan | HitlEvent (replan 옵션, Flow 7 연계) |
+
+### OCP 확장
+
+```rust
+// GitHub: 5단계
+impl DataSource for GitHubDataSource {
+    async fn on_failed(&self, item, count, _ctx) -> Result<EscalationAction> {
+        match count { 1 => Retry, 2 => CommentAndRetry, 3 => Hitl, 4 => Skip, _ => Replan }
+    }
+}
+
+// Slack: 다른 정책 가능
+impl DataSource for SlackDataSource {
+    async fn on_failed(&self, item, count, _ctx) -> Result<EscalationAction> {
+        match count { 1 => Retry, _ => Hitl }  // 바로 사용자에게 DM
+    }
+}
+```
+
+새 DataSource 추가 시 escalation 정책만 구현. 코어 변경 0.
+
+### Worktree 보존
+
+```
+DataSource.after_task(Implement, Failed):
+  → worktree 보존 (삭제하지 않음)
+  → HITL 알림에 경로 포함
+  → 보존 기간: 7일 (설정 가능)
+  → autodev worktree list/clean으로 관리
+  → log-cleanup cron에서 만료 시 자동 삭제
+```
+
+### Graceful Shutdown
+
+```
+SIGINT → on_shutdown:
+  1. Running 아이템 완료 대기 (timeout: 30초, 설정 가능)
+     → timeout 초과: Pending으로 롤백
+  2. DataSource.on_phase_exit(Running) 호출 (best-effort)
+  3. Cron engine 정지
+```
+
+---
+
+### 관련 플로우
+
+- [Flow 0: DataSource](../00-datasource/flow.md) — on_failed, EscalationAction
+- [Flow 5: HITL 알림](../05-hitl-notification/flow.md) — Level 3, 5
+- [Flow 7: 피드백 루프](../07-feedback-loop/flow.md) — replan 경로

--- a/plugins/autodev/spec/draft/10-claw-workspace/flow.md
+++ b/plugins/autodev/spec/draft/10-claw-workspace/flow.md
@@ -1,0 +1,109 @@
+# Flow 10: Claw 워크스페이스 설정
+
+### 시나리오
+
+사용자가 Claw의 판단 방식을 자연어로 커스터마이즈하고, Claw 세션으로 상호작용한다.
+
+### 워크스페이스 구조
+
+```
+~/.autodev/claw-workspace/
+├── CLAUDE.md                         # 판단 원칙
+├── .claude/rules/
+│   ├── scheduling.md                 # 큐 평가 규칙
+│   ├── branch-naming.md              # 브랜치 네이밍
+│   ├── review-policy.md              # 리뷰 정책
+│   ├── decompose-strategy.md         # 스펙 분해 전략
+│   ├── hitl-policy.md                # HITL 판단 기준
+│   └── auto-approve-policy.md        # 자동 승인 기준
+├── commands/                         # Claw 세션용 커맨드
+└── skills/
+    ├── decompose/                    # 스펙 분해
+    ├── gap-detect/                   # gap 탐지
+    └── prioritize/                   # 우선순위 판단
+```
+
+Per-repo 오버라이드: `~/.autodev/workspaces/org-repo/claw/` (같은 파일명 = 오버라이드)
+
+### /claw 세션 진입 경험
+
+```
+/claw 실행 →
+
+Step 1: 상태 수집
+  autodev status --json
+  autodev hitl list --json
+  autodev decisions list --json -n 3
+  autodev spec list --json
+
+Step 2: 요약 표시
+
+  📊 autodev 상태 요약
+
+  ● daemon running (uptime 2h 15m)
+
+  Repos:
+    org/repo-a — queue: 1R 2P | specs: auth-v2 ████████░░ 60%
+
+  ⚠ HITL 대기: 1건
+    → #44 Session adapter — 3회 실패
+
+  🧠 최근 판단:
+    14:30 advance #42 | 14:25 decompose auth-v2
+
+  무엇을 도와드릴까요?
+
+Step 3: 자연어 대화
+  → Bash tool로 autodev CLI 호출
+```
+
+### 자연어 → CLI 매핑 예시
+
+```
+"지금 상황 어때?"      → autodev status --format rich
+"큐 막힌 거 있어?"     → autodev queue list --json → 분석
+"413번 진행시켜"       → autodev queue advance issue:org/repo:413
+"HITL 대기 목록"       → autodev hitl list --json
+"cron 일시정지"        → autodev cron pause gap-detection
+"뭐 하면 좋을까?"     → status + hitl + queue 종합 → 추천
+```
+
+### Plugin slash command 통합
+
+```
+v4 (15개) → v5 (3개):
+  /auto   — 데몬 제어 (start/stop/setup/config/dashboard/update)
+  /spec   — 스펙 CRUD (add/update/list/status/remove/pause/resume)
+  /claw   — 대화 세션 (나머지 모든 조회/조작을 자연어로)
+```
+
+### Claw CLI 호출 메커니즘
+
+Bash tool (확정). Claude Code의 Bash tool로 autodev CLI 실행.
+추가 구현 불필요. autodev CLI가 --json 출력 지원.
+
+### Agent와 AgentRuntime 연동
+
+```yaml
+# .autodev.yaml
+runtime:
+  default: claude
+  overrides:
+    claw_evaluate: claude    # Claw headless는 이 런타임 사용
+```
+
+agent .md 파일의 `model` 필드는 해당 runtime 내 모델 선택:
+
+```markdown
+# agents/issue-analyzer.md
+---
+model: sonnet     # ClaudeRuntime → --model sonnet
+---               # GeminiRuntime → 무시 (기본 모델)
+```
+
+---
+
+### 관련 플로우
+
+- [Flow 0: AgentRuntime](../00-agent-runtime/flow.md) — 런타임 선택
+- [Flow 12: CLI 레퍼런스](../12-cli-reference/flow.md) — 전체 커맨드

--- a/plugins/autodev/spec/draft/11-convention-bootstrap/flow.md
+++ b/plugins/autodev/spec/draft/11-convention-bootstrap/flow.md
@@ -1,0 +1,65 @@
+# Flow 11: 컨벤션 부트스트랩 + 자율 개선
+
+### 시나리오
+
+레포 등록 시 `.claude/rules/`가 비어있다면, 기술 스택을 기반으로 컨벤션을 자동 생성한다.
+
+### Phase 1: Bootstrap
+
+```
+1. .claude/rules/ 또는 CLAUDE.md 존재 확인 → 있으면 skip
+2. 스펙/코드에서 기술 스택 추출 (Rust, TypeScript, Go, Python 등)
+3. 카테고리별 컨벤션 제안 (대화형):
+   - 프로젝트 구조
+   - 에러 처리
+   - 테스트 전략
+   - Git 워크플로우
+   - 코드 스타일
+4. 사용자 승인 → PR로 커밋
+```
+
+### Phase 2: 자율 개선
+
+```
+피드백 소스:
+  - HITL 응답의 message 필드
+  - PR 리뷰 코멘트 반복 패턴 (3회 이상)
+  - /spec update로 인한 컨벤션 변경
+  - 사용자 직접 지시
+
+Claw가 패턴 감지 → 규칙 변경 제안 → HITL 승인 → 자동 업데이트
+  - 레포 규칙: PR로 반영
+  - Claw workspace 규칙: 즉시 반영
+```
+
+### DataSource.before_task()에서 활용
+
+```rust
+impl DataSource for GitHubDataSource {
+    async fn before_task(&self, kind, item, ctx) -> Result<()> {
+        if kind == TaskKind::Implement {
+            // convention의 git-workflow 규칙에서 브랜치명 결정
+            let branch = ctx.repo.convention.branch_name(item);
+            // 예: feat/42-jwt-middleware
+        }
+        Ok(())
+    }
+}
+```
+
+### Claw decompose 시 이슈 템플릿
+
+```
+convention/issue-template:
+  - 이슈 본문 섹션: 변경 대상 파일, 테스트 계획
+  - 라벨 자동 부착 규칙
+  - 브랜치 네이밍 패턴
+```
+
+---
+
+### 관련 플로우
+
+- [Flow 0: DataSource](../00-datasource/flow.md) — before_task hook
+- [Flow 1: 레포 등록](../01-repo-registration/flow.md) — 등록 시 트리거
+- [Flow 3: 스펙 등록](../03-spec-registration/flow.md) — decompose 시 템플릿

--- a/plugins/autodev/spec/draft/12-cli-reference/flow.md
+++ b/plugins/autodev/spec/draft/12-cli-reference/flow.md
@@ -1,0 +1,93 @@
+# Flow 12: 인터페이스 레퍼런스
+
+### 아키텍처 (3-layer)
+
+```
+Layer 1: Slash Command (3개, thin wrapper)
+  /auto, /spec, /claw
+
+Layer 2: DataSource + AgentRuntime (OCP 확장점)
+  → 외부 시스템 lifecycle + LLM 실행 추상화
+
+Layer 3: autodev CLI (SSOT)
+  → DB 조작, 상태 전이, 코어 로직
+  → 모든 레이어가 CLI를 호출
+```
+
+### SSOT 보장
+
+```
+/spec add       → autodev spec add (CLI)
+/claw 세션      → Bash: autodev queue list --json (CLI)
+DataSource hook → db.queue_advance (코어, CLI 내부)
+Cron script     → autodev agent (CLI)
+```
+
+### Plugin 구조
+
+```
+plugins/autodev/
+├── .claude-plugin/plugin.json     # 3 commands, 3 agents
+├── commands/
+│   ├── auto.md                    # /auto
+│   ├── spec.md                    # /spec
+│   └── claw.md                    # /claw
+├── agents/
+│   ├── issue-analyzer.md
+│   ├── pr-reviewer.md
+│   └── conflict-resolver.md
+└── skills/
+    ├── cli-reference/
+    └── label-setup/
+```
+
+### Slash Command 매핑
+
+| v4 | v5 |
+|----|-----|
+| /auto, /auto-setup, /auto-config, /auto-dashboard, /update | /auto (서브커맨드) |
+| /add-spec, /update-spec, /spec | /spec (서브커맨드) |
+| /status, /board, /decisions, /hitl, /repo, /claw, /cron | /claw (자연어) |
+
+### autodev CLI 전체 참조
+
+```
+autodev
+├── start / stop / restart
+├── status [--format text|json|rich]
+├── dashboard
+├── repo
+│   ├── add / list / show / update / remove / config
+├── spec
+│   ├── add / list / show / update
+│   ├── pause / resume / complete / remove
+│   ├── link / unlink
+│   ├── status <id> / verify <id> / decisions <id>
+├── queue
+│   ├── list / show
+│   ├── advance / skip
+│   └── dependency add / remove
+├── hitl
+│   ├── list / show / respond / timeout
+├── cron
+│   ├── list / add / update
+│   ├── pause / resume / remove / trigger
+├── claw
+│   ├── init / rules / edit
+├── decisions
+│   ├── list / show
+├── agent [--repo <name>] [-p <prompt>]
+├── convention
+├── worktree list / clean
+├── board [--format text|json|rich]
+├── logs / usage / report
+```
+
+모든 서브커맨드는 `--json` 또는 `--format json` 출력 지원.
+
+---
+
+### 관련 플로우
+
+- [Flow 10: Claw 워크스페이스](../10-claw-workspace/flow.md)
+- [Flow 14: 시각화](../14-visualization/flow.md)

--- a/plugins/autodev/spec/draft/13-cron/flow.md
+++ b/plugins/autodev/spec/draft/13-cron/flow.md
@@ -1,0 +1,87 @@
+# Flow 13: Cron 관리
+
+### 시나리오
+
+Daemon이 주기적으로 실행해야 하는 작업을 스크립트 기반 cron으로 관리한다.
+
+### 기본 Cron Jobs
+
+#### Global (결정적, LLM 불필요)
+
+| Job | 주기 | Guard | 동작 |
+|-----|------|-------|------|
+| hitl-timeout | 5분 | 미응답 HITL 있을 때 | `autodev hitl timeout` |
+| daily-report | 매일 06시 | 활동 있을 때 | 일간 리포트 |
+| log-cleanup | 매일 00시 | 보관 초과 로그 있을 때 | 오래된 로그/worktree 삭제 |
+
+#### Per-repo (LLM, AgentRuntime 사용)
+
+| Job | 주기 | 동작 |
+|-----|------|------|
+| claw-evaluate | 60초 | Claw headless (큐 평가 → advance/skip) |
+| gap-detection | 1시간 | 스펙-코드 대조 |
+| knowledge-extract | 1시간 | merged PR 지식 추출 |
+
+### Force Trigger (코어)
+
+별도 구현 불필요. 코어 이벤트에서 자동 호출:
+
+```
+코어.on_done()            → force_claw_evaluate()
+코어.on_failed()          → force_claw_evaluate()
+코어.on_spec_active()     → force_claw_evaluate()
+코어.on_hitl_responded()  → force_claw_evaluate()
+```
+
+### 스크립트 구조
+
+```bash
+#!/bin/bash
+# ~/.autodev/crons/claw-evaluate.sh
+
+# Guard
+PENDING=$(autodev queue list --repo "$AUTODEV_REPO_NAME" --json | jq 'length')
+if [ "$PENDING" = "0" ]; then
+  echo "skip: 큐 비어있음"
+  exit 0
+fi
+
+# 실행 (AgentRuntime 설정에 따라 적절한 LLM 사용)
+autodev agent --repo "$AUTODEV_REPO_NAME" -p "큐를 평가하고 다음 작업을 결정해줘"
+```
+
+### 환경변수 주입
+
+Daemon이 cron 실행 시 자동 주입:
+
+| 변수 | 예시 |
+|------|------|
+| `AUTODEV_REPO_NAME` | `org/repo-a` |
+| `AUTODEV_REPO_ROOT` | `/Users/me/repos/repo-a` |
+| `AUTODEV_REPO_URL` | `https://github.com/org/repo-a` |
+| `AUTODEV_HOME` | `~/.autodev` |
+| `AUTODEV_DB` | `~/.autodev/autodev.db` |
+| `AUTODEV_CLAW_WORKSPACE` | `~/.autodev/claw-workspace` |
+
+### /claw 세션에서 관리
+
+```
+"cron 목록 보여줘"       → autodev cron list --json
+"gap-detection 일시정지" → autodev cron pause gap-detection
+"커스텀 cron 추가"       → autodev cron add --name ... --interval ...
+```
+
+### Built-in vs Custom
+
+| | Built-in | Custom |
+|---|---|---|
+| 생성 | 레포 등록 시 자동 | /cron add |
+| 제거 | 불가 (pause/resume) | 자유 |
+| Guard | 내장 | 사용자 자유 |
+
+---
+
+### 관련 플로우
+
+- [Flow 0: AgentRuntime](../00-agent-runtime/flow.md) — claw-evaluate 실행 런타임
+- [Flow 10: Claw 워크스페이스](../10-claw-workspace/flow.md) — Claw headless

--- a/plugins/autodev/spec/draft/14-visualization/flow.md
+++ b/plugins/autodev/spec/draft/14-visualization/flow.md
@@ -1,0 +1,123 @@
+# Flow 14: 시각화
+
+### 시나리오
+
+사용자가 TUI, CLI, Claw 세션 3개 레이어에서 일관된 시각 경험을 갖는다.
+
+### `--format` 옵션 (CLI 공통)
+
+| 값 | 용도 |
+|---|------|
+| `text` | 기본 텍스트 (기존 호환) |
+| `json` | 구조화된 JSON (Claw 파싱용) |
+| `rich` | 색상 + 박스 + 진행률 바 (터미널용) |
+
+모든 CLI 서브커맨드(status, board, spec list, spec status, queue list 등)에 적용.
+
+### CLI 출력 개선
+
+#### `autodev status --format rich`
+
+```
+● autodev daemon (uptime 2h 15m)
+
+Repos:
+  org/repo-a    ● active   queue: 3P 1R 2D   specs: 2/3
+  org/repo-b    ● active   queue: 0P 0R 5D   specs: 1/1 ✓
+
+Runtime: claude/sonnet (45.2K tokens/1h)
+HITL: 1 pending ⚠
+Next claw-evaluate: 25s
+```
+
+#### `autodev board --format rich`
+
+```
+auth-v2  Auth Module v2                    ████████░░░░ 60% (3/5)
+  ✅ #42 JWT middleware
+  ✅ #43 Token API
+  🔄 #44 Session adapter (running, claude/sonnet)
+  ⏳ #45 Error handling (dep: #44)
+  ⏳ #46 Missing tests
+```
+
+#### `autodev spec status <id> --format rich`
+
+```
+auth-v2  Auth Module v2
+Status: Active | Runtime: claude/sonnet
+Progress: ████████░░░░ 60% (3/5)
+
+Issues:
+  ✅ #42 JWT middleware       Done     6m   1.2K tokens
+  ✅ #43 Token API            Done     8m   1.8K tokens
+  🔄 #44 Session adapter      Running  3m   ...
+  ⏳ #45 Error handling        Pending  dep:#44
+  ⏳ #46 Missing tests         Pending
+
+Acceptance Criteria:
+  ✅ POST /auth/login → JWT 반환 (200)
+  ✅ 만료 토큰 → 401 반환
+  ⬜ POST /auth/refresh → 새 토큰 반환
+  ⬜ cargo test -p auth 전체 통과
+
+Dependencies:
+  #45 depends on #44 (shared: src/auth/session.rs)
+```
+
+### TUI Dashboard 추가 패널
+
+v4 대비 추가:
+
+```
+┌─ Runtime ──────────────────┐  ┌─ DataSource ────────────────┐
+│ claude/sonnet  12 runs  OK │  │ github  ● connected         │
+│ claude/opus     2 runs  OK │  │   last scan: 30s ago        │
+│ Tokens: 45.2K in / 12.1K  │  │   compensation queue: 0     │
+│ Avg duration: 4m 32s      │  │                             │
+└────────────────────────────┘  └─────────────────────────────┘
+
+┌─ Hooks (1h) ──────────────────────┐
+│ on_phase_enter   24 ok  1 ⚠       │
+│ before_task       8 ok            │
+│ after_task        8 ok            │
+│ ⚠ LabelSyncer: rate limit (1 pending) │
+└───────────────────────────────────┘
+```
+
+### 전이 타임라인
+
+ItemDetail 오버레이에서 아이템의 상태 전이 이력 표시:
+
+```
+┌─ #42 JWT middleware ─────────────────────────┐
+│ Timeline:                                     │
+│  14:00 ○ Pending  ← github.collect()         │
+│         ├ DependencyAnalyzer: no deps         │
+│         └ SpecLinker: linked to auth-v2       │
+│  14:05 ○ Ready    ← Claw advance             │
+│  14:06 ○ Running  ← AnalyzeTask              │
+│         └ claude/sonnet (1.2K tokens, 6m)    │
+│  14:12 ● Done                                 │
+│         └ SpecCompletionCheck: 3/5 done       │
+└───────────────────────────────────────────────┘
+```
+
+### 데이터 요구사항
+
+```sql
+transition_events (
+    id          TEXT PRIMARY KEY,
+    work_id     TEXT NOT NULL,
+    event_type  TEXT NOT NULL,    -- on_phase_enter, before_task, after_task, ...
+    detail      TEXT,             -- handler name, result, error message
+    created_at  TEXT NOT NULL
+)
+```
+
+---
+
+### 관련 플로우
+
+- [Flow 6: 칸반 보드](../06-kanban-board/flow.md) — TUI/CLI 상세
+- [Flow 10: Claw 워크스페이스](../10-claw-workspace/flow.md) — Claw 세션 내 시각화

--- a/plugins/autodev/spec/draft/DESIGN-v5.md
+++ b/plugins/autodev/spec/draft/DESIGN-v5.md
@@ -1,0 +1,956 @@
+# DESIGN v5: DataSource + AgentRuntime 아키텍처
+
+> **Date**: 2026-03-21
+> **Status**: Draft
+> **기준**: v4 DESIGN.md + 운영 피드백 + 열린 이슈 반영
+
+---
+
+## 핵심 원칙
+
+### 1. CPU 모델
+
+```
+상태 전이가 유일한 실행 트리거.
+전이 발생 → 코어 로직 실행 → DataSource hook 실행 → DB commit
+```
+
+### 2. OCP 확장점 3개
+
+```
+새 외부 시스템  = DataSource impl 추가     → 코어 변경 0
+새 LLM        = AgentRuntime impl 추가    → 코어 변경 0
+새 파이프라인   = Task impl 추가           → 코어 변경 0
+```
+
+### 3. 관심사 분리
+
+```
+Daemon  = 토큰 안 쓰는 인프라 (수집, 상태 관리, 실행, cron)
+Claw    = 토큰 쓰는 판단 전부 (큐 평가, 스펙 분해, gap 탐지)
+코어    = DB 전이, 의존성, 스펙 링크, decision 기록 (내부 로직)
+DataSource = 외부 시스템 hook (라벨, 알림, escalation)
+AgentRuntime = LLM 실행 추상화 (Claude, Gemini, Codex, ...)
+```
+
+### 4. Workspace + DataSource 소유권
+
+```
+"repo"는 GitHub 전용 개념이다. DataSource가 늘어나면 깨진다.
+→ "workspace"가 최상위 그룹, DataSource가 자신의 ID 체계로 리소스를 소유한다.
+
+workspace "auth-project"
+  ├── github datasource → issues, pulls (org/repo 기준)
+  ├── jira datasource   → tickets (AUTH-xxx 기준)
+  └── slack datasource  → threads (channel 기준)
+
+QueueItem은 반드시 하나의 DataSource에 귀속된다.
+work_id = "{datasource}:{type}:{external_id}"
+  github:issue:42
+  github:pr:43
+  jira:ticket:AUTH-123
+  slack:thread:C01-1234
+```
+
+---
+
+## 전체 아키텍처
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  사용자                                                          │
+│                                                                  │
+│  레포 Claude 세션          Claw 세션              터미널          │
+│  └─ /spec                 └─ /claw               autodev        │
+│       │                       │                  dashboard      │
+└───────┼───────────────────────┼──────────────────────┼───────────┘
+        │                       │                      │
+        ▼                       ▼                      ▼
+┌──────────────────┐  ┌──────────────────┐  ┌──────────────────┐
+│  Plugin Commands │  │  Claw Agent      │  │  TUI Dashboard   │
+│  (3개: thin      │  │  (AgentRuntime   │  │  (읽기 전용)      │
+│   wrapper)       │  │   기반 세션)      │  │                  │
+│  /auto           │  │  자연어 → CLI     │  │  BoardRenderer   │
+│  /spec           │  │                  │  │                  │
+│  /claw           │  │                  │  │                  │
+└────────┬─────────┘  └────────┬─────────┘  └────────┬─────────┘
+         │                     │                      │
+         │      ┌──────────────┘                      │
+         ▼      ▼                                     ▼
+┌──────────────────────────────────────────────────────────────────┐
+│  autodev CLI (SSOT)                                              │
+│                                                                  │
+│  autodev workspace  add/list/show/update/remove                  │
+│  autodev spec    add/list/show/update/pause/resume/complete/     │
+│                  remove/link/unlink/status/verify/decisions      │
+│  autodev queue   list/show/advance/skip/dependency               │
+│  autodev hitl    list/show/respond/timeout                       │
+│  autodev cron    list/add/update/pause/resume/remove/trigger     │
+│  autodev claw    init/rules/edit                                 │
+│  autodev agent / dashboard / start / stop / status               │
+└────────┬─────────────────────────────────────────────────────────┘
+         │
+         ▼
+┌──────────────────────────────────────────────────────────────────┐
+│  코어 (내부 로직, DataSource/AgentRuntime 무관)                    │
+│                                                                  │
+│  ┌─ DependencyAnalyzer    파일 단위 의존성 분석                   │
+│  ├─ SpecLinker            spec_issues 자동 링크                  │
+│  ├─ DependencyGuard       advance 시 선행 아이템 검증             │
+│  ├─ SpecCompletionCheck   linked issues 완료 감지                │
+│  ├─ DecisionRecorder      claw_decisions 기록                    │
+│  ├─ ForceClawEvaluate     claw-evaluate cron 즉시 트리거          │
+│  ├─ TestRunner            test_commands 실행 (결정적)             │
+│  └─ TokenUsageRecorder    토큰 사용량 기록                        │
+└────────┬─────────────────────────────────────────────────────────┘
+         │
+         ▼
+┌──────────────────────────────────────────────────────────────────┐
+│  Daemon (토큰 0 — LLM 호출 없음)                                  │
+│                                                                  │
+│  ┌────────────────────────────────────────────────────────┐      │
+│  │  Heartbeat (tick_interval_secs, 기본 10초)             │      │
+│  │                                                        │      │
+│  │  1. DataSource.collect()  → Pending 저장               │      │
+│  │     → 코어.on_enter_pending()                          │      │
+│  │     → DataSource.on_phase_enter(Pending)               │      │
+│  │                                                        │      │
+│  │  2. Ready 아이템 drain                                 │      │
+│  │     → DataSource.on_phase_enter(Running)               │      │
+│  │     → DataSource.before_task()                         │      │
+│  │     → AgentRuntime.invoke()  (Task 실행)               │      │
+│  │     → DataSource.after_task()                          │      │
+│  │                                                        │      │
+│  │  3. 완료/실패 처리                                      │      │
+│  │     → DataSource.on_done() 또는 on_failed()            │      │
+│  │     → 코어.on_done() 또는 apply_escalation()           │      │
+│  └────────────────────────────────────────────────────────┘      │
+│                                                                  │
+│  ┌────────────────────────────────────────────────────────┐      │
+│  │  Cron Engine               등록된 job 주기 실행        │      │
+│  │  ├─ claw-evaluate (60초)   Claw headless 호출         │      │
+│  │  ├─ gap-detection (1시간)  스펙-코드 대조              │      │
+│  │  ├─ knowledge-extract      merged PR 지식 추출        │      │
+│  │  ├─ hitl-timeout (5분)     미응답 HITL 확인           │      │
+│  │  ├─ daily-report           일간 리포트                │      │
+│  │  └─ log-cleanup            오래된 로그 정리           │      │
+│  └────────────────────────────────────────────────────────┘      │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## DataSource trait
+
+외부 시스템(GitHub, Slack, Jira, ...)의 lifecycle을 캡슐화하는 OCP 확장점.
+각 DataSource는 **자신의 ID 체계와 리소스 컬렉션을 소유**한다.
+
+### trait 정의
+
+```rust
+#[async_trait]
+pub trait DataSource: Send + Sync {
+    fn name(&self) -> &str;
+
+    // ── 리소스 소유권 ──
+
+    /// 이 DataSource가 관리하는 컬렉션 유형
+    /// 예: GitHub → ["issue", "pr"], Jira → ["ticket"], Slack → ["thread"]
+    fn collection_types(&self) -> Vec<&str>;
+
+    /// work_id로 외부 시스템의 리소스 상세 정보 조회
+    /// 코어가 DataSource 내부 구조를 몰라도 필요한 정보를 가져올 수 있음
+    async fn resolve(&self, work_id: &str) -> Result<ResourceDetail>;
+
+    /// 외부 시스템에서 사람이 볼 수 있는 URL
+    fn external_url(&self, item: &QueueItem) -> Option<String>;
+
+    // ── 수집 ──
+
+    /// 외부 소스를 스캔하여 새 아이템 반환
+    /// 반환된 QueueItem.work_id는 반드시 "{self.name()}:{type}:{external_id}" 형식
+    /// collect()는 멱등: 이미 Ready/Running/Done인 아이템은 반환하지 않음
+    async fn collect(&mut self, workspace: &WorkspaceConfig) -> Result<Vec<QueueItem>>;
+
+    // ── 큐 상태 전이 hook ──
+    async fn on_phase_enter(&self, phase: QueuePhase, item: &QueueItem, ctx: &HookContext) -> Result<()>;
+    async fn on_phase_exit(&self, phase: QueuePhase, item: &QueueItem, ctx: &HookContext) -> Result<()>;
+
+    // ── Task 실행 hook ──
+    async fn before_task(&self, kind: TaskKind, item: &QueueItem, ctx: &HookContext) -> Result<()>;
+    async fn after_task(&self, kind: TaskKind, item: &QueueItem, result: &TaskOutcome, ctx: &HookContext) -> Result<()>;
+
+    // ── 완료/실패/skip ──
+    async fn on_done(&self, item: &QueueItem, ctx: &HookContext) -> Result<()>;
+    async fn on_failed(&self, item: &QueueItem, failure_count: u32, ctx: &HookContext) -> Result<EscalationAction>;
+    async fn on_skip(&self, item: &QueueItem, reason: &str, ctx: &HookContext) -> Result<()>;
+
+    // ── HITL 알림 (선택적) ──
+    async fn after_hitl_created(&self, event: &HitlEvent, ctx: &HookContext) -> Result<()> { Ok(()) }
+}
+```
+
+### QueueItem과 DataSource 귀속
+
+```rust
+pub struct QueueItem {
+    /// "{datasource}:{type}:{external_id}" 형식
+    /// 예: "github:issue:42", "jira:ticket:AUTH-123", "slack:thread:C01-1234"
+    pub work_id: String,
+    pub workspace_id: String,
+    pub phase: QueuePhase,
+    pub title: String,
+    pub task_kind: TaskKind,
+    pub metadata_json: String,
+    // ...
+}
+
+impl QueueItem {
+    /// work_id에서 DataSource 이름 추출
+    pub fn datasource_name(&self) -> &str {
+        self.work_id.split(':').next().unwrap()
+    }
+
+    /// work_id에서 컬렉션 타입 추출
+    pub fn collection_type(&self) -> &str {
+        self.work_id.splitn(3, ':').nth(1).unwrap()
+    }
+
+    /// work_id에서 외부 시스템 고유 ID 추출
+    pub fn external_id(&self) -> &str {
+        self.work_id.splitn(3, ':').nth(2).unwrap()
+    }
+}
+```
+
+### ResourceDetail (DataSource가 반환)
+
+```rust
+pub struct ResourceDetail {
+    pub title: String,
+    pub body: String,
+    pub author: String,
+    pub labels: Vec<String>,
+    pub url: Option<String>,
+    pub extra: serde_json::Value,  // DataSource별 추가 정보
+}
+```
+
+코어는 `resolve()`를 통해 DataSource의 내부 구조를 몰라도 필요한 정보를 가져온다.
+예: DependencyAnalyzer가 이슈 본문에서 파일 경로를 추출할 때 `source.resolve(work_id).body`를 사용.
+
+### HookContext
+
+```rust
+pub struct HookContext<'a> {
+    pub workspace: &'a WorkspaceConfig,
+    pub workspace_id: &'a str,
+}
+```
+
+DataSource hook에 최소한의 정보만 전달. DataSource가 코어 내부 구조에 의존하지 않도록.
+
+### EscalationAction (DataSource가 결정, 코어가 실행)
+
+```rust
+pub enum EscalationAction {
+    Retry,
+    CommentAndRetry { comment: String },
+    Hitl { event: NewHitlEvent },
+    Skip { reason: String },
+    Replan { event: NewHitlEvent },
+}
+```
+
+### GitHubDataSource 구현 예시
+
+```rust
+impl DataSource for GitHubDataSource {
+    fn name(&self) -> &str { "github" }
+
+    fn collection_types(&self) -> Vec<&str> { vec!["issue", "pr"] }
+
+    async fn resolve(&self, work_id: &str) -> Result<ResourceDetail> {
+        // work_id = "github:issue:42"
+        let (_, type_, number) = parse_work_id(work_id);
+        let item = self.gh.get_issue_or_pr(number).await?;
+        Ok(ResourceDetail {
+            title: item.title,
+            body: item.body,
+            author: item.author,
+            labels: item.labels,
+            url: Some(format!("https://github.com/{}/{}/{}", self.owner, self.repo, number)),
+            extra: json!({ "state": item.state, "assignees": item.assignees }),
+        })
+    }
+
+    fn external_url(&self, item: &QueueItem) -> Option<String> {
+        let number = item.external_id();
+        Some(format!("https://github.com/{}/{}/issues/{}", self.owner, self.repo, number))
+    }
+
+    async fn collect(&mut self, workspace: &WorkspaceConfig) -> Result<Vec<QueueItem>> {
+        // autodev:analyze 라벨이 붙은 이슈 감지
+        // work_id = "github:issue:{number}" 형식으로 QueueItem 생성
+    }
+
+    async fn on_phase_enter(&self, phase: QueuePhase, item: &QueueItem, _ctx: &HookContext) -> Result<()> {
+        match phase {
+            Pending  => self.gh.add_label(item.external_id(), "autodev:queued").await,
+            Ready    => self.gh.replace_label(item.external_id(), "autodev:queued", "autodev:ready").await,
+            Running  => self.gh.replace_label(item.external_id(), "autodev:ready", "autodev:wip").await,
+            Done     => self.gh.replace_label(item.external_id(), "autodev:wip", "autodev:done").await,
+            Skipped  => self.gh.add_label(item.external_id(), "autodev:skip").await,
+        }
+    }
+
+    async fn before_task(&self, kind: TaskKind, item: &QueueItem, ctx: &HookContext) -> Result<()> {
+        if kind == TaskKind::Implement {
+            let branch = ctx.workspace.convention.branch_name(item);
+            self.gh.comment(item.external_id(), &format!("🔨 구현 시작: `{branch}`")).await?;
+        }
+        Ok(())
+    }
+
+    async fn on_failed(&self, item: &QueueItem, failure_count: u32, _ctx: &HookContext) -> Result<EscalationAction> {
+        match failure_count {
+            1     => Ok(EscalationAction::Retry),
+            2     => Ok(EscalationAction::CommentAndRetry { comment: "⚠️ 2회 실패".into() }),
+            3     => Ok(EscalationAction::Hitl { event: escalation_hitl(item, Level3) }),
+            4     => Ok(EscalationAction::Skip { reason: "4회 실패 자동 스킵".into() }),
+            _     => Ok(EscalationAction::Replan { event: replan_hitl(item) }),
+        }
+    }
+}
+```
+
+### Workspace 설정에서 DataSource 바인딩
+
+```yaml
+# .autodev.yaml (workspace 설정)
+name: "auth-project"
+
+sources:
+  github:
+    url: https://github.com/org/repo
+    scan_interval_secs: 300
+    issue_concurrency: 1
+    pr_concurrency: 1
+```
+
+다중 소스:
+
+```yaml
+name: "auth-project"
+
+sources:
+  github:
+    url: https://github.com/org/repo
+    scan_interval_secs: 300
+  jira:
+    host: jira.company.com
+    project: AUTH
+    scan_interval_secs: 300
+  slack:
+    channel: "#dev-auth"
+    scan_interval_secs: 60
+```
+
+하나의 workspace에 여러 DataSource가 바인딩되면, 각 DataSource가 독립적으로 collect하고 hook을 실행.
+코어는 `item.datasource_name()`으로 어떤 DataSource의 아이템인지 판별하여 적절한 DataSource에 hook을 위임.
+
+### Daemon의 DataSource 라우팅
+
+```rust
+fn source_for(&self, item: &QueueItem) -> &dyn DataSource {
+    let name = item.datasource_name();  // "github", "jira", "slack"
+    self.sources.get(name).unwrap()
+}
+```
+
+### 트랜잭션 정책
+
+```
+1. DB 전이 (코어, atomic)          ← 필수, 실패 시 롤백
+2. DataSource hook (best-effort)    ← 실패해도 전이는 유효
+   → 실패 시 보상 큐에 추가 → 다음 tick에서 재시도 (최대 3회)
+   → 3회 실패 시 로그 경고만 (다음 collect에서 보정 가능)
+```
+
+### 보상 큐 (영속, Daemon 재시작에도 유지)
+
+```sql
+compensation_queue (
+    id            TEXT PRIMARY KEY,
+    work_id       TEXT NOT NULL,
+    datasource    TEXT NOT NULL,
+    hook_type     TEXT NOT NULL,     -- "on_phase_enter", "on_failed" 등
+    hook_args     TEXT,              -- JSON (phase, reason 등)
+    attempt_count INT DEFAULT 0,
+    next_retry_at TEXT NOT NULL,
+    created_at    TEXT NOT NULL
+)
+```
+
+Daemon 시작 시 이 테이블을 스캔하여 미완료 hook을 복구.
+
+---
+
+## AgentRuntime trait
+
+LLM 실행 시스템(Claude, Gemini, Codex, ...)을 추상화하는 OCP 확장점.
+
+### trait 정의
+
+autodev가 **실제로 필요한 기능** 에서 도출한 인터페이스.
+
+```rust
+#[async_trait]
+pub trait AgentRuntime: Send + Sync {
+    fn name(&self) -> &str;
+    async fn invoke(&self, request: RuntimeRequest) -> RuntimeResponse;
+    fn capabilities(&self) -> RuntimeCapabilities;
+}
+
+/// autodev → 런타임 요청 (core 소유)
+pub struct RuntimeRequest {
+    pub working_dir: PathBuf,
+    pub prompt: String,
+    pub system_prompt: Option<String>,
+    pub structured_output: Option<StructuredOutput>,
+    pub session_id: Option<String>,
+}
+
+pub struct StructuredOutput {
+    pub schema: String,   // JSON Schema
+}
+
+/// 런타임 → autodev 응답 (core 소유)
+pub struct RuntimeResponse {
+    pub exit_code: i32,
+    pub stdout: String,
+    pub stderr: String,
+    pub duration: Duration,
+    pub token_usage: Option<TokenUsage>,
+    pub session_id: Option<String>,
+}
+
+/// 런타임 기능 선언
+pub struct RuntimeCapabilities {
+    pub can_edit_files: bool,
+    pub supports_structured_output: bool,
+    pub supports_system_prompt: bool,
+    pub supports_session_resume: bool,
+    pub max_context_tokens: usize,
+}
+```
+
+### 의존성 방향
+
+```
+core/runtime.rs (trait + DTO)     ← autodev가 정의하는 인터페이스
+     ↑ impl
+infra/runtimes/
+  ├── claude.rs                   ← Claude CLI 플래그로 매핑
+  ├── gemini.rs                   ← Gemini CLI 플래그로 매핑
+  ├── codex.rs                    ← Codex CLI 플래그로 매핑
+  └── custom.rs                  ← 임의 CLI
+
+core → infra 방향 의존 없음.
+```
+
+### core 옵션 → CLI 매핑 (각 런타임의 책임)
+
+| core 옵션 | Claude | Gemini | Codex |
+|-----------|--------|--------|-------|
+| `system_prompt` | `--append-system-prompt` | prompt prepend | prompt prepend |
+| `structured_output` | `--output-format json` + `--json-schema` | `--output-format json` | `--output-schema <file>` + `--json` |
+| `working_dir` | `current_dir()` | `current_dir()` | `--cd <dir>` |
+| `session_id` | `--resume <uuid>` | `--resume <id>` | `codex exec resume <id>` |
+
+기능 미지원 시 각 런타임이 폴백 처리 (예: system_prompt → prompt prepend).
+
+### 설정
+
+```yaml
+# .autodev.yaml
+runtime:
+  default: claude
+  claude:
+    model: sonnet
+  overrides:
+    analyze: claude       # 분석은 Claude
+    implement: claude     # 구현은 Claude
+    review: gemini        # 리뷰는 Gemini (대규모 컨텍스트)
+    claw_evaluate: claude # Claw 판단은 Claude
+```
+
+### RuntimeRegistry
+
+```rust
+pub struct RuntimeRegistry {
+    runtimes: HashMap<String, Arc<dyn AgentRuntime>>,
+    default_name: String,
+    overrides: HashMap<TaskKind, String>,
+}
+
+impl RuntimeRegistry {
+    pub fn resolve(&self, task_kind: TaskKind) -> Arc<dyn AgentRuntime> {
+        let name = self.overrides.get(&task_kind).unwrap_or(&self.default_name);
+        self.runtimes[name].clone()
+    }
+}
+```
+
+---
+
+## 큐 상태 머신
+
+### Phase 전이
+
+```
+         ┌──────────────────────────────────────────────┐
+         │                                              │
+         ▼                                              │
+      Pending ──(advance)──> Ready ──(drain)──> Running │
+         │                                       │      │
+         │                                  ┌────┴────┐ │
+         │                                  │         │ │
+         │                               Success   Failure
+         │                                  │         │
+         └──────(skip)───> Skipped          ▼         │
+                                          Done     (escalation)
+                                                      │
+                                              ┌───────┴──────┐
+                                              │              │
+                                          Retry→Pending   HITL/Skip
+```
+
+### Daemon 실행 사이클
+
+```rust
+// Heartbeat tick
+async fn tick(&mut self) {
+    // 1. Collect
+    for source in &mut self.sources {
+        let items = source.collect(&workspace).await;
+        for item in items {
+            self.db.queue_upsert(&item);
+            self.core.on_enter_pending(&item);       // 의존성, 스펙링크, decision
+            source.on_phase_enter(Pending, &item, &ctx).await;  // 라벨
+        }
+    }
+
+    // 2. Drain: Ready → Running
+    for item in self.queue.drain_ready() {
+        let source = self.source_for(&item);
+        source.on_phase_enter(Running, &item, &ctx).await;
+        source.before_task(item.task_kind, &item, &ctx).await;
+
+        let runtime = self.registry.resolve(item.task_kind);
+        self.spawn_task(item, runtime);
+    }
+}
+
+// Task 완료
+async fn on_task_complete(&mut self, result: TaskResult) {
+    let source = self.source_for(&result);
+
+    match result.status {
+        Success => {
+            source.after_task(kind, &item, &result.outcome, &ctx).await;
+            source.on_done(&item, &ctx).await;
+            self.core.on_done(&item);  // 스펙완료체크, decision, force_evaluate
+        }
+        Failed => {
+            source.after_task(kind, &item, &result.outcome, &ctx).await;
+            let action = source.on_failed(&item, failure_count, &ctx).await;
+            self.core.apply_escalation(&item, action);  // DB 전이, HITL 생성
+        }
+    }
+}
+```
+
+### 코어 on_enter_pending
+
+```
+1. DependencyAnalyzer
+   → 이슈 본문에서 파일 경로 추출
+   → 큐의 다른 아이템과 파일 단위 겹침 확인
+   → 겹침 발견 시 dependency 메타데이터에 선행 work_id 기록
+   → Claw가 다음 evaluate에서 의미론적 보정
+
+2. SpecLinker
+   → 라벨 [XX-spec-name] 패턴, 이슈 본문 스펙 참조 추출
+   → 매칭 시 spec_issues 테이블 링크
+   → 실패 시 로그만 (Claw가 보정)
+
+3. DecisionRecorder
+   → source: collector 기록
+```
+
+### 코어 on_done
+
+```
+1. DecisionRecorder: 완료 기록
+2. SpecCompletionCheck: linked spec의 모든 issues Done?
+   → 모두 Done → on_spec_completing 이벤트
+3. ForceClawEvaluate: claw-evaluate 즉시 트리거
+4. TokenUsageRecorder: 토큰 기록
+```
+
+### DependencyGuard (advance 시)
+
+```
+queue advance 요청 시:
+  1. dependency 메타데이터 확인
+  2. 선행 아이템이 Done 아니면 → advance 차단
+  3. Done이면 → 통과
+```
+
+---
+
+## Spec 상태 머신
+
+### 상태 전이
+
+```
+Draft ──→ Active ←──→ Paused
+              │
+              ▼
+          Completing
+              │
+              ▼
+          Completed (terminal)
+
+Any ──→ Archived (soft delete)
+Archived ──resume──→ Active (복구)
+```
+
+### 상태별 전이/동작
+
+| 상태 | 가능한 전이 | CLI | 코어 이벤트 |
+|------|------------|-----|-----------|
+| Draft | → Active | `spec add` | on_spec_active |
+| Active | → Paused, → Completing, → Archived | `spec pause`, (자동), `spec remove` | - |
+| Paused | → Active, → Archived | `spec resume`, `spec remove` | on_spec_active |
+| Completing | → Active, → Completed | (테스트 실패), (HITL 승인) | on_spec_completing |
+| Completed | → Archived | `spec remove` | on_spec_completed |
+| Archived | → Active | `spec resume` | on_spec_active |
+
+### on_spec_completing 파이프라인
+
+```
+모든 linked issues Done 감지 (on_done에서)
+  → TestRunner: spec.test_commands 순차 실행
+    → 실패: 실패 항목을 이슈로 생성 → on_enter_pending
+    → 성공: 다음 단계
+  → ForceClawEvaluate: gap detection (Claw에게 위임)
+    → gap 발견: 이슈 생성 → 루프 계속
+    → gap 없음: 다음 단계
+  → HitlCreator: 최종 확인 HITL (Low severity)
+    → approve → on_spec_completed
+    → request-changes → Active로 복귀
+```
+
+---
+
+## HITL 시스템
+
+### HITL 생성 경로
+
+| 생성자 | 트리거 |
+|--------|--------|
+| DataSource.on_failed() | EscalationAction::Hitl/Replan 반환 시 |
+| 코어 on_spec_completing | 최종 확인 요청 시 |
+| 코어 DependencyGuard | 스펙 충돌 감지 시 |
+
+### 이벤트 유형별 선택지 (고정)
+
+```rust
+pub struct HitlOption {
+    pub key: String,      // "retry", "skip" 등
+    pub label: String,    // 사용자 표시용
+    pub action: String,   // 라우팅 대상: "advance", "skip", "replan"
+}
+```
+
+| 유형 | 선택지 |
+|------|--------|
+| Escalation Level 3 | retry→advance, skip→skip, reassign→replan |
+| Escalation Level 5 | replan→replan, force-retry→advance, abandon→skip |
+| Spec Completion | approve→spec_completed, request-changes→spec_active |
+| Conflict | prioritize-A→advance, prioritize-B→advance, pause-both→pause |
+
+### on_hitl_responded
+
+```
+HITL 응답 → DB 저장 → HitlResponseRouter:
+  "advance"        → queue advance
+  "skip"           → queue skip
+  "replan"         → Claw에게 스펙 수정 제안 위임
+  "spec_completed" → on_spec_completed
+  "spec_active"    → spec Active 복귀
+→ ForceClawEvaluate
+```
+
+---
+
+## Graceful Shutdown
+
+```
+SIGINT → on_shutdown:
+  1. Running 아이템 완료 대기 (timeout: 30초, 설정 가능)
+     → timeout 초과: Pending으로 롤백
+  2. DataSource.on_phase_exit(Running) 호출 (best-effort)
+  3. Cron engine 정지
+```
+
+### Worktree 보존
+
+```
+DataSource.after_task(Implement, Failed):
+  → worktree 보존 (삭제하지 않음)
+  → HITL 알림에 경로 포함
+  → 보존 기간: 7일 기본 (설정 가능)
+  → autodev worktree list/clean으로 관리
+```
+
+---
+
+## Cron
+
+### Force Trigger (코어)
+
+```
+코어.on_done()            → force_claw_evaluate()
+코어.on_failed()          → force_claw_evaluate()
+코어.on_spec_active()     → force_claw_evaluate()
+코어.on_hitl_responded()  → force_claw_evaluate()
+```
+
+### Force Trigger Debounce
+
+```
+무한 루프 방지:
+  on_done → force → Claw advance → on_done → force → ...
+
+대응:
+  1. 5초 윈도우 내 중복 force 신호는 병합 (1회만 실행)
+  2. 동일 tick 내 최대 1회만 Claw 호출
+  3. 실행 중인 Claw 세션이 있으면 다음 tick으로 연기
+```
+
+### 기본 Cron Jobs
+
+| Job | 유형 | 주기 | 동작 |
+|-----|------|------|------|
+| claw-evaluate | per-workspace, LLM | 60초 | Claw headless (큐 평가) |
+| gap-detection | per-workspace, LLM | 1시간 | 스펙-코드 대조 |
+| knowledge-extract | per-workspace, LLM | 1시간 | merged PR 지식 추출 |
+| hitl-timeout | global, 결정적 | 5분 | 미응답 HITL 만료 |
+| daily-report | global, 결정적 | 매일 06시 | 일간 리포트 |
+| log-cleanup | global, 결정적 | 매일 00시 | 오래된 로그 정리 |
+
+---
+
+## Decisions 테이블
+
+```sql
+claw_decisions (
+    id              TEXT PRIMARY KEY,
+    workspace_id    TEXT NOT NULL,
+    spec_id         TEXT,
+    work_id         TEXT,
+    action          TEXT NOT NULL,     -- advance, skip, decompose, prioritize, replan, approve
+    source          TEXT NOT NULL,     -- claw, collector, hitl_response, system
+    reasoning       TEXT,
+    confidence      REAL,
+    context_json    TEXT,
+    created_at      TEXT NOT NULL
+)
+```
+
+---
+
+## Plugin 구조
+
+### commands/ (15개 → 3개)
+
+```
+plugins/autodev/
+├── .claude-plugin/plugin.json     # 3 commands, 3 agents
+├── commands/
+│   ├── auto.md                    # /auto (start/stop/setup/config/dashboard/update)
+│   ├── spec.md                    # /spec (add/update/list/status/remove/pause/resume)
+│   └── claw.md                    # /claw (자연어 대화 세션)
+├── agents/
+│   ├── issue-analyzer.md
+│   ├── pr-reviewer.md
+│   └── conflict-resolver.md
+├── skills/
+│   ├── cli-reference/
+│   └── label-setup/
+└── cli/src/
+```
+
+### /claw 세션 진입 경험
+
+```
+/claw 실행 →
+
+Step 1: 상태 수집 (autodev status/hitl/decisions/spec --json)
+
+Step 2: 요약 표시
+
+  📊 autodev 상태 요약
+
+  ● daemon running (uptime 2h 15m)
+
+  Repos:
+    org/repo-a — queue: 1R 2P | specs: auth-v2 ████████░░ 60%
+    org/repo-b — queue: 5D   | specs: payment ██░░░░░░░░ 25%
+
+  ⚠ HITL 대기: 1건
+    → #44 Session adapter — 3회 실패, 사람 확인 필요
+
+  🧠 최근 판단:
+    14:30 advance #42 | 14:25 decompose auth-v2 | 14:20 skip #39
+
+  무엇을 도와드릴까요?
+
+Step 3: 자연어 대화 (Bash tool로 autodev CLI 호출)
+```
+
+---
+
+## 시각화
+
+### CLI 출력 (--format 옵션)
+
+| 값 | 용도 |
+|---|------|
+| `text` | 기본 텍스트 (기존 호환) |
+| `json` | 구조화된 JSON (Claw 파싱용) |
+| `rich` | 색상 + 박스 + 진행률 바 |
+
+#### `autodev status --format rich`
+
+```
+● autodev daemon (uptime 2h 15m)
+
+Repos:
+  org/repo-a    ● active   queue: 3P 1R 2D   specs: 2/3
+  org/repo-b    ● active   queue: 0P 0R 5D   specs: 1/1 ✓
+
+Runtime: claude/sonnet (45.2K tokens/1h)
+HITL: 1 pending ⚠
+Next claw-evaluate: 25s
+```
+
+#### `autodev board --format rich`
+
+```
+auth-v2  Auth Module v2                    ████████░░░░ 60% (3/5)
+  ✅ #42 JWT middleware
+  ✅ #43 Token API
+  🔄 #44 Session adapter (running, claude/sonnet)
+  ⏳ #45 Error handling (dep: #44)
+  ⏳ #46 Missing tests
+```
+
+### TUI Dashboard 강화
+
+#### 추가 패널
+
+```
+┌─ Runtime ──────────────────┐  ┌─ DataSource ────────────────┐
+│ claude/sonnet  12 runs  OK │  │ github  ● connected         │
+│ claude/opus     2 runs  OK │  │   last scan: 30s ago        │
+│ Tokens: 45.2K in / 12.1K  │  │   compensation queue: 0     │
+│ Avg duration: 4m 32s      │  │                             │
+└────────────────────────────┘  └─────────────────────────────┘
+```
+
+#### 전이 타임라인 (ItemDetail 오버레이)
+
+```
+┌─ #42 JWT middleware ─────────────────────────┐
+│ Timeline:                                     │
+│  14:00 ○ Pending  ← github.collect()         │
+│         └ SpecLinker: linked to auth-v2       │
+│  14:05 ○ Ready    ← Claw advance             │
+│  14:06 ○ Running  ← AnalyzeTask              │
+│         └ claude/sonnet (1.2K tokens, 6m)    │
+│  14:12 ● Done                                 │
+│         └ SpecCompletionCheck: 3/5 done       │
+└───────────────────────────────────────────────┘
+```
+
+### 추가 테이블 (시각화용)
+
+```sql
+transition_events (
+    id          TEXT PRIMARY KEY,
+    work_id     TEXT NOT NULL,
+    event_type  TEXT NOT NULL,
+    detail      TEXT,
+    created_at  TEXT NOT NULL
+)
+```
+
+---
+
+## 해소하는 이슈
+
+| # | 이슈 | 해소 위치 |
+|---|------|----------|
+| 430 | claw-evaluate decisions 미기록 | DecisionRecorder (코어, 모든 전이 시 자동) |
+| 416 | agent 세션 시작 시 상태 요약 | /claw 진입 Step 2 |
+| 414 | 스펙 분해 → 이슈 자동 생성 | on_spec_active → ForceClawEvaluate |
+| 413 | 이슈 의존성 + spec_issues 링크 | on_enter_pending (DependencyAnalyzer + SpecLinker) |
+| 405 | worktree 브랜치 네이밍 | DataSource.before_task() + convention |
+| 395 | 이슈 템플릿 시스템 | Claw decompose + convention |
+| 386 | done 시 데이터소스별 완료 처리 | DataSource.on_done() (OCP) |
+| 382 | graceful shutdown | on_shutdown 이벤트 |
+
+## REMAINING-WORK 해소
+
+| 항목 | 해소 위치 |
+|------|----------|
+| C2 Notifier 연결 | DataSource.on_done/on_failed에 흡수 |
+| C3 Force trigger | 코어에서 자동 (on_done, on_failed, on_spec_active, on_hitl_responded) |
+| C4 Escalation 5단계 | DataSource.on_failed() → EscalationAction |
+| H1 Spec completion | on_spec_completing 파이프라인 |
+
+---
+
+## 구현 순서
+
+```
+Phase 1: 코어 리팩토링
+  → DataSource trait 정의 (core/datasource.rs)
+  → AgentRuntime trait 정의 (core/runtime.rs)
+  → GitHubDataSource 구현 (기존 Collector/Notifier 통합)
+  → ClaudeRuntime 구현 (기존 Agent/Claude 통합)
+
+Phase 2: 상태 머신 강화
+  → 코어 on_enter_pending, on_done, on_failed 구현
+  → DependencyAnalyzer, SpecLinker, DependencyGuard
+  → Spec lifecycle (Completing, Archived 추가)
+
+Phase 3: Plugin 통합
+  → commands/ 15개 → 3개 통합
+  → /claw 세션 진입 경험
+  → CLI --format rich 옵션
+
+Phase 4: 시각화
+  → TUI Runtime/DataSource 패널
+  → 전이 타임라인
+  → transition_events 테이블
+
+Phase 5: 확장
+  → GeminiRuntime, CodexRuntime 구현
+  → RuntimeRegistry task별 오버라이드
+  → Multi-LLM 리뷰 (MultiRuntime)
+```

--- a/plugins/autodev/spec/draft/README.md
+++ b/plugins/autodev/spec/draft/README.md
@@ -1,0 +1,28 @@
+# Spec v5 Draft
+
+> **Date**: 2026-03-21
+
+## 설계 문서
+
+- **[DESIGN-v5.md](./DESIGN-v5.md)** — 전체 아키텍처 설계
+
+## Flow 문서
+
+| # | Flow | 설명 |
+|---|------|------|
+| 00 | [DataSource](./00-datasource/flow.md) | 외부 시스템 OCP (GitHub, Slack, Jira) |
+| 00 | [AgentRuntime](./00-agent-runtime/flow.md) | LLM 실행 OCP (Claude, Gemini, Codex) |
+| 01 | [레포 등록](./01-repo-registration/flow.md) | 레포 등록/변경/제거 + DataSource 바인딩 |
+| 02 | [이슈 등록](./02-issue-registration/flow.md) | 이슈 모드 + 의존성 분석 + 스펙 링크 |
+| 03 | [스펙 등록](./03-spec-registration/flow.md) | 스펙 모드 + lifecycle (6상태) |
+| 04 | [스펙 우선순위](./04-spec-priority/flow.md) | 다중 스펙 + DependencyGuard |
+| 05 | [HITL 알림](./05-hitl-notification/flow.md) | HITL 생성/응답/라우팅 |
+| 06 | [칸반 보드](./06-kanban-board/flow.md) | TUI + CLI + Claw 시각화 |
+| 07 | [피드백 루프](./07-feedback-loop/flow.md) | PR 리뷰 / spec update / replan |
+| 08 | [스펙 완료](./08-spec-completion/flow.md) | 완료 감지 + 테스트 + gap detection |
+| 09 | [실패 복구](./09-failure-recovery/flow.md) | DataSource별 escalation + shutdown |
+| 10 | [Claw 워크스페이스](./10-claw-workspace/flow.md) | 세션 경험 + slash command 통합 |
+| 11 | [컨벤션](./11-convention-bootstrap/flow.md) | 부트스트랩 + 자율 개선 |
+| 12 | [CLI 레퍼런스](./12-cli-reference/flow.md) | 3-layer + 전체 커맨드 참조 |
+| 13 | [Cron](./13-cron/flow.md) | force trigger + 스크립트 관리 |
+| 14 | [시각화](./14-visualization/flow.md) | --format rich + TUI 패널 + 타임라인 |


### PR DESCRIPTION
## Summary

- v5 아키텍처 설계 draft 문서 추가 (DESIGN-v5.md + 16개 flow 문서)
- 3개 OCP 확장점: DataSource trait, AgentRuntime trait, Task trait
- repo → workspace 전환 (GitHub 비종속)
- QueueItem DataSource 귀속 (work_id 체계)
- Slash command 15개 → 3개 통합
- 3개 LLM(Claude/Codex/Gemini) 리뷰 완료 — 평균 91/100

## 주요 변경

| 항목 | v4 | v5 |
|------|----|----|
| 외부 시스템 | Collector + Notifier (분산) | DataSource trait (통합) |
| LLM 실행 | Claude 하드코딩 | AgentRuntime trait (OCP) |
| 최상위 그룹 | repo (GitHub 전용) | workspace (범용) |
| QueueItem ID | issue:org/repo:42 | github:issue:42 (DataSource 소유) |
| Slash command | 15개 | 3개 (/auto, /spec, /claw) |
| 실패 복구 | daemon 코드에 산재 | DataSource.on_failed() → EscalationAction |
| 보상 큐 | 없음 | compensation_queue 테이블 |

## 문서 구조

```
plugins/autodev/spec/draft/
├── DESIGN-v5.md              ← 전체 아키텍처
├── README.md
├── 00-datasource/flow.md     ← DataSource trait (신규)
├── 00-agent-runtime/flow.md  ← AgentRuntime trait (신규)
├── 01~13-*/flow.md           ← 기존 flow 재작성
└── 14-visualization/flow.md  ← 시각화 (신규)
```

## Test plan

- [ ] v4 스펙 대비 요구사항 누락 없음 확인
- [ ] DataSource trait 설계의 OCP 준수 검증
- [ ] AgentRuntime trait의 CLI 매핑 테이블 검증
- [ ] workspace 구조의 다중 DataSource 시나리오 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)