### PR TITLE
feat(autodev): implement v5 5-level escalation policy with yaml-defined on_fail routing

### DIFF
--- a/plugins/autodev/cli/Cargo.lock
+++ b/plugins/autodev/cli/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autodev"
-version = "0.42.0"
+version = "0.43.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/plugins/autodev/cli/src/core/config/models.rs
+++ b/plugins/autodev/cli/src/core/config/models.rs
@@ -16,6 +16,7 @@ pub struct WorkflowConfig {
     pub daemon: DaemonConfig,
     pub workflows: Workflows,
     pub claw: ClawConfig,
+    pub escalation: EscalationConfig,
 }
 
 /// 태스크 소스 설정 — 소스 종류별 하위 키
@@ -133,6 +134,101 @@ impl Default for GitHubSourceConfig {
             knowledge_extraction: true,
             auto_approve: false,
             auto_approve_threshold: 0.8,
+        }
+    }
+}
+
+// ═══════════════════════════════════════════════
+// escalation — 5-Level failure escalation 정책
+// ═══════════════════════════════════════════════
+
+/// 5단계 에스컬레이션 정책 설정.
+///
+/// workspace yaml에서 failure_count → action 매핑과 on_fail script를 정의한다.
+///
+/// ```yaml
+/// escalation:
+///   levels:
+///     1: retry
+///     2: retry_with_comment
+///     3: hitl
+///     4: skip
+///     5: replan
+///   on_fail:
+///     - "echo 'task failed'"
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct EscalationConfig {
+    /// failure_count → EscalationAction 매핑.
+    /// 키는 1~5, 값은 retry | retry_with_comment | hitl | skip | replan.
+    pub levels: std::collections::BTreeMap<u32, EscalationAction>,
+    /// 실패 시 실행할 on_fail script 목록.
+    /// retry 레벨에서는 실행하지 않고, 나머지 레벨에서 순차 실행한다.
+    pub on_fail: Vec<String>,
+}
+
+impl Default for EscalationConfig {
+    fn default() -> Self {
+        let mut levels = std::collections::BTreeMap::new();
+        levels.insert(1, EscalationAction::Retry);
+        levels.insert(2, EscalationAction::RetryWithComment);
+        levels.insert(3, EscalationAction::Hitl);
+        levels.insert(4, EscalationAction::Skip);
+        levels.insert(5, EscalationAction::Replan);
+        Self {
+            levels,
+            on_fail: Vec::new(),
+        }
+    }
+}
+
+impl EscalationConfig {
+    /// failure_count에 대응하는 EscalationAction을 반환한다.
+    /// 정의된 범위를 초과하면 가장 높은 레벨의 action을 반환한다.
+    pub fn action_for(&self, failure_count: u32) -> EscalationAction {
+        if let Some(action) = self.levels.get(&failure_count) {
+            return *action;
+        }
+        // failure_count가 정의된 최대 레벨을 초과하면 최고 레벨 action 사용
+        self.levels
+            .values()
+            .last()
+            .copied()
+            .unwrap_or(EscalationAction::Replan)
+    }
+
+    /// 해당 action에서 on_fail script를 실행해야 하는지 여부.
+    /// retry만 on_fail을 실행하지 않는다.
+    pub fn should_run_on_fail(&self, action: EscalationAction) -> bool {
+        action != EscalationAction::Retry
+    }
+}
+
+/// 에스컬레이션 액션 종류.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EscalationAction {
+    /// 조용한 재시도 (on_fail 실행 안 함, worktree 보존)
+    Retry,
+    /// on_fail 실행 + 재시도
+    RetryWithComment,
+    /// on_fail 실행 + HITL 이벤트 생성
+    Hitl,
+    /// on_fail 실행 + Skipped 상태 전이
+    Skip,
+    /// on_fail 실행 + HITL(replan) 생성
+    Replan,
+}
+
+impl std::fmt::Display for EscalationAction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            EscalationAction::Retry => write!(f, "retry"),
+            EscalationAction::RetryWithComment => write!(f, "retry_with_comment"),
+            EscalationAction::Hitl => write!(f, "hitl"),
+            EscalationAction::Skip => write!(f, "skip"),
+            EscalationAction::Replan => write!(f, "replan"),
         }
     }
 }
