### PR TITLE
feat(autodev): add missing v5 CLI commands (context, queue done/hitl, retry-script)

### DIFF
--- a/plugins/autodev/cli/Cargo.lock
+++ b/plugins/autodev/cli/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autodev"
-version = "0.44.0"
+version = "0.47.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/plugins/autodev/cli/src/cli/queue.rs
+++ b/plugins/autodev/cli/src/cli/queue.rs
@@ -236,3 +236,170 @@ pub fn queue_list_db(
     }
     Ok(output)
 }
+
+/// 아이템 컨텍스트 조회 (script용 정보 조회)
+///
+/// v5 spec에서 script가 아이템 정보를 조회하는 유일한 방법.
+/// `autodev context $WORK_ID --json` 형태로 사용.
+pub fn queue_context(db: &Database, work_id: &str, json: bool) -> Result<String> {
+    use crate::core::repository::RepoRepository;
+
+    let item = db
+        .queue_get_item(work_id)?
+        .ok_or_else(|| anyhow::anyhow!("queue item not found: {work_id}"))?;
+
+    // Resolve repo info
+    let repos = db.repo_list()?;
+    let repo = repos.iter().find(|r| {
+        // repo_id is the internal ID; match by checking enabled repos
+        let enabled = db.repo_find_enabled().unwrap_or_default();
+        enabled
+            .iter()
+            .any(|e| e.id == item.repo_id && e.name == r.name)
+    });
+
+    let repo_url = repo.map(|r| r.url.as_str()).unwrap_or("");
+    let repo_name = repo.map(|r| r.name.as_str()).unwrap_or("");
+
+    if json {
+        let mut context = serde_json::json!({
+            "work_id": item.work_id,
+            "queue": {
+                "phase": item.phase.as_str(),
+                "type": item.queue_type.to_string(),
+                "task_kind": item.task_kind.to_string(),
+                "failure_count": item.failure_count,
+                "escalation_level": item.escalation_level,
+            },
+            "source": {
+                "url": repo_url,
+                "repo_name": repo_name,
+            },
+            "issue": {
+                "number": item.github_number,
+                "title": item.title,
+            },
+        });
+        if let Some(ref metadata) = item.metadata_json {
+            if let Ok(meta_value) = serde_json::from_str::<serde_json::Value>(metadata) {
+                context["metadata"] = meta_value;
+            }
+        }
+        return Ok(serde_json::to_string_pretty(&context)?);
+    }
+
+    let title = item.title.as_deref().unwrap_or("-");
+    Ok(format!(
+        "Work ID:    {}\nRepo:       {} ({})\nType:       {}\nPhase:      {}\nTask kind:  {}\nGH number:  #{}\nTitle:      {}\nFailures:   {}\nEscalation: {}\n",
+        item.work_id,
+        repo_name,
+        repo_url,
+        item.queue_type,
+        item.phase,
+        item.task_kind,
+        item.github_number,
+        title,
+        item.failure_count,
+        item.escalation_level,
+    ))
+}
+
+/// Completed → Done 전환 (evaluate 완료 판정 후 호출)
+pub fn queue_done(db: &Database, work_id: &str, reason: Option<&str>) -> Result<String> {
+    let item = db
+        .queue_get_item(work_id)?
+        .ok_or_else(|| anyhow::anyhow!("queue item not found: {work_id}"))?;
+
+    if item.phase != QueuePhase::Completed {
+        anyhow::bail!(
+            "cannot mark as done: item is in '{}' phase (expected 'completed')",
+            item.phase
+        );
+    }
+
+    let transitioned = db.queue_transit(work_id, QueuePhase::Completed, QueuePhase::Done)?;
+    if !transitioned {
+        anyhow::bail!("failed to transition {work_id}: concurrent modification");
+    }
+
+    // Record decision
+    record_decision(db, &item.repo_id, DecisionType::Advance, work_id, reason);
+
+    Ok(format!("done: {work_id} (completed → done)"))
+}
+
+/// queue_hitl의 결과: 출력 메시지와 생성된 HITL 이벤트.
+#[derive(Debug)]
+pub struct QueueHitlResult {
+    pub output: String,
+    pub hitl_event: Option<NewHitlEvent>,
+    pub hitl_id: Option<String>,
+}
+
+/// Completed → HITL 전환 (evaluate가 사람 판단 필요로 분류)
+pub fn queue_hitl(db: &Database, work_id: &str, reason: Option<&str>) -> Result<QueueHitlResult> {
+    let item = db
+        .queue_get_item(work_id)?
+        .ok_or_else(|| anyhow::anyhow!("queue item not found: {work_id}"))?;
+
+    if item.phase != QueuePhase::Completed {
+        anyhow::bail!(
+            "cannot move to hitl: item is in '{}' phase (expected 'completed')",
+            item.phase
+        );
+    }
+
+    let transitioned = db.queue_transit(work_id, QueuePhase::Completed, QueuePhase::Hitl)?;
+    if !transitioned {
+        anyhow::bail!("failed to transition {work_id}: concurrent modification");
+    }
+
+    // Record decision
+    record_decision(db, &item.repo_id, DecisionType::Hitl, work_id, reason);
+
+    // Create HITL event
+    let default_reason = reason.unwrap_or("evaluate determined human judgment needed");
+    let event = NewHitlEvent {
+        repo_id: item.repo_id.clone(),
+        spec_id: None,
+        work_id: Some(work_id.to_string()),
+        severity: HitlSeverity::Medium,
+        situation: format!("Queue item requires human review: {default_reason}"),
+        context: format!("work_id: {work_id}"),
+        options: vec![
+            "Mark as done".to_string(),
+            "Retry".to_string(),
+            "Skip".to_string(),
+        ],
+    };
+    let hitl_id = db.hitl_create(&event).ok();
+
+    Ok(QueueHitlResult {
+        output: format!("hitl: {work_id} (completed → hitl)"),
+        hitl_event: Some(event),
+        hitl_id,
+    })
+}
+
+/// Failed 아이템을 Completed로 되돌려 on_done 재실행 기회를 제공
+pub fn queue_retry_script(db: &Database, work_id: &str) -> Result<String> {
+    let item = db
+        .queue_get_item(work_id)?
+        .ok_or_else(|| anyhow::anyhow!("queue item not found: {work_id}"))?;
+
+    if item.phase != QueuePhase::Failed {
+        anyhow::bail!(
+            "cannot retry script: item is in '{}' phase (expected 'failed')",
+            item.phase
+        );
+    }
+
+    let transitioned = db.queue_transit(work_id, QueuePhase::Failed, QueuePhase::Completed)?;
+    if !transitioned {
+        anyhow::bail!("failed to transition {work_id}: concurrent modification");
+    }
+
+    Ok(format!(
+        "retry-script: {work_id} (failed → completed, will be re-evaluated)"
+    ))
+}

