### PR TITLE
fix(autodev): set SQLite busy_timeout and fix non-atomic DB operations

### DIFF
--- a/plugins/autodev/cli/src/infra/db/mod.rs
+++ b/plugins/autodev/cli/src/infra/db/mod.rs
@@ -13,7 +13,9 @@ pub struct Database {
 impl Database {
     pub fn open(path: &Path) -> Result<Self> {
         let conn = Connection::open(path)?;
-        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")?;
+        conn.execute_batch(
+            "PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON; PRAGMA busy_timeout=5000;",
+        )?;
         Ok(Self { conn })
     }
 
@@ -27,5 +29,186 @@ impl Database {
 
     pub fn conn(&self) -> &Connection {
         &self.conn
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::models::*;
+    use crate::core::repository::*;
+    use std::sync::{Arc, Barrier};
+
+    fn setup_db() -> Database {
+        let db = Database::open(Path::new(":memory:")).unwrap();
+        db.initialize().unwrap();
+        db
+    }
+
+    fn add_repo(db: &Database) -> String {
+        db.repo_add("https://github.com/test/repo", "test-repo")
+            .unwrap()
+    }
+
+    fn make_queue_item(repo_id: &str, work_id: &str) -> QueueItemRow {
+        let now = chrono::Utc::now().to_rfc3339();
+        QueueItemRow {
+            work_id: work_id.to_string(),
+            repo_id: repo_id.to_string(),
+            queue_type: QueueType::Issue,
+            phase: QueuePhase::Pending,
+            title: Some("test".to_string()),
+            skip_reason: None,
+            created_at: now.clone(),
+            updated_at: now,
+            task_kind: crate::core::phase::TaskKind::Analyze,
+            github_number: 1,
+            metadata_json: None,
+            failure_count: 0,
+            escalation_level: 0,
+        }
+    }
+
+    #[test]
+    fn busy_timeout_is_set() {
+        let db = setup_db();
+        let timeout: i64 = db
+            .conn()
+            .query_row("PRAGMA busy_timeout", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(timeout, 5000);
+    }
+
+    #[test]
+    fn queue_increment_failure_returns_correct_count() {
+        let db = setup_db();
+        let repo_id = add_repo(&db);
+        let item = make_queue_item(&repo_id, "work-1");
+        db.queue_upsert(&item).unwrap();
+
+        let count1 = db.queue_increment_failure("work-1").unwrap();
+        assert_eq!(count1, 1);
+
+        let count2 = db.queue_increment_failure("work-1").unwrap();
+        assert_eq!(count2, 2);
+
+        let count3 = db.queue_increment_failure("work-1").unwrap();
+        assert_eq!(count3, 3);
+    }
+
+    #[test]
+    fn feedback_upsert_insert_then_update_atomically() {
+        let db = setup_db();
+        let repo_id = add_repo(&db);
+        let pattern = NewFeedbackPattern {
+            repo_id: repo_id.clone(),
+            pattern_type: "style".to_string(),
+            suggestion: "use snake_case".to_string(),
+            source: "review".to_string(),
+        };
+
+        // First insert
+        let id1 = db.feedback_upsert(&pattern).unwrap();
+        assert!(!id1.is_empty());
+
+        // Second upsert returns existing id
+        let id2 = db.feedback_upsert(&pattern).unwrap();
+        assert_eq!(id1, id2);
+
+        // Verify occurrence_count incremented
+        let patterns = db.feedback_list(&repo_id).unwrap();
+        assert_eq!(patterns.len(), 1);
+        assert_eq!(patterns[0].occurrence_count, 2);
+    }
+
+    #[test]
+    fn concurrent_increment_failure_on_file_db() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+
+        // Set up initial data
+        {
+            let db = Database::open(&db_path).unwrap();
+            db.initialize().unwrap();
+            let repo_id = add_repo(&db);
+            let item = make_queue_item(&repo_id, "work-concurrent");
+            db.queue_upsert(&item).unwrap();
+        }
+
+        let iterations = 10;
+        let threads = 4;
+        let barrier = Arc::new(Barrier::new(threads));
+
+        let handles: Vec<_> = (0..threads)
+            .map(|_| {
+                let path = db_path.clone();
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    let db = Database::open(&path).unwrap();
+                    barrier.wait();
+                    for _ in 0..iterations {
+                        db.queue_increment_failure("work-concurrent").unwrap();
+                    }
+                })
+            })
+            .collect();
+
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        // Verify total increments
+        let db = Database::open(&db_path).unwrap();
+        let count = db.queue_get_failure_count("work-concurrent").unwrap();
+        assert_eq!(count, (threads * iterations) as i32);
+    }
+
+    #[test]
+    fn concurrent_feedback_upsert_on_file_db() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+
+        // Set up initial data
+        let repo_id;
+        {
+            let db = Database::open(&db_path).unwrap();
+            db.initialize().unwrap();
+            repo_id = add_repo(&db);
+        }
+
+        let iterations = 10;
+        let threads = 4;
+        let barrier = Arc::new(Barrier::new(threads));
+
+        let handles: Vec<_> = (0..threads)
+            .map(|_| {
+                let path = db_path.clone();
+                let barrier = Arc::clone(&barrier);
+                let rid = repo_id.clone();
+                std::thread::spawn(move || {
+                    let db = Database::open(&path).unwrap();
+                    barrier.wait();
+                    for _ in 0..iterations {
+                        let pattern = NewFeedbackPattern {
+                            repo_id: rid.clone(),
+                            pattern_type: "style".to_string(),
+                            suggestion: "use snake_case".to_string(),
+                            source: "review".to_string(),
+                        };
+                        db.feedback_upsert(&pattern).unwrap();
+                    }
+                })
+            })
+            .collect();
+
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        // Verify single row with correct occurrence_count
+        let db = Database::open(&db_path).unwrap();
+        let patterns = db.feedback_list(&repo_id).unwrap();
+        assert_eq!(patterns.len(), 1);
+        assert_eq!(patterns[0].occurrence_count, (threads * iterations) as i32);
     }
 }