@@ -431,5 +527,114 @@ claw:
         assert_eq!(cfg.claw.recovery_interval_secs, 120);
         assert_eq!(cfg.claw.schedule_interval_secs, 60);
         assert_eq!(cfg.claw.gap_detection_interval_secs, 3600);
+    }
+
+    // ═══════════════════════════════════════════════
+    // EscalationConfig 테스트
+    // ═══════════════════════════════════════════════
+
+    #[test]
+    fn escalation_config_defaults() {
+        let cfg = EscalationConfig::default();
+        assert_eq!(cfg.levels.len(), 5);
+        assert_eq!(cfg.action_for(1), EscalationAction::Retry);
+        assert_eq!(cfg.action_for(2), EscalationAction::RetryWithComment);
+        assert_eq!(cfg.action_for(3), EscalationAction::Hitl);
+        assert_eq!(cfg.action_for(4), EscalationAction::Skip);
+        assert_eq!(cfg.action_for(5), EscalationAction::Replan);
+        assert!(cfg.on_fail.is_empty());
+    }
+
+    #[test]
+    fn escalation_config_defaults_when_omitted() {
+        let yaml = r#"
+daemon:
+  log_level: "info"
+"#;
+        let cfg: WorkflowConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(cfg.escalation.levels.len(), 5);
+        assert_eq!(cfg.escalation.action_for(1), EscalationAction::Retry);
+        assert!(cfg.escalation.on_fail.is_empty());
+    }
+
+    #[test]
+    fn escalation_config_from_yaml() {
+        let yaml = r#"
+escalation:
+  levels:
+    1: retry
+    2: retry_with_comment
+    3: hitl
+    4: skip
+    5: replan
+  on_fail:
+    - "gh issue comment $ISSUE --body 'task failed'"
+    - "echo 'notification sent'"
+"#;
+        let cfg: WorkflowConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(cfg.escalation.levels.len(), 5);
+        assert_eq!(cfg.escalation.action_for(1), EscalationAction::Retry);
+        assert_eq!(
+            cfg.escalation.action_for(2),
+            EscalationAction::RetryWithComment
+        );
+        assert_eq!(cfg.escalation.action_for(3), EscalationAction::Hitl);
+        assert_eq!(cfg.escalation.action_for(4), EscalationAction::Skip);
+        assert_eq!(cfg.escalation.action_for(5), EscalationAction::Replan);
+        assert_eq!(cfg.escalation.on_fail.len(), 2);
+    }
+
+    #[test]
+    fn escalation_config_custom_levels() {
+        let yaml = r#"
+escalation:
+  levels:
+    1: retry
+    2: retry
+    3: skip
+"#;
+        let cfg: WorkflowConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(cfg.escalation.levels.len(), 3);
+        assert_eq!(cfg.escalation.action_for(1), EscalationAction::Retry);
+        assert_eq!(cfg.escalation.action_for(2), EscalationAction::Retry);
+        assert_eq!(cfg.escalation.action_for(3), EscalationAction::Skip);
+        // Beyond max → last defined action
+        assert_eq!(cfg.escalation.action_for(99), EscalationAction::Skip);
+    }
+
+    #[test]
+    fn escalation_config_partial_override_preserves_defaults() {
+        let yaml = r#"
+escalation:
+  on_fail:
+    - "echo fail"
+"#;
+        let cfg: WorkflowConfig = serde_yaml::from_str(yaml).unwrap();
+        // levels should use defaults
+        assert_eq!(cfg.escalation.levels.len(), 5);
+        assert_eq!(cfg.escalation.on_fail.len(), 1);
+        assert_eq!(cfg.escalation.on_fail[0], "echo fail");
+    }
+
+    #[test]
+    fn escalation_should_run_on_fail() {
+        let cfg = EscalationConfig::default();
+        assert!(!cfg.should_run_on_fail(EscalationAction::Retry));
+        assert!(cfg.should_run_on_fail(EscalationAction::RetryWithComment));
+        assert!(cfg.should_run_on_fail(EscalationAction::Hitl));
+        assert!(cfg.should_run_on_fail(EscalationAction::Skip));
+        assert!(cfg.should_run_on_fail(EscalationAction::Replan));
+    }
+
+    #[test]
+    fn escalation_action_display() {
+        assert_eq!(EscalationAction::Retry.to_string(), "retry");
+        assert_eq!(
+            EscalationAction::RetryWithComment.to_string(),
+            "retry_with_comment"
+        );
+        assert_eq!(EscalationAction::Hitl.to_string(), "hitl");
+        assert_eq!(EscalationAction::Skip.to_string(), "skip");
+        assert_eq!(EscalationAction::Replan.to_string(), "replan");
     }
 }

