### PR TITLE
fix(git-utils): protect develop branch in guard hook

### DIFF
--- a/plugins/git-utils/scripts/default-branch-guard-commit-hook.sh
+++ b/plugins/git-utils/scripts/default-branch-guard-commit-hook.sh
@@ -52,11 +52,16 @@ GIT_DIR=$(git rev-parse --git-dir 2>/dev/null) || exit 0
 CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || true)
 [ -z "$CURRENT_BRANCH" ] && exit 0
 
-# 기본 브랜치가 아니면 패스
-[ "$CURRENT_BRANCH" != "$DEFAULT_BRANCH" ] && exit 0
+# 보호 브랜치 목록 구성 (default branch + develop)
+PROTECTED_BRANCHES="$DEFAULT_BRANCH develop"
+IS_PROTECTED=false
+for BRANCH in $PROTECTED_BRANCHES; do
+  [ "$CURRENT_BRANCH" = "$BRANCH" ] && IS_PROTECTED=true && break
+done
+[ "$IS_PROTECTED" = false ] && exit 0
 
-# 기본 브랜치에서 git commit 시도 → 블로킹
-echo "[Branch Guard] 기본 브랜치($DEFAULT_BRANCH)에서 커밋할 수 없습니다." >&2
+# 보호 브랜치에서 git commit 시도 → 블로킹
+echo "[Branch Guard] 보호 브랜치($CURRENT_BRANCH)에서 커밋할 수 없습니다." >&2
 echo "기본 브랜치에 직접 커밋하는 것은 권장하지 않습니다." >&2
 echo "" >&2
 echo "먼저 새 브랜치를 생성해주세요:" >&2

--- a/plugins/git-utils/scripts/default-branch-guard-hook.sh
+++ b/plugins/git-utils/scripts/default-branch-guard-hook.sh
@@ -41,11 +41,16 @@ GIT_DIR=$(git rev-parse --git-dir 2>/dev/null) || exit 0
 CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || true)
 [ -z "$CURRENT_BRANCH" ] && exit 0
 
-# 기본 브랜치가 아니면 패스
-[ "$CURRENT_BRANCH" != "$DEFAULT_BRANCH" ] && exit 0
+# 보호 브랜치 목록 구성 (default branch + develop)
+PROTECTED_BRANCHES="$DEFAULT_BRANCH develop"
+IS_PROTECTED=false
+for BRANCH in $PROTECTED_BRANCHES; do
+  [ "$CURRENT_BRANCH" = "$BRANCH" ] && IS_PROTECTED=true && break
+done
+[ "$IS_PROTECTED" = false ] && exit 0
 
-# 기본 브랜치에서 파일 수정 시도 → 블로킹
-echo "[Branch Guard] 기본 브랜치($DEFAULT_BRANCH)에서 파일을 수정하려 합니다." >&2
+# 보호 브랜치에서 파일 수정 시도 → 블로킹
+echo "[Branch Guard] 보호 브랜치($CURRENT_BRANCH)에서 파일을 수정하려 합니다." >&2
 echo "기본 브랜치에 직접 작업하는 것은 권장하지 않습니다." >&2
 echo "" >&2
 echo "먼저 새 브랜치를 생성해주세요:" >&2

--- a/plugins/git-utils/src/cli.ts
+++ b/plugins/git-utils/src/cli.ts
@@ -188,11 +188,18 @@ async function main(): Promise<void> {
         // stdin not available or not JSON
       }
 
+      // Parse protected branches (comma-separated)
+      const protectedBranchesRaw = parsed.flags['protected-branches'] as string | undefined;
+      const protectedBranches = protectedBranchesRaw
+        ? protectedBranchesRaw.split(',').map(b => b.trim()).filter(Boolean)
+        : undefined;
+
       const result = await guard.check({
         target,
         projectDir: (parsed.flags['project-dir'] as string) || process.cwd(),
         createBranchScript: (parsed.flags['create-branch-script'] as string) || 'git-utils branch',
         defaultBranch: parsed.flags['default-branch'] as string | undefined,
+        protectedBranches,
         toolCommand,
         toolFilePath,
       });

--- a/plugins/git-utils/src/core/guard.ts
+++ b/plugins/git-utils/src/core/guard.ts
@@ -86,6 +86,14 @@ export function createGuardService(git: GitService): GuardService {
         }
       }
 
