### PR TITLE
feat(autodev): implement v5 cron environment variable injection

### DIFF
--- a/plugins/autodev/cli/Cargo.lock
+++ b/plugins/autodev/cli/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autodev"
-version = "0.40.7"
+version = "0.40.9"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/plugins/autodev/cli/src/cli/cron.rs
+++ b/plugins/autodev/cli/src/cli/cron.rs
@@ -194,8 +194,10 @@ pub fn cron_trigger(db: &Database, env: &dyn Env, name: &str, repo: Option<&str>
             cmd.env("AUTODEV_REPO_NAME", &repo_info.name);
             cmd.env("AUTODEV_REPO_URL", &repo_info.url);
             cmd.env("AUTODEV_REPO_ID", &repo_info.id);
-            let workspace =
-                config::workspaces_path(env).join(config::sanitize_repo_name(&repo_info.name));
+            let sanitized = config::sanitize_repo_name(&repo_info.name);
+            // WORKSPACE: short workspace name for cron scripts (v5 spec)
+            cmd.env("WORKSPACE", &sanitized);
+            let workspace = config::workspaces_path(env).join(&sanitized);
             cmd.env("AUTODEV_WORKSPACE", workspace.to_string_lossy().as_ref());
             cmd.env(
                 "AUTODEV_REPO_ROOT",

--- a/plugins/autodev/cli/src/service/daemon/cron/runner.rs
+++ b/plugins/autodev/cli/src/service/daemon/cron/runner.rs
@@ -101,6 +101,8 @@ impl ScriptRunner {
             vars.insert("AUTODEV_REPO_URL".to_string(), repo.url.clone());
 
             let sanitized = crate::core::config::sanitize_repo_name(&repo.name);
+            // WORKSPACE: short workspace name for cron scripts (v5 spec)
+            vars.insert("WORKSPACE".to_string(), sanitized.clone());
             let workspace = home.join("workspaces").join(&sanitized);
             vars.insert(
                 "AUTODEV_WORKSPACE".to_string(),
@@ -194,6 +196,27 @@ mod tests {
         assert_eq!(vars.get("AUTODEV_REPO_ID").unwrap(), "repo-456");
     }
 
+    #[test]
+    fn build_env_vars_includes_workspace_name_when_repo_provided() {
+        let home = PathBuf::from("/home/autodev");
+        let mut job = sample_job();
+        job.repo_id = Some("repo-456".to_string());
+        let repo = sample_repo_info();
+        let vars = ScriptRunner::build_env_vars(&home, &job, Some(&repo));
+
+        // WORKSPACE should be the sanitized repo name (v5 spec)
+        assert_eq!(vars.get("WORKSPACE").unwrap(), "my-repo");
+    }
+
+    #[test]
+    fn build_env_vars_excludes_workspace_when_no_repo() {
+        let home = PathBuf::from("/home/autodev");
+        let job = sample_job();
+        let vars = ScriptRunner::build_env_vars(&home, &job, None);
+
+        assert!(!vars.contains_key("WORKSPACE"));
+    }
+
     // ═══════════════════════════════════════════════
     // run tests
     // ═══════════════════════════════════════════════
@@ -248,5 +271,16 @@ mod tests {
 
         assert_eq!(result.exit_code, 0);
         assert_eq!(result.stdout.trim(), "/my/home");
+    }
+
+    #[tokio::test]
+    async fn run_injects_workspace_env_var_into_script() {
+        let mut env_vars = HashMap::new();
+        env_vars.insert("WORKSPACE".to_string(), "my-project".to_string());
+
+        let result = ScriptRunner::run("echo $WORKSPACE", env_vars).await;
+
+        assert_eq!(result.exit_code, 0);
+        assert_eq!(result.stdout.trim(), "my-project");
     }
 }


### PR DESCRIPTION
## Summary

- Add `WORKSPACE` environment variable (sanitized repo name) to cron script execution, completing the v5 spec requirement for cron-engine environment variables
- Both daemon cron runner (`ScriptRunner::build_env_vars`) and CLI cron trigger (`cron_trigger`) now inject `WORKSPACE` consistently
- `AUTODEV_HOME` and `AUTODEV_DB` were already implemented; this PR adds the missing `WORKSPACE` variable

## Test plan

- [x] Unit test: `build_env_vars_includes_workspace_name_when_repo_provided` — verifies WORKSPACE is set to sanitized repo name
- [x] Unit test: `build_env_vars_excludes_workspace_when_no_repo` — verifies WORKSPACE is absent for global jobs
- [x] Unit test: `run_injects_workspace_env_var_into_script` — verifies WORKSPACE is available inside executed script
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] All 365+ existing tests pass

Closes #460

🤖 Generated with [Claude Code](https://claude.com/claude-code)