### PR TITLE
fix(autodev): record claw-evaluate decisions to DB

### DIFF
--- a/plugins/autodev/cli/Cargo.lock
+++ b/plugins/autodev/cli/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autodev"
-version = "0.40.7"
+version = "0.40.9"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/plugins/autodev/cli/src/cli/queue.rs
+++ b/plugins/autodev/cli/src/cli/queue.rs
@@ -85,6 +85,7 @@ fn record_decision(
         DecisionType::Skip => "manual skip",
         DecisionType::Hitl => "manual hitl",
         DecisionType::Replan => "manual replan",
+        DecisionType::Noop => "no-op",
     };
     let _ = db.decision_add(&NewClawDecision {
         repo_id: repo_id.to_string(),

--- a/plugins/autodev/cli/src/core/models.rs
+++ b/plugins/autodev/cli/src/core/models.rs
@@ -763,6 +763,8 @@ pub enum DecisionType {
     Skip,
     Hitl,
     Replan,
+    /// No actionable work found during evaluation tick.
+    Noop,
 }
 
 impl DecisionType {
@@ -772,6 +774,7 @@ impl DecisionType {
             DecisionType::Skip => "skip",
             DecisionType::Hitl => "hitl",
             DecisionType::Replan => "replan",
+            DecisionType::Noop => "noop",
         }
     }
 }
@@ -785,6 +788,7 @@ impl std::str::FromStr for DecisionType {
             "skip" => Ok(DecisionType::Skip),
             "hitl" => Ok(DecisionType::Hitl),
             "replan" => Ok(DecisionType::Replan),
+            "noop" => Ok(DecisionType::Noop),
             _ => Err(format!("invalid decision type: {s}")),
         }
     }

--- a/plugins/autodev/cli/src/service/daemon/cron/engine.rs
+++ b/plugins/autodev/cli/src/service/daemon/cron/engine.rs
@@ -4,8 +4,8 @@ use std::path::PathBuf;
 use tokio::task::JoinHandle;
 use tracing::{info, warn};
 
-use crate::core::models::RepoInfo;
-use crate::core::repository::{CronRepository, RepoRepository};
+use crate::core::models::{DecisionType, NewClawDecision, RepoInfo};
+use crate::core::repository::{ClawDecisionRepository, CronRepository, RepoRepository};
 use crate::infra::db::Database;
 
 use super::runner::{CronExecResult, ScriptRunner};
