### PR TITLE
feat(autodev): abstract done handling with data-source-specific completers

### DIFF
--- a/plugins/autodev/cli/Cargo.lock
+++ b/plugins/autodev/cli/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autodev"
-version = "0.44.0"
+version = "0.47.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/plugins/autodev/cli/src/core/completer.rs
+++ b/plugins/autodev/cli/src/core/completer.rs
@@ -1,0 +1,77 @@
+//! Completer trait — 데이터 소스별 완료 처리 추상화.
+//!
+//! Claw가 `done`을 판단하면 아이템의 `queue_type`에 따라
+//! 다른 완료 처리를 수행한다.
+//!
+//! - IssueCompleter: 이슈 close + autodev:done 라벨 + 완료 코멘트
+//! - PrCompleter: 검증 게이트 + merge + 소스 이슈 close + autodev:done 라벨
+//! - SpecCompleter: 스펙 상태 업데이트 + 관련 이슈/PR 정리
+
+use std::fmt;
+
+use async_trait::async_trait;
+
+use super::queue_item::QueueItem;
+
+/// 완료 처리 결과.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CompleteResult {
+    /// 완료 처리 성공
+    Completed,
+    /// 검증 게이트 미충족 — review로 되돌림
+    ReviewRequired { reason: String },
+    /// 완료 처리 실패 — HITL 에스컬레이션 필요
+    EscalationNeeded { reason: String },
+}
+
+impl fmt::Display for CompleteResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CompleteResult::Completed => write!(f, "completed"),
+            CompleteResult::ReviewRequired { reason } => {
+                write!(f, "review required: {reason}")
+            }
+            CompleteResult::EscalationNeeded { reason } => {
+                write!(f, "escalation needed: {reason}")
+            }
+        }
+    }
+}
+
+/// 데이터 소스별 완료 처리 인터페이스.
+///
+/// `queue_type`에 따라 적절한 구현체가 선택되며,
+/// 각 구현체는 해당 데이터 소스에 맞는 완료 처리를 수행한다.
+#[async_trait]
+pub trait Completer: Send + Sync {
+    /// 큐 아이템의 완료 처리를 수행한다.
+    ///
+    /// - `Completed`: 성공적으로 완료됨
+    /// - `ReviewRequired`: 검증 미충족 — review 단계로 되돌려야 함
+    /// - `EscalationNeeded`: 완료 실패 — HITL 에스컬레이션 필요
+    async fn complete(&self, item: &QueueItem) -> CompleteResult;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn complete_result_display() {
+        assert_eq!(CompleteResult::Completed.to_string(), "completed");
+        assert_eq!(
+            CompleteResult::ReviewRequired {
+                reason: "no review".into()
+            }
+            .to_string(),
+            "review required: no review"
+        );
+        assert_eq!(
+            CompleteResult::EscalationNeeded {
+                reason: "merge failed".into()
+            }
+            .to_string(),
+            "escalation needed: merge failed"
+        );
+    }
+}

--- a/plugins/autodev/cli/src/core/mod.rs
+++ b/plugins/autodev/cli/src/core/mod.rs
@@ -1,5 +1,6 @@
 pub mod board;
 pub mod collector;
+pub mod completer;
 pub mod config;
 pub mod datasource;
 pub mod handler;

