### PR TITLE
test(autodev): add e2e tests for claw and convention subcommands

### DIFF
--- a/plugins/autodev/cli/tests/e2e_claw.rs
+++ b/plugins/autodev/cli/tests/e2e_claw.rs
@@ -1,0 +1,181 @@
+//! E2E tests for `autodev claw` subcommands:
+//! init, rules, edit
+
+mod e2e_helpers;
+
+use e2e_helpers::*;
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+const REPO_URL: &str = "https://github.com/org/claw-repo";
+const REPO_NAME: &str = "org/claw-repo";
+
+// ═══════════════════════════════════════════════
+// 1. claw init
+// ═══════════════════════════════════════════════
+
+#[test]
+fn e2e_claw_init_creates_workspace() {
+    let home = TempDir::new().unwrap();
+
+    autodev(&home)
+        .args(["claw", "init"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Claw workspace initialized"));
+}
+
+#[test]
+fn e2e_claw_init_idempotent() {
+    let home = TempDir::new().unwrap();
+
+    // First init
+    autodev(&home).args(["claw", "init"]).assert().success();
+
+    // Second init should also succeed (idempotent)
+    autodev(&home)
+        .args(["claw", "init"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Claw workspace initialized"));
+}
+
+#[test]
+fn e2e_claw_init_with_repo() {
+    let home = TempDir::new().unwrap();
+    setup_repo(&home, REPO_URL);
+
+    autodev(&home)
+        .args(["claw", "init", "--repo", REPO_NAME])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Per-repo claw override initialized",
+        ));
+}
+
+// ═══════════════════════════════════════════════
+// 2. claw rules
+// ═══════════════════════════════════════════════
+
+#[test]
+fn e2e_claw_rules_without_init_fails() {
+    let home = TempDir::new().unwrap();
+
+    autodev(&home)
+        .args(["claw", "rules"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("not initialized"));
+}
+
+#[test]
+fn e2e_claw_rules_after_init_lists_rules() {
+    let home = TempDir::new().unwrap();
+
+    // Initialize workspace first
+    autodev(&home).args(["claw", "init"]).assert().success();
+
+    // List rules should show global rules
+    autodev(&home)
+        .args(["claw", "rules"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("[global]"));
+}
+
+#[test]
+fn e2e_claw_rules_json_output() {
+    let home = TempDir::new().unwrap();
+
+    // Initialize workspace first
+    autodev(&home).args(["claw", "init"]).assert().success();
+
+    // JSON output should be a valid JSON array
+    let json = run_json(&home, &["claw", "rules", "--json"]);
+    assert!(json.is_array(), "claw rules --json should be an array");
+    let arr = json.as_array().unwrap();
+    assert!(
+        !arr.is_empty(),
+        "claw rules should return at least one rule after init"
+    );
+}
+
+#[test]
+fn e2e_claw_rules_with_repo_without_repo_init_fails() {
+    let home = TempDir::new().unwrap();
+
+    // Initialize global workspace
+    autodev(&home).args(["claw", "init"]).assert().success();
+
+    // Listing rules with --repo without initializing per-repo should fail
+    autodev(&home)
+        .args(["claw", "rules", "--repo", REPO_NAME])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("not initialized"));
+}
+
+#[test]
+fn e2e_claw_rules_with_repo_after_repo_init() {
+    let home = TempDir::new().unwrap();
+    setup_repo(&home, REPO_URL);
+
+    // Initialize global + per-repo
+    autodev(&home)
+        .args(["claw", "init", "--repo", REPO_NAME])
+        .assert()
+        .success();
+
+    // Listing rules with --repo should succeed
+    autodev(&home)
+        .args(["claw", "rules", "--repo", REPO_NAME])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("[global]"));
+}
+
+// ═══════════════════════════════════════════════
+// 3. claw edit
+// ═══════════════════════════════════════════════
+
+#[test]
+fn e2e_claw_edit_without_init_fails() {
+    let home = TempDir::new().unwrap();
+
+    autodev(&home)
+        .args(["claw", "edit", "scheduling"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("not initialized"));
+}
+
+#[test]
+fn e2e_claw_edit_nonexistent_rule_fails() {
+    let home = TempDir::new().unwrap();
+
+    autodev(&home).args(["claw", "init"]).assert().success();
+
+    // Use EDITOR=true to avoid blocking on interactive editor
+    autodev(&home)
+        .env("EDITOR", "true")
+        .args(["claw", "edit", "nonexistent-rule-name"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("not found"));
+}
+
+#[test]
+fn e2e_claw_edit_existing_rule_succeeds() {
+    let home = TempDir::new().unwrap();
+
+    autodev(&home).args(["claw", "init"]).assert().success();
+
+    // Use EDITOR=true (exits 0 without modifying) to simulate editor
+    autodev(&home)
+        .env("EDITOR", "true")
+        .args(["claw", "edit", "scheduling"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Updated"));
+}

--- a/plugins/autodev/cli/tests/e2e_convention.rs
+++ b/plugins/autodev/cli/tests/e2e_convention.rs
@@ -1,0 +1,356 @@
+//! E2E tests for `autodev convention` subcommands:
+//! detect, bootstrap, patterns, collect-feedback, propose, apply-approved
+
+mod e2e_helpers;
+
+use e2e_helpers::*;
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+const REPO_URL: &str = "https://github.com/org/convention-repo";
+const REPO_NAME: &str = "org/convention-repo";
+
+// ═══════════════════════════════════════════════
+// 1. convention detect
+// ═══════════════════════════════════════════════
+
+#[test]
+fn e2e_convention_detect_rust_repo() {
+    let home = TempDir::new().unwrap();
+    let repo_dir = TempDir::new().unwrap();
+
+    // Create a Cargo.toml to simulate a Rust project
+    std::fs::write(
+        repo_dir.path().join("Cargo.toml"),
+        "[package]\nname = \"test\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+
+    autodev(&home)
+        .args(["convention", "detect", &repo_dir.path().to_string_lossy()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Rust"));
+}
+
+#[test]
+fn e2e_convention_detect_empty_repo() {
+    let home = TempDir::new().unwrap();
+    let repo_dir = TempDir::new().unwrap();
+
+    autodev(&home)
+        .args(["convention", "detect", &repo_dir.path().to_string_lossy()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("no technology stack detected"));
+}
+
+#[test]
+fn e2e_convention_detect_nonexistent_path_fails() {
+    let home = TempDir::new().unwrap();
+
+    autodev(&home)
+        .args(["convention", "detect", "/tmp/nonexistent-path-12345"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("not a directory"));
+}
+
+#[test]
+fn e2e_convention_detect_typescript_repo() {
+    let home = TempDir::new().unwrap();
+    let repo_dir = TempDir::new().unwrap();
+
+    std::fs::write(
+        repo_dir.path().join("package.json"),
+        r#"{"dependencies":{"typescript":"^5.0.0","react":"^18.0.0"}}"#,
+    )
+    .unwrap();
+
+    autodev(&home)
+        .args(["convention", "detect", &repo_dir.path().to_string_lossy()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("TypeScript").and(predicate::str::contains("React")));
+}
+
+// ═══════════════════════════════════════════════
+// 2. convention bootstrap
+// ═══════════════════════════════════════════════
+
+#[test]
+fn e2e_convention_bootstrap_dry_run() {
+    let home = TempDir::new().unwrap();
+    let repo_dir = TempDir::new().unwrap();
+
+    // Create a Rust project
+    std::fs::write(
+        repo_dir.path().join("Cargo.toml"),
+        "[package]\nname = \"test\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+
+    autodev(&home)
+        .args([
+            "convention",
+            "bootstrap",
+            &repo_dir.path().to_string_lossy(),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("would create"));
+
+    // Files should NOT be created in dry-run mode
+    assert!(
+        !repo_dir.path().join(".claude/rules").exists(),
+        "dry-run should not create files"
+    );
+}
+
+#[test]
+fn e2e_convention_bootstrap_apply() {
+    let home = TempDir::new().unwrap();
+    let repo_dir = TempDir::new().unwrap();
+
+    // Create a Rust project
+    std::fs::write(
+        repo_dir.path().join("Cargo.toml"),
+        "[package]\nname = \"test\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+
+    autodev(&home)
+        .args([
+            "convention",
+            "bootstrap",
+            &repo_dir.path().to_string_lossy(),
+            "--apply",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("[created]"));
+
+    // Files should be created with --apply
+    assert!(
+        repo_dir.path().join(".claude/rules").exists(),
+        "bootstrap --apply should create .claude/rules/"
+    );
+}
+
+#[test]
+fn e2e_convention_bootstrap_empty_repo() {
+    let home = TempDir::new().unwrap();
+    let repo_dir = TempDir::new().unwrap();
+
+    // No marker files — empty project
+    autodev(&home)
+        .args([
+            "convention",
+            "bootstrap",
+            &repo_dir.path().to_string_lossy(),
+            "--apply",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("git-workflow.md"));
+}
+
+#[test]
+fn e2e_convention_bootstrap_skips_existing_files() {
+    let home = TempDir::new().unwrap();
+    let repo_dir = TempDir::new().unwrap();
+
+    // Create a Rust project
+    std::fs::write(
+        repo_dir.path().join("Cargo.toml"),
+        "[package]\nname = \"test\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+
+    // First bootstrap
+    autodev(&home)
+        .args([
+            "convention",
+            "bootstrap",
+            &repo_dir.path().to_string_lossy(),
+            "--apply",
+        ])
+        .assert()
+        .success();
+
+    // Second bootstrap should skip existing files
+    autodev(&home)
+        .args([
+            "convention",
+            "bootstrap",
+            &repo_dir.path().to_string_lossy(),
+            "--apply",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("skipped"));
+}
+
+// ═══════════════════════════════════════════════
+// 3. convention patterns
+// ═══════════════════════════════════════════════
+
+#[test]
+fn e2e_convention_patterns_no_repo() {
+    let home = TempDir::new().unwrap();
+    setup_repo(&home, REPO_URL);
+
+    autodev(&home)
+        .args(["convention", "patterns"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Specify --repo"));
+}
+
+#[test]
+fn e2e_convention_patterns_with_repo_empty() {
+    let home = TempDir::new().unwrap();
+    setup_repo(&home, REPO_URL);
+
+    autodev(&home)
+        .args(["convention", "patterns", "--repo", REPO_NAME])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No feedback patterns found"));
+}
+
+#[test]
+fn e2e_convention_patterns_json_empty() {
+    let home = TempDir::new().unwrap();
+    setup_repo(&home, REPO_URL);
+
+    let json = run_json(
+        &home,
+        &["convention", "patterns", "--repo", REPO_NAME, "--json"],
+    );
+    assert!(json.is_array(), "patterns --json should be an array");
+    assert_eq!(json.as_array().unwrap().len(), 0);
+}
+
+// ═══════════════════════════════════════════════
+// 4. convention collect-feedback
+// ═══════════════════════════════════════════════
+
+#[test]
+fn e2e_convention_collect_feedback_no_hitl_events() {
+    let home = TempDir::new().unwrap();
+    setup_repo(&home, REPO_URL);
+
+    // collect-feedback uses `gh` for PR reviews which will fail in test env,
+    // but the HITL feedback collection part should succeed
+    let output = autodev(&home)
+        .args(["convention", "collect-feedback", REPO_NAME])
+        .output()
+        .expect("run command");
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // Should report 0 patterns collected from HITL (no events exist)
+    assert!(
+        stdout.contains("Collected 0 feedback pattern(s)"),
+        "expected 'Collected 0', got: {stdout}"
+    );
+}
+
+#[test]
+fn e2e_convention_collect_feedback_with_hitl_response() {
+    let home = TempDir::new().unwrap();
+    let repo_id = setup_repo(&home, REPO_URL);
+
+    // Seed a HITL event and respond to it with a message
+    let event_id = seed_hitl_event(
+        &home,
+        &repo_id,
+        None,
+        None,
+        "medium",
+        "Style issue found",
+        &["Fix it", "Ignore"],
+    );
+
+    // Respond with a feedback message
+    autodev(&home)
+        .args([
+            "hitl",
+            "respond",
+            &event_id,
+            "--choice",
+            "1",
+            "--message",
+            "Use consistent naming conventions",
+        ])
+        .assert()
+        .success();
+
+    // Collect feedback — should pick up the responded event
+    let output = autodev(&home)
+        .args(["convention", "collect-feedback", REPO_NAME])
+        .output()
+        .expect("run command");
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        stdout.contains("Collected 1 feedback pattern(s)"),
+        "expected 'Collected 1', got: {stdout}"
+    );
+}
+
+// ═══════════════════════════════════════════════
+// 5. convention propose
+// ═══════════════════════════════════════════════
+
+#[test]
+fn e2e_convention_propose_no_patterns() {
+    let home = TempDir::new().unwrap();
+    setup_repo(&home, REPO_URL);
+
+    autodev(&home)
+        .args(["convention", "propose", REPO_NAME])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No actionable patterns found"));
+}
+
+#[test]
+fn e2e_convention_propose_repo_not_found() {
+    let home = TempDir::new().unwrap();
+    setup_repo(&home, REPO_URL);
+
+    autodev(&home)
+        .args(["convention", "propose", "org/nonexistent"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("repository not found"));
+}
+
+// ═══════════════════════════════════════════════
+// 6. convention apply-approved
+// ═══════════════════════════════════════════════
+
+#[test]
+fn e2e_convention_apply_approved_no_events() {
+    let home = TempDir::new().unwrap();
+    setup_repo(&home, REPO_URL);
+
+    autodev(&home)
+        .args(["convention", "apply-approved", REPO_NAME])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("0 applied"));
+}
+
+#[test]
+fn e2e_convention_apply_approved_repo_not_found() {
+    let home = TempDir::new().unwrap();
+    setup_repo(&home, REPO_URL);
+
+    autodev(&home)
+        .args(["convention", "apply-approved", "org/nonexistent"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("repository not found"));
+}


### PR DESCRIPTION
## Summary
- Add 11 e2e tests for `autodev claw` subcommands (init, rules, edit) covering success paths, error cases, and JSON output
- Add 17 e2e tests for `autodev convention` subcommands (detect, bootstrap, patterns, collect-feedback, propose, apply-approved) covering tech stack detection, dry-run vs apply, feedback pipeline, and error handling

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] All 28 new tests pass (`cargo test --test e2e_claw --test e2e_convention`)
- [x] Existing tests unaffected

Closes #470

🤖 Generated with [Claude Code](https://claude.com/claude-code)