+      // 보호 브랜치 목록 구성: default branch + 추가 보호 브랜치 + 기본 보호 대상(develop)
+      const protectedSet = new Set<string>([defaultBranch, 'develop']);
+      if (input.protectedBranches) {
+        for (const b of input.protectedBranches) {
+          protectedSet.add(b);
+        }
+      }
+
       // Guard 2: 특수 상태 (rebase/merge) → 패스
       const state = await git.getSpecialState();
       if (state.rebase || state.merge) {
@@ -100,19 +108,19 @@ export function createGuardService(git: GitService): GuardService {
       // 현재 브랜치 확인
       const currentBranch = await git.getCurrentBranch();
 
-      // 기본 브랜치가 아니면 패스
-      if (currentBranch !== defaultBranch) {
+      // 보호 브랜치가 아니면 패스
+      if (!protectedSet.has(currentBranch)) {
         return { allowed: true, currentBranch, defaultBranch };
       }
 
-      // 기본 브랜치에서 작업 → 차단
+      // 보호 브랜치에서 작업 → 차단
       const action = input.target === 'commit' ? '커밋할 수 없습니다' : '파일을 수정하려 합니다';
       return {
         allowed: false,
         currentBranch,
         defaultBranch,
         reason: [
-          `[Branch Guard] 기본 브랜치(${defaultBranch})에서 ${action}.`,
+          `[Branch Guard] 보호 브랜치(${currentBranch})에서 ${action}.`,
           `먼저 새 브랜치를 생성해주세요:`,
           `  ${input.createBranchScript} <branch-name>`,
         ].join('\n'),

--- a/plugins/git-utils/src/types.ts
+++ b/plugins/git-utils/src/types.ts
@@ -115,6 +115,8 @@ export interface GuardInput {
   projectDir: string;
   createBranchScript: string;
   defaultBranch?: string;
+  /** 추가 보호 브랜치 목록 (default branch 외에 보호할 브랜치) */
+  protectedBranches?: string[];
   /** commit guard 전용: stdin으로 전달된 tool_input.command */
   toolCommand?: string;
   /** write guard 전용: stdin으로 전달된 tool_input.file_path */

--- a/plugins/git-utils/tests/core/guard.test.ts
+++ b/plugins/git-utils/tests/core/guard.test.ts
@@ -94,6 +94,36 @@ describe('GuardService.check', () => {
       const result = await guard.check(baseInput);
       expect(result.allowed).toBe(false);
     });
+
+    test('develop 브랜치는 default branch가 main이어도 보호됨 → allowed: false', async () => {
+      const guard = createGuardService(mockGit({
+        getCurrentBranch: async () => 'develop',
+        detectDefaultBranch: async () => 'main',
+      }));
+      const result = await guard.check(baseInput);
+      expect(result.allowed).toBe(false);
+      expect(result.currentBranch).toBe('develop');
+      expect(result.defaultBranch).toBe('main');
+    });
+
+    test('protectedBranches로 추가 지정한 브랜치도 보호됨 → allowed: false', async () => {
+      const guard = createGuardService(mockGit({
+        getCurrentBranch: async () => 'staging',
+        detectDefaultBranch: async () => 'main',
+      }));
+      const result = await guard.check({ ...baseInput, protectedBranches: ['staging', 'release'] });
+      expect(result.allowed).toBe(false);
+      expect(result.currentBranch).toBe('staging');
+    });
+
+    test('protectedBranches에 없는 브랜치는 허용됨 → allowed: true', async () => {
+      const guard = createGuardService(mockGit({
+        getCurrentBranch: async () => 'feat/something',
+        detectDefaultBranch: async () => 'main',
+      }));
+      const result = await guard.check({ ...baseInput, protectedBranches: ['staging'] });
+      expect(result.allowed).toBe(true);
+    });
   });
 
   describe('default branch 감지 fallback', () => {
@@ -131,7 +161,7 @@ describe('GuardService.check', () => {
       expect(result.allowed).toBe(false);
     });
 
-    test('기본 브랜치에서 차단 시 reason에 브랜치 생성 안내 포함', async () => {
+    test('보호 브랜치에서 차단 시 reason에 브랜치 생성 안내 포함', async () => {
       const guard = createGuardService(mockGit());
       const result = await guard.check(baseInput);
       expect(result.reason).toContain('파일을 수정하려 합니다');
@@ -180,10 +210,11 @@ describe('GuardService.check', () => {
   });
 
   describe('차단 메시지 포맷', () => {
-    test('차단 시 reason에 현재 브랜치 이름 포함', async () => {
+    test('차단 시 reason에 보호 브랜치 이름 포함', async () => {
       const guard = createGuardService(mockGit());
       const result = await guard.check(baseInput);
       expect(result.reason).toContain('main');
+      expect(result.reason).toContain('보호 브랜치');
       expect(result.currentBranch).toBe('main');
     });
 


### PR DESCRIPTION
## Summary
- Guard hook now protects `develop` branch by default alongside the detected default branch (e.g., `main`)
- Added `protectedBranches` field to `GuardInput` type and `--protected-branches` CLI flag for custom protected branch configuration
- Updated both shell scripts (`default-branch-guard-hook.sh`, `default-branch-guard-commit-hook.sh`) to check against protected branch list instead of single default branch

## Test plan
- [x] Existing 174 tests pass (0 failures)
- [x] New test: `develop` branch blocked when default branch is `main`
- [x] New test: custom `protectedBranches` list blocks specified branches
- [x] New test: non-protected branches still allowed with custom list

Closes #396

🤖 Generated with [Claude Code](https://claude.com/claude-code)