--- a/plugins/autodev/cli/src/infra/gh/mock.rs
+++ b/plugins/autodev/cli/src/infra/gh/mock.rs
@@ -25,6 +25,10 @@ pub struct MockGh {
     pub label_ops: Mutex<Vec<(String, String, i64, String)>>,
     /// 생성된 이슈 기록: (repo_name, title, body)
     pub created_issues: Mutex<Vec<(String, String, String)>>,
+    /// 닫힌 이슈 기록: (repo_name, number)
+    pub closed_issues: Mutex<Vec<(String, i64)>>,
+    /// 머지된 PR 기록: (repo_name, number)
+    pub merged_prs: Mutex<Vec<(String, i64)>>,
     /// 생성된 PR 기록: (repo_name, head, base, title, body)
     #[allow(clippy::type_complexity)]
     pub created_prs: Mutex<Vec<(String, String, String, String, String)>>,
@@ -45,6 +49,8 @@ impl Default for MockGh {
             added_labels: Mutex::new(Vec::new()),
             label_ops: Mutex::new(Vec::new()),
             created_issues: Mutex::new(Vec::new()),
+            closed_issues: Mutex::new(Vec::new()),
+            merged_prs: Mutex::new(Vec::new()),
             created_prs: Mutex::new(Vec::new()),
             reviewed_prs: Mutex::new(Vec::new()),
             paginate_calls: Mutex::new(Vec::new()),
@@ -214,6 +220,22 @@ impl Gh for MockGh {
             title.to_string(),
             body.to_string(),
         ));
+        true
+    }
+
+    async fn issue_close(&self, repo_name: &str, number: i64, _host: Option<&str>) -> bool {
+        self.closed_issues
+            .lock()
+            .unwrap()
+            .push((repo_name.to_string(), number));
+        true
+    }
+
+    async fn pr_merge(&self, repo_name: &str, number: i64, _host: Option<&str>) -> bool {
+        self.merged_prs
+            .lock()
+            .unwrap()
+            .push((repo_name.to_string(), number));
         true
     }
 

--- a/plugins/autodev/cli/src/infra/gh/mod.rs
+++ b/plugins/autodev/cli/src/infra/gh/mod.rs
@@ -91,6 +91,14 @@ pub trait Gh: Send + Sync {
         host: Option<&str>,
     ) -> Vec<String>;
 
+    /// `gh api repos/{repo}/issues/{number} --method PATCH -f state=closed`
+    /// 이슈를 닫는다 (best effort)
+    async fn issue_close(&self, repo_name: &str, number: i64, host: Option<&str>) -> bool;
+
+    /// `gh api repos/{repo}/pulls/{number}/merge --method PUT`
+    /// PR을 머지한다. 성공 시 true.
+    async fn pr_merge(&self, repo_name: &str, number: i64, host: Option<&str>) -> bool;
+
     /// `gh api repos/{repo}/pulls/{number}/reviews --method POST -f event={event}`
     /// event: `"APPROVE"` | `"REQUEST_CHANGES"` | `"COMMENT"`
     /// GitHub PR UI에서 Approved / Changes Requested 상태를 설정한다.

--- a/plugins/autodev/cli/src/infra/gh/real.rs
+++ b/plugins/autodev/cli/src/infra/gh/real.rs
@@ -410,6 +410,98 @@ impl Gh for RealGh {
         }
     }
 