--- a/plugins/autodev/cli/src/core/models.rs
+++ b/plugins/autodev/cli/src/core/models.rs
@@ -712,6 +712,7 @@ pub struct HitlResponse {
     pub created_at: String,
 }
 
+#[derive(Debug)]
 pub struct NewHitlEvent {
     pub repo_id: String,
     pub spec_id: Option<String>,

--- a/plugins/autodev/cli/src/infra/db/repository.rs
+++ b/plugins/autodev/cli/src/infra/db/repository.rs
@@ -827,7 +827,6 @@ impl QueueRepository for Database {
             (QueuePhase::Pending, QueuePhase::Ready),
             (QueuePhase::Ready, QueuePhase::Running),
             (QueuePhase::Running, QueuePhase::Completed),
-            (QueuePhase::Completed, QueuePhase::Done),
         ];
 
         let conn = self.conn();
@@ -846,7 +845,12 @@ impl QueueRepository for Database {
         match current {
             None => anyhow::bail!("queue item not found: {work_id}"),
             Some(QueuePhase::Hitl) => {
-                anyhow::bail!("cannot advance hitl state: use queue done/hitl commands")
+                anyhow::bail!("cannot advance hitl item: respond via 'hitl respond' first")
+            }
+            Some(QueuePhase::Completed) => {
+                anyhow::bail!(
+                    "cannot advance completed item: use 'queue done' or 'queue hitl' instead"
+                )
             }
             Some(phase) => {
                 if phase.is_terminal() {

--- a/plugins/autodev/cli/src/main.rs
+++ b/plugins/autodev/cli/src/main.rs
@@ -89,6 +89,7 @@ enum Commands {
         #[command(subcommand)]
         action: SpecAction,
     },
+
     /// HITL (Human-in-the-Loop) 이벤트 관리
     Hitl {
         #[command(subcommand)]
@@ -283,20 +284,23 @@ enum QueueAction {
         #[arg(long)]
         json: bool,
     },
-    /// v5: Completed → on_done script → Done 전이
+    /// Completed → Done 전환 (evaluate가 완료 판정 후 호출)
     Done {
         /// 작업 ID
         work_id: String,
+        /// 판단 사유
+        #[arg(long)]
+        reason: Option<String>,
     },
-    /// v5: Completed → HITL 전이
+    /// Completed → HITL 전환 (evaluate가 사람 판단 필요로 분류)
     Hitl {
         /// 작업 ID
         work_id: String,
         /// HITL 사유
         #[arg(long)]
-        reason: String,
+        reason: Option<String>,
     },
-    /// v5: Failed 아이템의 on_done script 재실행
+    /// Failed 아이템의 on_done 스크립트 재실행 (Failed → Completed 전환)
     RetryScript {
         /// 작업 ID
         work_id: String,
@@ -877,19 +881,31 @@ async fn main() -> Result<()> {
                 let output = client::queue::queue_show(&db, &work_id, json)?;
                 println!("{output}");
             }
-            QueueAction::Done { work_id } => {
-                println!("v5: queue done {work_id} — evaluate에서 호출되는 명령입니다.");
-                println!("Completed → on_done script → Done 전이를 수행합니다.");
+            QueueAction::Done { work_id, reason } => {
+                let output = client::queue::queue_done(&db, &work_id, reason.as_deref())?;
+                println!("{output}");
             }
             QueueAction::Hitl { work_id, reason } => {
-                println!("v5: queue hitl {work_id} --reason \"{reason}\"");
-                println!("Completed → HITL 전이를 수행합니다.");
+                let result = client::queue::queue_hitl(&db, &work_id, reason.as_deref())?;
+                println!("{}", result.output);
+
+                // Dispatch HITL notification if created
+                if let Some(ref hitl_event) = result.hitl_event {
+                    if let Some(ref dispatcher) = build_cli_dispatcher(&cfg) {
+                        let notif = autodev::core::notifier::NotificationEvent::from_hitl_created(
+                            hitl_event,
+                            result.hitl_id.clone(),
+                        );
+                        dispatch_notification(dispatcher, &notif).await;
+                    }
+                }
             }
             QueueAction::RetryScript { work_id } => {
-                println!("v5: queue retry-script {work_id}");
-                println!("Failed 아이템의 on_done script를 재실행합니다.");
+                let output = client::queue::queue_retry_script(&db, &work_id)?;
+                println!("{output}");
             }
         },
+
         Commands::Config { action } => match action {
             ConfigAction::Show => {
                 client::config_show(&env)?;
@@ -1202,35 +1218,35 @@ async fn main() -> Result<()> {
         },
         Commands::Context {
             work_id,
-            json: _,
+            json,
             field,
         } => {
-            // v5 context 조회: MockDataSource로 기본 컨텍스트 반환
-            // 실제 구현에서는 DataSource를 workspace config에서 resolve
-            use autodev::v5::core::datasource::DataSource;
-            use autodev::v5::core::queue_item::V5QueueItem;
-            use autodev::v5::infra::sources::mock::MockDataSource;
-
-            let parts: Vec<&str> = work_id.rsplitn(2, ':').collect();
-            let (state, source_id) = if parts.len() == 2 {
-                (parts[0], parts[1])
-            } else {
-                ("unknown", work_id.as_str())
-            };
-            let item = V5QueueItem::new(
-                work_id.clone(),
-                source_id.to_string(),
-                "default".to_string(),
-                state.to_string(),
-            );
-            let source = MockDataSource::new("github");
-            let ctx = source.get_context(&item).await?;
-
             if let Some(ref f) = field {
+                // --field: use v5 DataSource for structured field extraction
+                use autodev::v5::core::datasource::DataSource;
+                use autodev::v5::core::queue_item::V5QueueItem;
+                use autodev::v5::infra::sources::mock::MockDataSource;
+
+                let parts: Vec<&str> = work_id.rsplitn(2, ':').collect();
+                let (state, source_id) = if parts.len() == 2 {
+                    (parts[0], parts[1])
+                } else {
+                    ("unknown", work_id.as_str())
+                };
+                let item = V5QueueItem::new(
+                    work_id.clone(),
+                    source_id.to_string(),
+                    "default".to_string(),
+                    state.to_string(),
+                );
+                let source = MockDataSource::new("github");
+                let ctx = source.get_context(&item).await?;
                 let value = client::context::extract_field(&ctx, f)?;
                 println!("{value}");
             } else {
-                println!("{}", serde_json::to_string_pretty(&ctx)?);
+                // Default: use DB-backed context for compatibility
+                let output = client::queue::queue_context(&db, &work_id, json)?;
+                println!("{output}");
             }
         }
         Commands::Board { repo, json } => {

--- a/plugins/autodev/cli/tests/e2e_queue_workflow.rs
+++ b/plugins/autodev/cli/tests/e2e_queue_workflow.rs
@@ -212,27 +212,6 @@ fn e2e_queue_advance_running_to_completed() {
 }
 
 #[test]
-fn e2e_queue_advance_completed_to_done() {
-    let home = TempDir::new().unwrap();
-    let repo_id = setup_repo(&home, REPO_URL);
-    seed_queue_item(
-        &home,
-        &repo_id,
-        "issue:org/queue-repo:43",
-        "issue",
-        "completed",
-        None,
-        43,
-    );
-
-    autodev(&home)
-        .args(["queue", "advance", "issue:org/queue-repo:43"])
-        .assert()
-        .success()
-        .stdout(predicate::str::contains("completed").and(predicate::str::contains("done")));
-}
-
-#[test]
 fn e2e_queue_advance_full_lifecycle() {
     let home = TempDir::new().unwrap();
     let repo_id = setup_repo(&home, REPO_URL);
@@ -261,18 +240,18 @@ fn e2e_queue_advance_full_lifecycle() {
         .args(["queue", "advance", "issue:org/queue-repo:50"])
         .assert()
         .success();
-    // completed → done
+    // v5: advance stops at completed — queue done moves to done
     autodev(&home)
         .args(["queue", "advance", "issue:org/queue-repo:50"])
         .assert()
-        .success();
+        .failure();
 
-    // Verify final state
+    // Verify final state is completed
     autodev(&home)
         .args(["queue", "show", "issue:org/queue-repo:50"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("done"));
+        .stdout(predicate::str::contains("completed"));
 }
 
 #[test]
@@ -458,6 +437,173 @@ fn e2e_queue_list_unextracted() {
 
 // ═══════════════════════════════════════════════
 // 6. PR advance with review overflow → HITL
+// ═══════════════════════════════════════════════
+
+#[test]
+// ═══════════════════════════════════════════════
+// 7. queue done (Completed → Done)
+// ═══════════════════════════════════════════════
+
+fn e2e_queue_done_completed_to_done() {
+    let home = TempDir::new().unwrap();
+    let repo_id = setup_repo(&home, REPO_URL);
+    seed_queue_item(
+        &home,
+        &repo_id,
+        "issue:org/queue-repo:100",
+        "issue",
+        "completed",
+        None,
+        100,
+    );
+
+    autodev(&home)
+        .args(["queue", "done", "issue:org/queue-repo:100"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("done"));
+
+    // Verify final state
+    autodev(&home)
+        .args(["queue", "show", "issue:org/queue-repo:100"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("done"));
+}
+
+#[test]
+fn e2e_queue_done_wrong_phase_fails() {
+    let home = TempDir::new().unwrap();
+    let repo_id = setup_repo(&home, REPO_URL);
+    seed_queue_item(
+        &home,
+        &repo_id,
+        "issue:org/queue-repo:101",
+        "issue",
+        "running",
+        None,
+        101,
+    );
+
+    autodev(&home)
+        .args(["queue", "done", "issue:org/queue-repo:101"])
+        .assert()
+        .failure();
+}
+
+// ═══════════════════════════════════════════════
+// 8. queue hitl (Completed → HITL)
+// ═══════════════════════════════════════════════
+
+#[test]
+fn e2e_queue_hitl_completed_to_hitl() {
+    let home = TempDir::new().unwrap();
+    let repo_id = setup_repo(&home, REPO_URL);
+    seed_queue_item(
+        &home,
+        &repo_id,
+        "issue:org/queue-repo:110",
+        "issue",
+        "completed",
+        None,
+        110,
+    );
+
+    autodev(&home)
+        .args([
+            "queue",
+            "hitl",
+            "issue:org/queue-repo:110",
+            "--reason",
+            "needs human review",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("hitl"));
+
+    // HITL event should be created
+    autodev(&home)
+        .args(["hitl", "list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("human review"));
+}
+
+// ═══════════════════════════════════════════════
+// 9. queue retry-script (Failed → Completed)
+// ═══════════════════════════════════════════════
+
+#[test]
+fn e2e_queue_retry_script() {
+    let home = TempDir::new().unwrap();
+    let repo_id = setup_repo(&home, REPO_URL);
+    seed_queue_item(
+        &home,
+        &repo_id,
+        "issue:org/queue-repo:120",
+        "issue",
+        "failed",
+        None,
+        120,
+    );
+
+    autodev(&home)
+        .args(["queue", "retry-script", "issue:org/queue-repo:120"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("retry-script"));
+
+    // Verify state is now completed
+    autodev(&home)
+        .args(["queue", "show", "issue:org/queue-repo:120"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("completed"));
+}
+
+// ═══════════════════════════════════════════════
+// 10. context
+// ═══════════════════════════════════════════════
+
+#[test]
+fn e2e_context_json() {
+    let home = TempDir::new().unwrap();
+    let repo_id = setup_repo(&home, REPO_URL);
+    seed_queue_item(
+        &home,
+        &repo_id,
+        "issue:org/queue-repo:130",
+        "issue",
+        "running",
+        Some("Test context"),
+        130,
+    );
+
+    autodev(&home)
+        .args(["context", "issue:org/queue-repo:130", "--json"])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("issue:org/queue-repo:130")
+                .and(predicate::str::contains("running"))
+                .and(predicate::str::contains("130")),
+        );
+}
+
+#[test]
+fn e2e_context_not_found() {
+    let home = TempDir::new().unwrap();
+    setup_repo(&home, REPO_URL);
+
+    autodev(&home)
+        .args(["context", "issue:org/queue-repo:999"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("not found"));
+}
+
+// ═══════════════════════════════════════════════
+// 11. PR advance with review overflow → HITL
 // ═══════════════════════════════════════════════
 
 #[test]

--- a/plugins/autodev/cli/tests/queue_advance_tests.rs
+++ b/plugins/autodev/cli/tests/queue_advance_tests.rs
@@ -91,18 +91,6 @@ fn advance_running_to_completed() {
 }
 
 #[test]
-fn advance_completed_to_done() {
-    let db = open_memory_db();
-    let repo_id = add_test_repo(&db);
-    insert_queue_item(&db, &repo_id, "work-1", "completed");
-
-    db.queue_advance("work-1").unwrap();
-
-    let phase = db.queue_get_phase("work-1").unwrap();
-    assert_eq!(phase, Some(QueuePhase::Done));
-}
-
-#[test]
 fn advance_nonexistent_returns_error() {
     let db = open_memory_db();
 
@@ -564,6 +552,177 @@ fn advance_creates_hitl_on_review_overflow() {
     let event = &hitl_events[0];
     assert!(event.situation.contains("review iteration"));
     assert_eq!(event.work_id.as_deref(), Some("pr:org/test-repo:50"));
+}
+
+// ═══════════════════════════════════════════════
+// 12. queue_done (Completed → Done)
+// ═══════════════════════════════════════════════
+
+#[test]
+fn queue_done_completed_to_done() {
+    let db = open_memory_db();
+    let repo_id = add_test_repo(&db);
+    insert_queue_item(&db, &repo_id, "work-done-1", "completed");
+
+    let output = autodev::cli::queue::queue_done(&db, "work-done-1", None).unwrap();
+    assert!(output.contains("done"));
+    assert!(output.contains("completed"));
+
+    let phase = db.queue_get_phase("work-done-1").unwrap();
+    assert_eq!(phase, Some(QueuePhase::Done));
+}
+
+#[test]
+fn queue_done_with_reason_records_decision() {
+    let db = open_memory_db();
+    let repo_id = add_test_repo(&db);
+    insert_queue_item(&db, &repo_id, "work-done-2", "completed");
+
+    autodev::cli::queue::queue_done(&db, "work-done-2", Some("all checks passed")).unwrap();
+
+    let decisions = db.decision_list(None, 10).unwrap();
+    assert!(!decisions.is_empty());
+    assert_eq!(decisions[0].reasoning, "all checks passed");
+}
+
+#[test]
+fn queue_done_wrong_phase_fails() {
+    let db = open_memory_db();
+    let repo_id = add_test_repo(&db);
+    insert_queue_item(&db, &repo_id, "work-done-3", "running");
+
+    let result = autodev::cli::queue::queue_done(&db, "work-done-3", None);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("running"));
+}
+
+#[test]
+fn queue_done_not_found_fails() {
+    let db = open_memory_db();
+
+    let result = autodev::cli::queue::queue_done(&db, "nonexistent", None);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("not found"));
+}
+
+// ═══════════════════════════════════════════════
+// 13. queue_hitl (Completed → HITL)
+// ═══════════════════════════════════════════════
+
+#[test]
+fn queue_hitl_completed_to_hitl() {
+    let db = open_memory_db();
+    let repo_id = add_test_repo(&db);
+    insert_queue_item(&db, &repo_id, "work-hitl-1", "completed");
+
+    let result = autodev::cli::queue::queue_hitl(&db, "work-hitl-1", None).unwrap();
+    assert!(result.output.contains("hitl"));
+    assert!(result.hitl_event.is_some());
+    assert!(result.hitl_id.is_some());
+
+    let phase = db.queue_get_phase("work-hitl-1").unwrap();
+    assert_eq!(phase, Some(QueuePhase::Hitl));
+}
+
+#[test]
+fn queue_hitl_with_reason() {
+    let db = open_memory_db();
+    let repo_id = add_test_repo(&db);
+    insert_queue_item(&db, &repo_id, "work-hitl-2", "completed");
+
+    let result = autodev::cli::queue::queue_hitl(&db, "work-hitl-2", Some("needs review")).unwrap();
+    assert!(result.output.contains("hitl"));
+
+    // Check HITL event was created with reason
+    let hitl_events = db.hitl_list(None).unwrap();
+    assert!(!hitl_events.is_empty());
+    assert!(hitl_events[0].situation.contains("needs review"));
+}
+
+#[test]
+fn queue_hitl_wrong_phase_fails() {
+    let db = open_memory_db();
+    let repo_id = add_test_repo(&db);
+    insert_queue_item(&db, &repo_id, "work-hitl-3", "pending");
+
+    let result = autodev::cli::queue::queue_hitl(&db, "work-hitl-3", None);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("pending"));
+}
+
+// ═══════════════════════════════════════════════
+// 14. queue_retry_script (Failed → Completed)
+// ═══════════════════════════════════════════════
+
+#[test]
+fn queue_retry_script_failed_to_completed() {
+    let db = open_memory_db();
+    let repo_id = add_test_repo(&db);
+    insert_queue_item(&db, &repo_id, "work-retry-1", "failed");
+
+    let output = autodev::cli::queue::queue_retry_script(&db, "work-retry-1").unwrap();
+    assert!(output.contains("retry-script"));
+    assert!(output.contains("failed"));
+    assert!(output.contains("completed"));
+
+    let phase = db.queue_get_phase("work-retry-1").unwrap();
+    assert_eq!(phase, Some(QueuePhase::Completed));
+}
+
+#[test]
+fn queue_retry_script_wrong_phase_fails() {
+    let db = open_memory_db();
+    let repo_id = add_test_repo(&db);
+    insert_queue_item(&db, &repo_id, "work-retry-2", "running");
+
+    let result = autodev::cli::queue::queue_retry_script(&db, "work-retry-2");
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("running"));
+}
+
+#[test]
+fn queue_retry_script_not_found_fails() {
+    let db = open_memory_db();
+
+    let result = autodev::cli::queue::queue_retry_script(&db, "nonexistent");
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("not found"));
+}
+
+// ═══════════════════════════════════════════════
+// 15. queue_context
+// ═══════════════════════════════════════════════
+
+#[test]
+fn queue_context_returns_item_info() {
+    let db = open_memory_db();
+    let repo_id = add_test_repo(&db);
+    insert_queue_item(&db, &repo_id, "work-ctx-1", "running");
+
+    let output = autodev::cli::queue::queue_context(&db, "work-ctx-1", false).unwrap();
+    assert!(output.contains("work-ctx-1"));
+    assert!(output.contains("running"));
+}
+
+#[test]
+fn queue_context_json_output() {
+    let db = open_memory_db();
+    let repo_id = add_test_repo(&db);
+    insert_queue_item(&db, &repo_id, "work-ctx-2", "pending");
+
+    let output = autodev::cli::queue::queue_context(&db, "work-ctx-2", true).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&output).expect("valid JSON");
+    assert_eq!(parsed["work_id"], "work-ctx-2");
+    assert_eq!(parsed["queue"]["phase"], "pending");
+}
+
+#[test]
+fn queue_context_not_found_fails() {
+    let db = open_memory_db();
+
+    let result = autodev::cli::queue::queue_context(&db, "nonexistent", false);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("not found"));
 }
 
 #[test]

--- a/plugins/autodev/cli/tests/v5_e2e_workflow.rs
+++ b/plugins/autodev/cli/tests/v5_e2e_workflow.rs
@@ -12,21 +12,30 @@ use tempfile::TempDir;
 const REPO_URL: &str = "https://github.com/org/v5-repo";
 
 // ═══════════════════════════════════════════════
-// 1. autodev context
+// 1. autodev context (--field uses v5 MockDataSource)
 // ═══════════════════════════════════════════════
 
 #[test]
 fn v5_context_outputs_json() {
     let home = TempDir::new().unwrap();
-    setup_repo(&home, REPO_URL);
+    let repo_id = setup_repo(&home, REPO_URL);
+    seed_queue_item(
+        &home,
+        &repo_id,
+        "issue:org/v5-repo:42",
+        "issue",
+        "running",
+        Some("Implement feature"),
+        42,
+    );
 
     autodev(&home)
-        .args(["context", "github:org/v5-repo#42:implement", "--json"])
+        .args(["context", "issue:org/v5-repo:42", "--json"])
         .assert()
         .success()
         .stdout(
             predicate::str::contains("work_id")
-                .and(predicate::str::contains("github:org/v5-repo#42:implement")),
+                .and(predicate::str::contains("issue:org/v5-repo:42")),
         );
 }
 
@@ -86,18 +95,26 @@ fn v5_context_nonexistent_field_fails() {
 #[test]
 fn v5_context_contains_source_type() {
     let home = TempDir::new().unwrap();
-    setup_repo(&home, REPO_URL);
+    let repo_id = setup_repo(&home, REPO_URL);
+    seed_queue_item(
+        &home,
+        &repo_id,
+        "issue:org/v5-repo:1",
+        "issue",
+        "running",
+        Some("Review task"),
+        1,
+    );
 
     let output = autodev(&home)
-        .args(["context", "github:org/v5-repo#1:review", "--json"])
+        .args(["context", "issue:org/v5-repo:1", "--json"])
         .output()
         .unwrap();
     assert!(output.status.success());
 
     let stdout = String::from_utf8(output.stdout).unwrap();
     let ctx: serde_json::Value = serde_json::from_str(&stdout).unwrap();
-    assert_eq!(ctx["source"]["type"], "mock");
-    assert_eq!(ctx["queue"]["state"], "review");
+    assert_eq!(ctx["queue"]["phase"], "running");
 }
 
 // ═══════════════════════════════════════════════
@@ -105,18 +122,24 @@ fn v5_context_contains_source_type() {
 // ═══════════════════════════════════════════════
 
 #[test]
-fn v5_queue_done_prints_message() {
+fn v5_queue_done_transitions_completed_to_done() {
     let home = TempDir::new().unwrap();
-    setup_repo(&home, REPO_URL);
+    let repo_id = setup_repo(&home, REPO_URL);
+    seed_queue_item(
+        &home,
+        &repo_id,
+        "issue:org/v5-repo:42",
+        "issue",
+        "completed",
+        Some("Implement feature"),
+        42,
+    );
 
     autodev(&home)
-        .args(["queue", "done", "github:org/v5-repo#42:implement"])
+        .args(["queue", "done", "issue:org/v5-repo:42"])
         .assert()
         .success()
-        .stdout(
-            predicate::str::contains("queue done")
-                .and(predicate::str::contains("github:org/v5-repo#42:implement")),
-        );
+        .stdout(predicate::str::contains("done"));
 }
 
 // ═══════════════════════════════════════════════
@@ -124,24 +147,30 @@ fn v5_queue_done_prints_message() {
 // ═══════════════════════════════════════════════
 
 #[test]
-fn v5_queue_hitl_prints_reason() {
+fn v5_queue_hitl_transitions_completed_to_hitl() {
     let home = TempDir::new().unwrap();
-    setup_repo(&home, REPO_URL);
+    let repo_id = setup_repo(&home, REPO_URL);
+    seed_queue_item(
+        &home,
+        &repo_id,
+        "issue:org/v5-repo:43",
+        "issue",
+        "completed",
+        Some("Needs review"),
+        43,
+    );
 
     autodev(&home)
         .args([
             "queue",
             "hitl",
-            "github:org/v5-repo#42:implement",
+            "issue:org/v5-repo:43",
             "--reason",
             "needs human review",
         ])
         .assert()
         .success()
-        .stdout(
-            predicate::str::contains("queue hitl")
-                .and(predicate::str::contains("needs human review")),
-        );
+        .stdout(predicate::str::contains("hitl"));
 }
 
 // ═══════════════════════════════════════════════
@@ -149,16 +178,22 @@ fn v5_queue_hitl_prints_reason() {
 // ═══════════════════════════════════════════════
 
 #[test]
-fn v5_queue_retry_script_prints_message() {
+fn v5_queue_retry_script_transitions_failed_to_completed() {
     let home = TempDir::new().unwrap();
-    setup_repo(&home, REPO_URL);
+    let repo_id = setup_repo(&home, REPO_URL);
+    seed_queue_item(
+        &home,
+        &repo_id,
+        "issue:org/v5-repo:44",
+        "issue",
+        "failed",
+        Some("Script failed"),
+        44,
+    );
 
     autodev(&home)
-        .args(["queue", "retry-script", "github:org/v5-repo#42:implement"])
+        .args(["queue", "retry-script", "issue:org/v5-repo:44"])
         .assert()
         .success()
-        .stdout(
-            predicate::str::contains("retry-script")
-                .and(predicate::str::contains("github:org/v5-repo#42:implement")),
-        );
+        .stdout(predicate::str::contains("retry"));
 }


### PR DESCRIPTION
## Summary
- Add `queue done`, `queue hitl`, `queue retry-script` CLI commands
- Completed→Done/Hitl phase transitions with decision recording
- Failed item on_done re-execution via retry-script
- Updated phase model and DB repository

## Test plan
- [x] `cargo check` passes
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] Updated e2e and unit tests

Closes #449

🤖 Generated with [Claude Code](https://claude.com/claude-code)