@@ -124,13 +124,78 @@ impl CronEngine {
     pub fn is_running(&self, job_id: &str) -> bool {
         self.running.get(job_id).is_some_and(|h| !h.is_finished())
     }
+
+    /// Record a claw-evaluate cron result as a decision in the DB.
+    ///
+    /// Parses the script stdout to determine the decision type:
+    /// - "skip: ..." → Noop (queue empty, no work)
+    /// - "evaluate: ..." with exit_code 0 → Advance (evaluation completed)
+    /// - "evaluate: ..." with non-zero exit → Skip (evaluation failed)
+    pub fn record_claw_evaluate_decision(&self, result: &CronExecResult) {
+        let repo_id = match &result.repo_id {
+            Some(id) => id.clone(),
+            None => {
+                warn!(
+                    "cron: cannot record decision for '{}': no repo_id",
+                    result.job_name
+                );
+                return;
+            }
+        };
+
+        let stdout = result.stdout.trim();
+
+        let (decision_type, reasoning) = if stdout.starts_with("skip:") {
+            let reason = stdout
+                .strip_prefix("skip:")
+                .unwrap_or("")
+                .trim()
+                .to_string();
+            (DecisionType::Noop, format!("claw-evaluate: {reason}"))
+        } else if result.exit_code == 0 {
+            (
+                DecisionType::Advance,
+                "claw-evaluate completed (exit=0)".to_string(),
+            )
+        } else {
+            (
+                DecisionType::Skip,
+                format!("claw-evaluate failed (exit={})", result.exit_code),
+            )
+        };
+
+        let decision = NewClawDecision {
+            repo_id,
+            spec_id: None,
+            decision_type,
+            target_work_id: None,
+            reasoning,
+            context_json: Some(
+                serde_json::json!({
+                    "source": "cron",
+                    "job_name": result.job_name,
+                    "exit_code": result.exit_code,
+                    "duration_ms": result.duration_ms,
+                })
+                .to_string(),
+            ),
+        };
+
+        match self.db.decision_add(&decision) {
+            Ok(id) => info!(
+                "cron: recorded claw-evaluate decision {id} (type={})",
+                decision.decision_type
+            ),
+            Err(e) => warn!("cron: failed to record claw-evaluate decision: {e}"),
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::core::models::{CronSchedule, CronStatus, NewCronJob};
-    use crate::core::repository::CronRepository;
+    use crate::core::repository::{ClawDecisionRepository, CronRepository, RepoRepository};
     use tempfile::TempDir;
 
     fn setup_db() -> (TempDir, Database) {
@@ -350,6 +415,109 @@ mod tests {
         // Should skip due to invalid cron expression
         let results = engine.tick().await;
         assert!(results.is_empty());
+    }
+
+    /// Setup DB with a repo and return (dir, engine_db_path, repo_id).
+    /// The engine takes ownership of one DB connection; tests open a second for verification.
+    fn setup_with_repo() -> (TempDir, std::path::PathBuf, String) {
+        let dir = TempDir::new().unwrap();
+        let db_path = dir.path().join("test.db");
+        let db = Database::open(&db_path).unwrap();
+        db.initialize().unwrap();
+        let repo_id = db
+            .repo_add("https://github.com/org/repo", "org/repo")
+            .unwrap();
+        (dir, db_path, repo_id)
+    }
+
+    fn make_cron_result(
+        job_name: &str,
+        repo_id: Option<String>,
+        exit_code: i32,
+        stdout: &str,
+    ) -> CronExecResult {
+        CronExecResult {
+            job_name: job_name.to_string(),
+            repo_id,
+            exit_code,
+            stdout: stdout.to_string(),
+            stderr: String::new(),
+            duration_ms: 100,
+        }
+    }
+
+    #[tokio::test]
+    async fn record_decision_noop_when_skip_output() {
+        let (dir, db_path, repo_id) = setup_with_repo();
+        let engine_db = Database::open(&db_path).unwrap();
+        let engine = CronEngine::new(engine_db, dir.path().to_path_buf());
+
+        let result = make_cron_result(
+            "claw-evaluate",
+            Some(repo_id),
+            0,
+            "skip: org/repo 큐 비어있고 HITL 없음\n",
+        );
+        engine.record_claw_evaluate_decision(&result);
+
+        let verify_db = Database::open(&db_path).unwrap();
+        let decisions = verify_db.decision_list(None, 10).unwrap();
+        assert_eq!(decisions.len(), 1);
+        assert_eq!(decisions[0].decision_type, DecisionType::Noop);
+        assert!(decisions[0].reasoning.contains("claw-evaluate"));
+        assert!(decisions[0].context_json.is_some());
+    }
+
+    #[tokio::test]
+    async fn record_decision_advance_on_success() {
+        let (dir, db_path, repo_id) = setup_with_repo();
+        let engine_db = Database::open(&db_path).unwrap();
+        let engine = CronEngine::new(engine_db, dir.path().to_path_buf());
+
+        let result = make_cron_result(
+            "claw-evaluate",
+            Some(repo_id),
+            0,
+            "evaluate: org/repo (pending=2, hitl=0)\nsome agent output",
+        );
+        engine.record_claw_evaluate_decision(&result);
+
+        let verify_db = Database::open(&db_path).unwrap();
+        let decisions = verify_db.decision_list(None, 10).unwrap();
+        assert_eq!(decisions.len(), 1);
+        assert_eq!(decisions[0].decision_type, DecisionType::Advance);
+        assert!(decisions[0].reasoning.contains("exit=0"));
+    }
+
+    #[tokio::test]
+    async fn record_decision_skip_on_failure() {
+        let (dir, db_path, repo_id) = setup_with_repo();
+        let engine_db = Database::open(&db_path).unwrap();
+        let engine = CronEngine::new(engine_db, dir.path().to_path_buf());
+
+        let result = make_cron_result("claw-evaluate", Some(repo_id), 1, "error output");
+        engine.record_claw_evaluate_decision(&result);
+
+        let verify_db = Database::open(&db_path).unwrap();
+        let decisions = verify_db.decision_list(None, 10).unwrap();
+        assert_eq!(decisions.len(), 1);
+        assert_eq!(decisions[0].decision_type, DecisionType::Skip);
+        assert!(decisions[0].reasoning.contains("exit=1"));
+    }
+
+    #[tokio::test]
+    async fn record_decision_skipped_without_repo_id() {
+        let (dir, db_path, _repo_id) = setup_with_repo();
+        let engine_db = Database::open(&db_path).unwrap();
+        let engine = CronEngine::new(engine_db, dir.path().to_path_buf());
+
+        let result = make_cron_result("claw-evaluate", None, 0, "some output");
+        engine.record_claw_evaluate_decision(&result);
+
+        // No decision should be recorded (no repo_id)
+        let verify_db = Database::open(&db_path).unwrap();
+        let decisions = verify_db.decision_list(None, 10).unwrap();
+        assert!(decisions.is_empty());
     }
 
     #[tokio::test]

--- a/plugins/autodev/cli/src/service/daemon/mod.rs
+++ b/plugins/autodev/cli/src/service/daemon/mod.rs
@@ -293,6 +293,11 @@ impl Daemon {
                         let results = cron.tick().await;
                         for r in &results {
                             info!("cron '{}' completed: exit_code={}", r.job_name, r.exit_code);
+
+                            // Record claw-evaluate decisions
+                            if r.job_name == crate::cli::cron::CLAW_EVALUATE_JOB {
+                                cron.record_claw_evaluate_decision(r);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- claw-evaluate cron was executing on 60s intervals but never recording decisions to the `claw_decisions` table, so `autodev decisions list` showed no entries from automated evaluation
- Added `DecisionType::Noop` variant for "no actionable work" decisions (queue empty, no HITL)
- After each claw-evaluate cron execution, the daemon now records a decision with type (noop/advance/skip), reasoning, and context JSON
- Added 4 unit tests covering all decision recording paths

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (366 lib tests + integration tests, 0 failures)
- [x] New tests: `record_decision_noop_when_skip_output`, `record_decision_advance_on_success`, `record_decision_skip_on_failure`, `record_decision_skipped_without_repo_id`
- [ ] Manual verification: run `autodev daemon start`, wait for claw-evaluate tick, then check `autodev decisions list`

Closes #430

🤖 Generated with [Claude Code](https://claude.com/claude-code)