+    async fn issue_close(&self, repo_name: &str, number: i64, host: Option<&str>) -> bool {
+        let mut args = vec![
+            "api".to_string(),
+            format!("repos/{repo_name}/issues/{number}"),
+            "--method".to_string(),
+            "PATCH".to_string(),
+            "--silent".to_string(),
+            "-f".to_string(),
+            "state=closed".to_string(),
+        ];
+
+        if let Some(h) = host {
+            args.push("--hostname".to_string());
+            args.push(h.to_string());
+        }
+
+        tracing::debug!("[gh:issue_close] >>> {repo_name}#{number}");
+        let start = Instant::now();
+
+        match tokio::process::Command::new("gh")
+            .args(&args)
+            .output()
+            .await
+        {
+            Ok(output) => {
+                let elapsed = start.elapsed();
+                if !output.status.success() {
+                    let stderr = String::from_utf8_lossy(&output.stderr);
+                    tracing::warn!(
+                        "[gh:issue_close] <<< FAILED (exit={}, {}ms): {}",
+                        output.status.code().unwrap_or(-1),
+                        elapsed.as_millis(),
+                        stderr.trim()
+                    );
+                }
+                output.status.success()
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "[gh:issue_close] <<< ERROR ({}ms): {e}",
+                    start.elapsed().as_millis()
+                );
+                false
+            }
+        }
+    }
+
+    async fn pr_merge(&self, repo_name: &str, number: i64, host: Option<&str>) -> bool {
+        let mut args = vec![
+            "api".to_string(),
+            format!("repos/{repo_name}/pulls/{number}/merge"),
+            "--method".to_string(),
+            "PUT".to_string(),
+            "--silent".to_string(),
+        ];
+
+        if let Some(h) = host {
+            args.push("--hostname".to_string());
+            args.push(h.to_string());
+        }
+
+        tracing::debug!("[gh:pr_merge] >>> {repo_name}#{number}");
+        let start = Instant::now();
+
+        match tokio::process::Command::new("gh")
+            .args(&args)
+            .output()
+            .await
+        {
+            Ok(output) => {
+                let elapsed = start.elapsed();
+                if !output.status.success() {
+                    let stderr = String::from_utf8_lossy(&output.stderr);
+                    tracing::warn!(
+                        "[gh:pr_merge] <<< FAILED (exit={}, {}ms): {}",
+                        output.status.code().unwrap_or(-1),
+                        elapsed.as_millis(),
+                        stderr.trim()
+                    );
+                }
+                output.status.success()
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "[gh:pr_merge] <<< ERROR ({}ms): {e}",
+                    start.elapsed().as_millis()
+                );
+                false
+            }
+        }
+    }
+
     async fn pr_review(
         &self,
         repo_name: &str,

--- a/plugins/autodev/cli/src/service/completers/issue.rs
+++ b/plugins/autodev/cli/src/service/completers/issue.rs
@@ -1,0 +1,105 @@
+//! IssueCompleter — Issue 큐 아이템의 완료 처리.
+//!
+//! 완료 동작:
+//! 1. GitHub 이슈 close
+//! 2. `autodev:done` 라벨 추가
+//! 3. `autodev:wip` 라벨 제거
+//! 4. 완료 코멘트 게시
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::core::completer::{CompleteResult, Completer};
+use crate::core::labels;
+use crate::core::queue_item::QueueItem;
+use crate::infra::gh::Gh;
+
+/// Issue 완료 처리 구현체.
+pub struct IssueCompleter {
+    gh: Arc<dyn Gh>,
+}
+
+impl IssueCompleter {
+    pub fn new(gh: Arc<dyn Gh>) -> Self {
+        Self { gh }
+    }
+}
+
+#[async_trait]
+impl Completer for IssueCompleter {
+    async fn complete(&self, item: &QueueItem) -> CompleteResult {
+        let gh_host = item.gh_host.as_deref();
+        let repo = &item.repo_name;
+        let number = item.github_number;
+
+        // 1. add-first: autodev:done 라벨 추가
+        self.gh.label_add(repo, number, labels::DONE, gh_host).await;
+
+        // 2. autodev:wip 라벨 제거
+        self.gh
+            .label_remove(repo, number, labels::WIP, gh_host)
+            .await;
+
+        // 3. 완료 코멘트 게시
+        let comment = format!(
+            "<!-- autodev:done -->\n\
+             ## Autodev: Issue #{number} completed\n\n\
+             This issue has been processed and marked as done by autodev."
+        );
+        self.gh.issue_comment(repo, number, &comment, gh_host).await;
+
+        // 4. 이슈 close
+        self.gh.issue_close(repo, number, gh_host).await;
+
+        CompleteResult::Completed
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::phase::TaskKind;
+    use crate::core::queue_item::testing::*;
+    use crate::infra::gh::mock::MockGh;
+
+    #[tokio::test]
+    async fn complete_adds_done_label_and_closes_issue() {
+        let gh = Arc::new(MockGh::new());
+        let item = test_issue(42, TaskKind::Analyze);
+
+        let completer = IssueCompleter::new(gh.clone());
+        let result = completer.complete(&item).await;
+
+        assert_eq!(result, CompleteResult::Completed);
+
+        // done 라벨 추가 확인
+        let added = gh.added_labels.lock().unwrap();
+        assert!(added.iter().any(|(_, n, l)| *n == 42 && l == labels::DONE));
+
+        // wip 라벨 제거 확인
+        let removed = gh.removed_labels.lock().unwrap();
+        assert!(removed.iter().any(|(_, n, l)| *n == 42 && l == labels::WIP));
+
+        // 이슈 close 확인
+        let closed = gh.closed_issues.lock().unwrap();
+        assert!(closed.iter().any(|(_, n)| *n == 42));
+
+        // 완료 코멘트 확인
+        let comments = gh.posted_comments.lock().unwrap();
+        assert!(comments
+            .iter()
+            .any(|(_, n, body)| *n == 42 && body.contains("<!-- autodev:done -->")));
+    }
+
+    #[tokio::test]
+    async fn complete_uses_add_first_ordering() {
+        let gh = Arc::new(MockGh::new());
+        let item = test_issue(42, TaskKind::Analyze);
+
+        let completer = IssueCompleter::new(gh.clone());
+        completer.complete(&item).await;
+
+        gh.assert_add_before_remove(42, labels::DONE, labels::WIP);
+    }
+}

--- a/plugins/autodev/cli/src/service/completers/mod.rs
+++ b/plugins/autodev/cli/src/service/completers/mod.rs
@@ -1,0 +1,106 @@
+//! Completers — 데이터 소스별 완료 처리 구현체.
+//!
+//! `queue_type`에 따라 적절한 `Completer`를 선택하는 팩토리를 제공한다.
+
+pub mod issue;
+pub mod pr;
+pub mod spec;
+
+use std::sync::Arc;
+
+use crate::core::completer::Completer;
+use crate::core::models::QueueType;
+use crate::core::repository::SpecRepository;
+use crate::infra::gh::Gh;
+
+use self::issue::IssueCompleter;
+use self::pr::PrCompleter;
+use self::spec::SpecCompleter;
+
+/// `queue_type`에 따라 적절한 `Completer`를 선택한다.
+///
+/// - `Issue` → `IssueCompleter`
+/// - `Pr` → `PrCompleter`
+/// - `Knowledge` / `Agent` → `spec_repo` 제공 시 `SpecCompleter`, 없으면 `IssueCompleter` 폴백
+pub fn select_completer(
+    queue_type: &QueueType,
+    gh: Arc<dyn Gh>,
+    spec_repo: Option<Arc<dyn SpecRepository + Send + Sync>>,
+) -> Box<dyn Completer> {
+    match queue_type {
+        QueueType::Issue => Box::new(IssueCompleter::new(gh)),
+        QueueType::Pr => Box::new(PrCompleter::new(gh)),
+        QueueType::Knowledge => Box::new(IssueCompleter::new(gh)),
+        QueueType::Agent => {
+            if let Some(sr) = spec_repo {
+                Box::new(SpecCompleter::new(gh, sr))
+            } else {
+                Box::new(IssueCompleter::new(gh))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::phase::TaskKind;
+    use crate::core::queue_item::testing::*;
+    use crate::infra::gh::mock::MockGh;
+
+    #[tokio::test]
+    async fn select_issue_completer() {
+        let gh = Arc::new(MockGh::new());
+        let completer = select_completer(&QueueType::Issue, gh.clone(), None);
+
+        let item = test_issue(42, TaskKind::Analyze);
+        let result = completer.complete(&item).await;
+
+        assert_eq!(result, crate::core::completer::CompleteResult::Completed);
+
+        // Verify it called issue_close (IssueCompleter behavior)
+        let closed = gh.closed_issues.lock().unwrap();
+        assert!(closed.iter().any(|(_, n)| *n == 42));
+    }
+
+    #[tokio::test]
+    async fn select_pr_completer_checks_review_gate() {
+        let gh = Arc::new(MockGh::new());
+        let completer = select_completer(&QueueType::Pr, gh.clone(), None);
+
+        // review_iteration = 0 → should require review
+        let item = test_pr_with_source(10, TaskKind::Review, Some(42), 0);
+        let result = completer.complete(&item).await;
+
+        assert!(matches!(
+            result,
+            crate::core::completer::CompleteResult::ReviewRequired { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn select_pr_completer_completes_reviewed_pr() {
+        let gh = Arc::new(MockGh::new());
+        let completer = select_completer(&QueueType::Pr, gh.clone(), None);
+
+        // review_iteration = 1 → should complete
+        let item = test_pr_with_source(10, TaskKind::Review, Some(42), 1);
+        let result = completer.complete(&item).await;
+
+        assert_eq!(result, crate::core::completer::CompleteResult::Completed);
+
+        let merged = gh.merged_prs.lock().unwrap();
+        assert!(merged.iter().any(|(_, n)| *n == 10));
+    }
+
+    #[tokio::test]
+    async fn select_knowledge_falls_back_to_issue() {
+        let gh = Arc::new(MockGh::new());
+        let completer = select_completer(&QueueType::Knowledge, gh.clone(), None);
+
+        let item = test_issue(5, TaskKind::Extract);
+        let result = completer.complete(&item).await;
+
+        assert_eq!(result, crate::core::completer::CompleteResult::Completed);
+    }
+}

--- a/plugins/autodev/cli/src/service/completers/pr.rs
+++ b/plugins/autodev/cli/src/service/completers/pr.rs
@@ -1,0 +1,186 @@
+//! PrCompleter — PR 큐 아이템의 완료 처리.
+//!
+//! 완료 동작:
+//! 1. 검증 게이트: review_iteration >= 1 확인
+//! 2. PR merge
+//! 3. 소스 이슈 close + autodev:done 라벨
+//! 4. PR에 autodev:done 라벨 추가
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::core::completer::{CompleteResult, Completer};
+use crate::core::labels;
+use crate::core::queue_item::QueueItem;
+use crate::infra::gh::Gh;
+
+/// PR 완료 처리 구현체.
+pub struct PrCompleter {
+    gh: Arc<dyn Gh>,
+}
+
+impl PrCompleter {
+    pub fn new(gh: Arc<dyn Gh>) -> Self {
+        Self { gh }
+    }
+}
+
+#[async_trait]
+impl Completer for PrCompleter {
+    async fn complete(&self, item: &QueueItem) -> CompleteResult {
+        let gh_host = item.gh_host.as_deref();
+        let repo = &item.repo_name;
+        let number = item.github_number;
+
+        // 1. 검증 게이트: review_iteration >= 1
+        let review_iteration = item.review_iteration_or_zero();
+        if review_iteration < 1 {
+            return CompleteResult::ReviewRequired {
+                reason: format!(
+                    "PR #{number} has review_iteration={review_iteration}, requires >= 1"
+                ),
+            };
+        }
+
+        // 2. PR merge
+        let merged = self.gh.pr_merge(repo, number, gh_host).await;
+        if !merged {
+            return CompleteResult::EscalationNeeded {
+                reason: format!("PR #{number} merge failed"),
+            };
+        }
+
+        // 3. PR에 autodev:done 라벨 추가 (add-first)
+        self.gh.label_add(repo, number, labels::DONE, gh_host).await;
+
+        // 4. autodev:wip 라벨 제거
+        self.gh
+            .label_remove(repo, number, labels::WIP, gh_host)
+            .await;
+
+        // 5. iteration 라벨 정리
+        if review_iteration > 0 {
+            self.gh
+                .label_remove(
+                    repo,
+                    number,
+                    &labels::iteration_label(review_iteration),
+                    gh_host,
+                )
+                .await;
+        }
+
+        // 6. 소스 이슈 완료 처리
+        if let Some(issue_num) = item.source_issue_number() {
+            self.gh
+                .label_add(repo, issue_num, labels::DONE, gh_host)
+                .await;
+            self.gh
+                .label_remove(repo, issue_num, labels::IMPLEMENTING, gh_host)
+                .await;
+            self.gh.issue_close(repo, issue_num, gh_host).await;
+        }
+
+        CompleteResult::Completed
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::phase::TaskKind;
+    use crate::core::queue_item::testing::*;
+    use crate::infra::gh::mock::MockGh;
+
+    #[tokio::test]
+    async fn complete_rejects_pr_without_review() {
+        let gh = Arc::new(MockGh::new());
+        // review_iteration = 0
+        let item = test_pr_with_source(10, TaskKind::Review, Some(42), 0);
+
+        let completer = PrCompleter::new(gh.clone());
+        let result = completer.complete(&item).await;
+
+        assert!(matches!(result, CompleteResult::ReviewRequired { .. }));
+
+        // merge 호출되지 않아야 함
+        let merged = gh.merged_prs.lock().unwrap();
+        assert!(merged.is_empty());
+    }
+
+    #[tokio::test]
+    async fn complete_merges_pr_with_review() {
+        let gh = Arc::new(MockGh::new());
+        // review_iteration = 1
+        let item = test_pr_with_source(10, TaskKind::Review, Some(42), 1);
+
+        let completer = PrCompleter::new(gh.clone());
+        let result = completer.complete(&item).await;
+
+        assert_eq!(result, CompleteResult::Completed);
+
+        // merge 호출 확인
+        let merged = gh.merged_prs.lock().unwrap();
+        assert!(merged.iter().any(|(_, n)| *n == 10));
+
+        // PR done 라벨 확인
+        let added = gh.added_labels.lock().unwrap();
+        assert!(added.iter().any(|(_, n, l)| *n == 10 && l == labels::DONE));
+
+        // 소스 이슈 done 라벨 확인
+        assert!(added.iter().any(|(_, n, l)| *n == 42 && l == labels::DONE));
+
+        // 소스 이슈 close 확인
+        let closed = gh.closed_issues.lock().unwrap();
+        assert!(closed.iter().any(|(_, n)| *n == 42));
+    }
+
+    #[tokio::test]
+    async fn complete_handles_pr_without_source_issue() {
+        let gh = Arc::new(MockGh::new());
+        // review_iteration = 2, no source issue
+        let item = test_pr_with_source(10, TaskKind::Review, None, 2);
+
+        let completer = PrCompleter::new(gh.clone());
+        let result = completer.complete(&item).await;
+
+        assert_eq!(result, CompleteResult::Completed);
+
+        // merge 호출 확인
+        let merged = gh.merged_prs.lock().unwrap();
+        assert!(merged.iter().any(|(_, n)| *n == 10));
+
+        // 소스 이슈 close 호출되지 않아야 함
+        let closed = gh.closed_issues.lock().unwrap();
+        assert!(closed.is_empty());
+    }
+
+    #[tokio::test]
+    async fn complete_uses_add_first_ordering() {
+        let gh = Arc::new(MockGh::new());
+        let item = test_pr_with_source(10, TaskKind::Review, Some(42), 1);
+
+        let completer = PrCompleter::new(gh.clone());
+        completer.complete(&item).await;
+
+        // PR: done before wip removal
+        gh.assert_add_before_remove(10, labels::DONE, labels::WIP);
+        // Source issue: done before implementing removal
+        gh.assert_add_before_remove(42, labels::DONE, labels::IMPLEMENTING);
+    }
+
+    #[tokio::test]
+    async fn complete_cleans_up_iteration_label() {
+        let gh = Arc::new(MockGh::new());
+        let item = test_pr_with_source(10, TaskKind::Review, None, 3);
+
+        let completer = PrCompleter::new(gh.clone());
+        completer.complete(&item).await;
+
+        let removed = gh.removed_labels.lock().unwrap();
+        assert!(removed
+            .iter()
+            .any(|(_, n, l)| *n == 10 && l == &labels::iteration_label(3)));
+    }
+}

--- a/plugins/autodev/cli/src/service/completers/spec.rs
+++ b/plugins/autodev/cli/src/service/completers/spec.rs
@@ -1,0 +1,234 @@
+//! SpecCompleter — Spec 큐 아이템의 완료 처리.
+//!
+//! 완료 동작:
+//! 1. 스펙 상태를 Completed로 업데이트
+//! 2. 관련 이슈/PR에 autodev:done 라벨 추가
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::core::completer::{CompleteResult, Completer};
+use crate::core::labels;
+use crate::core::models::SpecStatus;
+use crate::core::queue_item::QueueItem;
+use crate::core::repository::SpecRepository;
+use crate::infra::gh::Gh;
+
+/// Spec 완료 처리 구현체.
+pub struct SpecCompleter {
+    gh: Arc<dyn Gh>,
+    spec_repo: Arc<dyn SpecRepository + Send + Sync>,
+}
+
+impl SpecCompleter {
+    pub fn new(gh: Arc<dyn Gh>, spec_repo: Arc<dyn SpecRepository + Send + Sync>) -> Self {
+        Self { gh, spec_repo }
+    }
+}
+
+#[async_trait]
+impl Completer for SpecCompleter {
+    async fn complete(&self, item: &QueueItem) -> CompleteResult {
+        let gh_host = item.gh_host.as_deref();
+        let repo = &item.repo_name;
+
+        // 1. 스펙 상태를 Completed로 전이
+        // work_id에서 spec_id를 추출하지 못하면 에스컬레이션
+        let spec_id = item.work_id.strip_prefix("spec:").and_then(|rest| {
+            // work_id format: "spec:{repo_name}:{number}" — use repo_id for spec lookup
+            rest.rsplit(':').next()
+        });
+
+        let spec_id = match spec_id {
+            Some(id) => id.to_string(),
+            None => {
+                return CompleteResult::EscalationNeeded {
+                    reason: format!("cannot extract spec_id from work_id: {}", item.work_id),
+                };
+            }
+        };
+
+        // 스펙 상태 업데이트
+        if let Err(e) = self
+            .spec_repo
+            .spec_set_status(&spec_id, SpecStatus::Completed)
+        {
+            return CompleteResult::EscalationNeeded {
+                reason: format!("failed to update spec status: {e}"),
+            };
+        }
+
+        // 2. 관련 이슈 정리 — spec에 연결된 이슈들에 done 라벨 추가
+        if let Ok(issues) = self.spec_repo.spec_issues(&spec_id) {
+            for si in &issues {
+                self.gh
+                    .label_add(repo, si.issue_number, labels::DONE, gh_host)
+                    .await;
+                self.gh
+                    .label_remove(repo, si.issue_number, labels::WIP, gh_host)
+                    .await;
+                self.gh.issue_close(repo, si.issue_number, gh_host).await;
+            }
+        }
+
+        CompleteResult::Completed
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::models::*;
+    use crate::core::phase::TaskKind;
+    use crate::core::queue_item::{QueueItem, RepoRef};
+    use crate::infra::gh::mock::MockGh;
+    use anyhow::Result;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    // ─── Mock SpecRepository ───
+
+    struct MockSpecRepo {
+        status_updates: Mutex<Vec<(String, SpecStatus)>>,
+        issues: Mutex<Vec<SpecIssue>>,
+    }
+
+    impl MockSpecRepo {
+        fn new(issues: Vec<SpecIssue>) -> Self {
+            Self {
+                status_updates: Mutex::new(Vec::new()),
+                issues: Mutex::new(issues),
+            }
+        }
+    }
+
+    impl SpecRepository for MockSpecRepo {
+        fn spec_add(&self, _: &NewSpec) -> Result<String> {
+            Ok("s1".into())
+        }
+        fn spec_list(&self, _: Option<&str>) -> Result<Vec<Spec>> {
+            Ok(vec![])
+        }
+        fn spec_show(&self, _: &str) -> Result<Option<Spec>> {
+            Ok(None)
+        }
+        fn spec_update(&self, _: &str, _: &str, _: Option<&str>, _: Option<&str>) -> Result<()> {
+            Ok(())
+        }
+        fn spec_set_status(&self, id: &str, status: SpecStatus) -> Result<()> {
+            self.status_updates
+                .lock()
+                .unwrap()
+                .push((id.to_string(), status));
+            Ok(())
+        }
+        fn spec_issues(&self, _: &str) -> Result<Vec<SpecIssue>> {
+            Ok(self.issues.lock().unwrap().clone())
+        }
+        fn spec_issues_all(&self) -> Result<HashMap<String, Vec<SpecIssue>>> {
+            Ok(HashMap::new())
+        }
+        fn spec_issue_counts(&self) -> Result<HashMap<String, usize>> {
+            Ok(HashMap::new())
+        }
+        fn spec_link_issue(&self, _: &str, _: i64) -> Result<()> {
+            Ok(())
+        }
+        fn spec_unlink_issue(&self, _: &str, _: i64) -> Result<()> {
+            Ok(())
+        }
+        fn spec_list_by_status(&self, _: SpecStatus) -> Result<Vec<Spec>> {
+            Ok(vec![])
+        }
+        fn spec_set_priority(&self, _: &str, _: i32) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    fn make_spec_item(spec_number: i64) -> QueueItem {
+        let repo = RepoRef {
+            id: "r1".into(),
+            name: "org/repo".into(),
+            url: "https://github.com/org/repo".into(),
+            gh_host: None,
+        };
+        // Spec items use issue type internally but with spec work_id
+        QueueItem::new_issue(
+            &repo,
+            spec_number,
+            TaskKind::Analyze,
+            "Spec task".into(),
+            None,
+            vec![],
+            "autodev".into(),
+        )
+    }
+
+    #[tokio::test]
+    async fn complete_updates_spec_status_and_closes_issues() {
+        let gh = Arc::new(MockGh::new());
+        let spec_issues = vec![
+            SpecIssue {
+                spec_id: "s1".into(),
+                issue_number: 10,
+                created_at: "2024-01-01".into(),
+            },
+            SpecIssue {
+                spec_id: "s1".into(),
+                issue_number: 20,
+                created_at: "2024-01-02".into(),
+            },
+        ];
+        let spec_repo = Arc::new(MockSpecRepo::new(spec_issues));
+
+        let completer = SpecCompleter::new(gh.clone(), spec_repo.clone());
+
+        // Create item with spec-like work_id
+        let mut item = make_spec_item(1);
+        item.work_id = "spec:org/repo:s1".to_string();
+
+        let result = completer.complete(&item).await;
+
+        assert_eq!(result, CompleteResult::Completed);
+
+        // 스펙 상태 업데이트 확인
+        let updates = spec_repo.status_updates.lock().unwrap();
+        assert!(updates
+            .iter()
+            .any(|(id, status)| id == "s1" && *status == SpecStatus::Completed));
+
+        // 관련 이슈들에 done 라벨 추가 확인
+        let added = gh.added_labels.lock().unwrap();
+        assert!(added.iter().any(|(_, n, l)| *n == 10 && l == labels::DONE));
+        assert!(added.iter().any(|(_, n, l)| *n == 20 && l == labels::DONE));
+
+        // 관련 이슈들 close 확인
+        let closed = gh.closed_issues.lock().unwrap();
+        assert!(closed.iter().any(|(_, n)| *n == 10));
+        assert!(closed.iter().any(|(_, n)| *n == 20));
+    }
+
+    #[tokio::test]
+    async fn complete_with_no_linked_issues() {
+        let gh = Arc::new(MockGh::new());
+        let spec_repo = Arc::new(MockSpecRepo::new(vec![]));
+
+        let completer = SpecCompleter::new(gh.clone(), spec_repo.clone());
+
+        let mut item = make_spec_item(1);
+        item.work_id = "spec:org/repo:s1".to_string();
+
+        let result = completer.complete(&item).await;
+
+        assert_eq!(result, CompleteResult::Completed);
+
+        // 스펙 상태 업데이트는 수행됨
+        let updates = spec_repo.status_updates.lock().unwrap();
+        assert!(!updates.is_empty());
+
+        // 이슈 close 없음
+        let closed = gh.closed_issues.lock().unwrap();
+        assert!(closed.is_empty());
+    }
+}

--- a/plugins/autodev/cli/src/service/mod.rs
+++ b/plugins/autodev/cli/src/service/mod.rs
@@ -1,2 +1,3 @@
+pub mod completers;
 pub mod daemon;
 pub mod tasks;


### PR DESCRIPTION
## Summary
- Add `Completer` trait with `complete()` method
- `IssueCompleter`: GitHub issue close + `autodev:done` label + comment
- `PrCompleter`: verification gate (review_iteration >= 1) + merge + source issue close
- `SpecCompleter`: spec status update + related cleanup
- `select_completer()` routes by `queue_type`

## Test plan
- [x] `cargo check` passes
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes

Closes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)