--- a/plugins/autodev/cli/src/infra/db/repository.rs
+++ b/plugins/autodev/cli/src/infra/db/repository.rs
@@ -987,14 +987,10 @@ impl QueueRepository for Database {
     fn queue_increment_failure(&self, work_id: &str) -> Result<i32> {
         let conn = self.conn();
         let now = Utc::now().to_rfc3339();
-        conn.execute(
-            "UPDATE queue_items SET failure_count = failure_count + 1, updated_at = ?1 \
-             WHERE work_id = ?2",
-            rusqlite::params![now, work_id],
-        )?;
         let count: i32 = conn.query_row(
-            "SELECT failure_count FROM queue_items WHERE work_id = ?1",
-            rusqlite::params![work_id],
+            "UPDATE queue_items SET failure_count = failure_count + 1, updated_at = ?1 \
+             WHERE work_id = ?2 RETURNING failure_count",
+            rusqlite::params![now, work_id],
             |row| row.get(0),
         )?;
         Ok(count)
@@ -1116,8 +1112,10 @@ impl FeedbackPatternRepository for Database {
         let now = Utc::now().to_rfc3339();
         let id = Uuid::new_v4().to_string();
 
+        let tx = conn.unchecked_transaction()?;
+
         // Try insert first
-        let inserted = conn.execute(
+        let inserted = tx.execute(
             "INSERT OR IGNORE INTO feedback_patterns \
              (id, repo_id, pattern_type, suggestion, source, occurrence_count, confidence, status, sources_json, created_at, last_seen_at) \
              VALUES (?1, ?2, ?3, ?4, ?5, 1, 0.5, 'active', ?6, ?7, ?7)",
@@ -1134,7 +1132,7 @@ impl FeedbackPatternRepository for Database {
 
         if inserted == 0 {
             // Row already exists — increment occurrence_count and update sources_json
-            conn.execute(
+            tx.execute(
                 "UPDATE feedback_patterns \
                  SET occurrence_count = occurrence_count + 1, \
                      last_seen_at = ?1, \
@@ -1152,15 +1150,17 @@ impl FeedbackPatternRepository for Database {
             )?;
 
             // Return the existing id
-            let existing_id: String = conn.query_row(
+            let existing_id: String = tx.query_row(
                 "SELECT id FROM feedback_patterns \
                  WHERE repo_id = ?1 AND pattern_type = ?2 AND suggestion = ?3",
                 rusqlite::params![pattern.repo_id, pattern.pattern_type, pattern.suggestion],
                 |row| row.get(0),
             )?;
+            tx.commit()?;
             return Ok(existing_id);
         }
 
+        tx.commit()?;
         Ok(id)
     }
 


### PR DESCRIPTION
## Summary
- Add `PRAGMA busy_timeout=5000` to `Database::open` so concurrent writers wait instead of returning `SQLITE_BUSY` immediately
- Replace non-atomic UPDATE + SELECT in `queue_increment_failure` with a single `UPDATE ... RETURNING` statement
- Wrap `feedback_upsert` INSERT OR IGNORE + UPDATE in an `unchecked_transaction` for atomicity
- Add 5 tests including concurrent file-based DB tests for both fixed operations

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test --lib infra::db::tests` — all 5 tests pass
  - `busy_timeout_is_set` — verifies PRAGMA value is 5000
  - `queue_increment_failure_returns_correct_count` — sequential correctness
  - `feedback_upsert_insert_then_update_atomically` — sequential upsert correctness
  - `concurrent_increment_failure_on_file_db` — 4 threads x 10 iterations, verifies total = 40
  - `concurrent_feedback_upsert_on_file_db` — 4 threads x 10 iterations, verifies single row with count = 40

Closes #480

🤖 Generated with [Claude Code](https://claude.com/claude-code)