--- a/plugins/autodev/cli/src/core/models.rs
+++ b/plugins/autodev/cli/src/core/models.rs
@@ -363,11 +363,14 @@ impl fmt::Display for QueueType {
 /// 5-Level failure escalation.
 ///
 /// failure_count가 증가할 때마다 대응 수준을 높인다.
-/// 1회: 재시도, 2회: 코멘트, 3회: HITL, 4회: 스킵, 5+회: 리플랜.
+/// 1회: 재시도, 2회: 코멘트+재시도, 3회: HITL, 4회: 스킵, 5+회: 리플랜.
+///
+/// v5에서는 `EscalationConfig`(yaml)가 정책을 정의하며,
+/// 이 enum은 런타임 판정 결과를 표현한다.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum EscalationLevel {
     Retry = 1,
-    Comment = 2,
+    RetryWithComment = 2,
     Hitl = 3,
     Skip = 4,
     Replan = 5,
@@ -375,12 +378,26 @@ pub enum EscalationLevel {
 
 impl From<i32> for EscalationLevel {
     fn from(failure_count: i32) -> Self {
-        match failure_count {
-            0..=1 => EscalationLevel::Retry,
-            2 => EscalationLevel::Comment,
-            3 => EscalationLevel::Hitl,
-            4 => EscalationLevel::Skip,
-            _ => EscalationLevel::Replan,
+        use crate::core::config::models::EscalationConfig;
+        let cfg = EscalationConfig::default();
+        let count = if failure_count < 1 {
+            1
+        } else {
+            failure_count as u32
+        };
+        cfg.action_for(count).into()
+    }
+}
+
+impl From<crate::core::config::models::EscalationAction> for EscalationLevel {
+    fn from(action: crate::core::config::models::EscalationAction) -> Self {
+        use crate::core::config::models::EscalationAction;
+        match action {
+            EscalationAction::Retry => EscalationLevel::Retry,
+            EscalationAction::RetryWithComment => EscalationLevel::RetryWithComment,
+            EscalationAction::Hitl => EscalationLevel::Hitl,
+            EscalationAction::Skip => EscalationLevel::Skip,
+            EscalationAction::Replan => EscalationLevel::Replan,
         }
     }
 }
@@ -389,7 +406,7 @@ impl fmt::Display for EscalationLevel {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             EscalationLevel::Retry => write!(f, "retry"),
-            EscalationLevel::Comment => write!(f, "comment"),
+            EscalationLevel::RetryWithComment => write!(f, "retry_with_comment"),
             EscalationLevel::Hitl => write!(f, "hitl"),
             EscalationLevel::Skip => write!(f, "skip"),
             EscalationLevel::Replan => write!(f, "replan"),

--- a/plugins/autodev/cli/src/service/daemon/escalation.rs
+++ b/plugins/autodev/cli/src/service/daemon/escalation.rs
@@ -1,10 +1,12 @@
 //! 5-Level failure escalation for the daemon task loop.
 //!
-//! failure_count 증가 → EscalationLevel 판정 → 대응 액션 수행.
-//! Retry/Comment: 아이템을 pending으로 되돌려 재시도.
-//! Hitl/Replan: HITL 이벤트 생성 후 큐에서 제거.
-//! Skip: 즉시 제거 (기존 동작).
+//! failure_count 증가 → yaml 정책 기반 EscalationLevel 판정 → on_fail 조건부 실행 → 대응 액션 수행.
+//!
+//! v5 스펙에 따라 workspace yaml의 `escalation` 섹션에서 정책을 읽어온다:
+//! - `levels`: failure_count → action 매핑 (retry, retry_with_comment, hitl, skip, replan)
+//! - `on_fail`: 실패 시 실행할 script 목록 (retry에서는 실행 안 함)
 
+use crate::core::config::models::EscalationConfig;
 use crate::core::models::{EscalationLevel, HitlSeverity, NewHitlEvent, QueuePhase};
 use crate::core::repository::{HitlRepository, QueueRepository};
 use crate::infra::db::Database;
@@ -18,6 +20,33 @@ pub enum EscalationOutcome {
     /// HITL 이벤트를 생성하고 아이템을 제거한다. 알림 발송이 필요하다.
     /// `String` is the assigned hitl_id from the database.
     RemoveWithHitl(NewHitlEvent, String),
+}
+
+/// on_fail script를 순차 실행한다. 하나라도 실패하면 경고 로그를 남기지만 계속 진행한다.
+fn run_on_fail_scripts(scripts: &[String], work_id: &str) {
+    for script in scripts {
+        tracing::info!("on_fail: running script for {work_id}");
+        let result = std::process::Command::new("sh")
+            .arg("-c")
+            .arg(script)
+            .env("WORK_ID", work_id)
+            .output();
+        match result {
+            Ok(output) if !output.status.success() => {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                tracing::warn!(
+                    "on_fail script failed for {work_id} (exit {}): {stderr}",
+                    output.status.code().unwrap_or(-1)
+                );
+            }
+            Err(e) => {
+                tracing::warn!("on_fail script execution error for {work_id}: {e}");
+            }
+            Ok(_) => {
+                tracing::debug!("on_fail script succeeded for {work_id}");
+            }
+        }
+    }
 }
 
 /// HITL 이벤트를 DB에 저장하고, 성공 시 RemoveWithHitl, 실패 시 Remove를 반환한다.
@@ -38,18 +67,34 @@ fn create_hitl_or_remove(
 /// 실패한 태스크에 대해 에스컬레이션을 수행한다.
 ///
 /// 1. failure_count를 1 증가시킨다.
-/// 2. EscalationLevel을 산출한다.
-/// 3. 레벨에 따라 대응한다:
-///    - Retry: pending으로 되돌린다.
-///    - Comment: GitHub에 코멘트를 남기고 pending으로 되돌린다.
-///    - Hitl: HITL 이벤트를 생성하고 제거한다.
-///    - Skip: 제거한다 (기존 동작).
-///    - Replan: HITL 이벤트(replan)를 생성하고 제거한다.
+/// 2. yaml 정책에서 EscalationAction을 산출한다.
+/// 3. on_fail 실행 조건을 확인한다 (retry만 skip).
+/// 4. 레벨에 따라 대응한다:
+///    - Retry: pending으로 되돌린다 (on_fail 실행 안 함).
+///    - RetryWithComment: on_fail 실행 + pending으로 되돌린다.
+///    - Hitl: on_fail 실행 + HITL 이벤트를 생성하고 제거한다.
+///    - Skip: on_fail 실행 + 제거한다.
+///    - Replan: on_fail 실행 + HITL 이벤트(replan)를 생성하고 제거한다.
 pub fn escalate(
     db: &Database,
     work_id: &str,
     repo_id: &str,
     failure_msg: &str,
+) -> EscalationOutcome {
+    let cfg = EscalationConfig::default();
+    escalate_with_config(db, work_id, repo_id, failure_msg, &cfg)
+}
+
+/// yaml 정책을 받아 에스컬레이션을 수행한다.
+///
+/// `escalate()`의 config-aware 버전. daemon이 workspace yaml에서 로드한
+/// `EscalationConfig`를 직접 전달할 수 있다.
+pub fn escalate_with_config(
+    db: &Database,
+    work_id: &str,
+    repo_id: &str,
+    failure_msg: &str,
+    config: &EscalationConfig,
 ) -> EscalationOutcome {
     // 1. failure_count 증가
     let new_count = match db.queue_increment_failure(work_id) {
@@ -60,12 +105,29 @@ pub fn escalate(
         }
     };
 
-    let level = EscalationLevel::from(new_count);
-    tracing::info!("escalation: {work_id} failure_count={new_count} → level={level}");
+    let action = config.action_for(new_count as u32);
+    let level: EscalationLevel = action.into();
+    tracing::info!(
+        "escalation: {work_id} failure_count={new_count} → level={level} (action={action})"
+    );
 
+    // 2. on_fail 조건부 실행 (retry만 skip)
+    if config.should_run_on_fail(action) && !config.on_fail.is_empty() {
+        run_on_fail_scripts(&config.on_fail, work_id);
+    }
+
+    // 3. 레벨별 대응
     match level {
-        EscalationLevel::Retry | EscalationLevel::Comment => {
-            // pending으로 되돌려 재시도 (Comment 레벨의 코멘트는 태스크 자체가 이미 남김)
+        EscalationLevel::Retry => {
+            // 조용한 재시도: on_fail 실행 안 함, worktree 보존
+            if let Err(e) = db.queue_transit(work_id, QueuePhase::Running, QueuePhase::Pending) {
+                tracing::warn!("failed to reset {work_id} to pending: {e}");
+                return EscalationOutcome::Remove;
+            }
+            EscalationOutcome::Retry
+        }
+        EscalationLevel::RetryWithComment => {
+            // on_fail 실행 완료 + 재시도
             if let Err(e) = db.queue_transit(work_id, QueuePhase::Running, QueuePhase::Pending) {
                 tracing::warn!("failed to reset {work_id} to pending: {e}");
                 return EscalationOutcome::Remove;
@@ -108,5 +170,74 @@ pub fn escalate(
             };
             create_hitl_or_remove(db, work_id, hitl_event)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::config::models::EscalationAction;
+
+    #[test]
+    fn default_config_action_mapping() {
+        let cfg = EscalationConfig::default();
+        assert_eq!(cfg.action_for(1), EscalationAction::Retry);
+        assert_eq!(cfg.action_for(2), EscalationAction::RetryWithComment);
+        assert_eq!(cfg.action_for(3), EscalationAction::Hitl);
+        assert_eq!(cfg.action_for(4), EscalationAction::Skip);
+        assert_eq!(cfg.action_for(5), EscalationAction::Replan);
+        // Beyond max level → last defined action
+        assert_eq!(cfg.action_for(10), EscalationAction::Replan);
+    }
+
+    #[test]
+    fn should_run_on_fail_only_skips_retry() {
+        let cfg = EscalationConfig::default();
+        assert!(!cfg.should_run_on_fail(EscalationAction::Retry));
+        assert!(cfg.should_run_on_fail(EscalationAction::RetryWithComment));
+        assert!(cfg.should_run_on_fail(EscalationAction::Hitl));
+        assert!(cfg.should_run_on_fail(EscalationAction::Skip));
+        assert!(cfg.should_run_on_fail(EscalationAction::Replan));
+    }
+
+    #[test]
+    fn custom_config_overrides_levels() {
+        let mut levels = std::collections::BTreeMap::new();
+        levels.insert(1, EscalationAction::Retry);
+        levels.insert(2, EscalationAction::Retry);
+        levels.insert(3, EscalationAction::Skip);
+        let cfg = EscalationConfig {
+            levels,
+            on_fail: vec!["echo fail".to_string()],
+        };
+        assert_eq!(cfg.action_for(1), EscalationAction::Retry);
+        assert_eq!(cfg.action_for(2), EscalationAction::Retry);
+        assert_eq!(cfg.action_for(3), EscalationAction::Skip);
+        // Beyond max → last defined (Skip)
+        assert_eq!(cfg.action_for(99), EscalationAction::Skip);
+    }
+
+    #[test]
+    fn escalation_level_from_action() {
+        assert_eq!(
+            EscalationLevel::from(EscalationAction::Retry),
+            EscalationLevel::Retry
+        );
+        assert_eq!(
+            EscalationLevel::from(EscalationAction::RetryWithComment),
+            EscalationLevel::RetryWithComment
+        );
+        assert_eq!(
+            EscalationLevel::from(EscalationAction::Hitl),
+            EscalationLevel::Hitl
+        );
+        assert_eq!(
+            EscalationLevel::from(EscalationAction::Skip),
+            EscalationLevel::Skip
+        );
+        assert_eq!(
+            EscalationLevel::from(EscalationAction::Replan),
+            EscalationLevel::Replan
+        );
     }
 }

--- a/plugins/autodev/cli/src/service/daemon/mod.rs
+++ b/plugins/autodev/cli/src/service/daemon/mod.rs
@@ -120,6 +120,7 @@ pub struct Daemon {
     cron_engine: Option<CronEngine>,
     notifier: Option<notifiers::dispatcher::NotificationDispatcher>,
     shutdown_drain_timeout_secs: u64,
+    escalation_config: config::models::EscalationConfig,
 }
 
 impl Daemon {
@@ -133,6 +134,7 @@ impl Daemon {
         status_path: PathBuf,
         tick_interval_secs: u64,
         shutdown_drain_timeout_secs: u64,
+        escalation_config: config::models::EscalationConfig,
     ) -> Self {
         Self {
             manager,
@@ -145,6 +147,7 @@ impl Daemon {
             cron_engine: None,
             notifier: None,
             shutdown_drain_timeout_secs,
+            escalation_config,
         }
     }
 
@@ -172,7 +175,13 @@ impl Daemon {
         let escalation_retry = if let TaskStatus::Failed(ref msg) = task_result.status {
             match crate::cli::resolve_repo_id(&self.log_db, &task_result.repo_name) {
                 Ok(repo_id) => {
-                    match escalation::escalate(&self.log_db, &task_result.work_id, &repo_id, msg) {
+                    match escalation::escalate_with_config(
+                        &self.log_db,
+                        &task_result.work_id,
+                        &repo_id,
+                        msg,
+                        &self.escalation_config,
+                    ) {
                         escalation::EscalationOutcome::Retry => true,
                         escalation::EscalationOutcome::Remove => false,
                         escalation::EscalationOutcome::RemoveWithHitl(event, hitl_id) => {
@@ -625,6 +634,7 @@ pub async fn start(
         status_path,
         cfg.daemon.tick_interval_secs,
         cfg.daemon.shutdown_drain_timeout_secs,
+        cfg.escalation.clone(),
     )
     .with_cron_engine(cron_engine);
 


### PR DESCRIPTION
## Summary

- Add `EscalationConfig` to workspace yaml with configurable `levels` (failure_count → action mapping) and `on_fail` script list
- Implement 5 escalation actions: `retry`, `retry_with_comment`, `hitl`, `skip`, `replan` as defined in v5 spec
- `on_fail` scripts run conditionally — skipped only for `retry` level (silent retry), executed for all other levels
- Rename `EscalationLevel::Comment` to `RetryWithComment` for spec alignment
- Daemon passes `EscalationConfig` from yaml to `escalate_with_config()`
- `WORK_ID` env var injected into on_fail script processes for context lookup

## Test plan

- [x] `EscalationConfig` default produces correct 5-level mapping
- [x] YAML parsing correctly deserializes custom levels and on_fail scripts
- [x] Partial YAML override preserves default levels
- [x] `should_run_on_fail` returns false only for `retry`
- [x] `action_for` returns last defined action when failure_count exceeds max level
- [x] `EscalationLevel` converts correctly from `EscalationAction`
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (all 149 tests)

Closes #455

🤖 Generated with [Claude Code](https://claude.com/claude-code)