### PR TITLE
feat(autodev): add issue convention templates and title-based auto-classification

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,43 @@
+---
+name: Bug Report
+about: Report a bug in autodev
+title: "bug: "
+labels: autodev:analyze
+assignees: ""
+---
+
+## 증상 (Symptom)
+
+<!-- 발생한 문제를 간결하게 설명해주세요. -->
+
+## 재현 방법 (Steps to Reproduce)
+
+1.
+2.
+3.
+
+## 기대 동작 (Expected Behavior)
+
+<!-- 정상적으로 동작했을 때 어떤 결과를 기대하는지 설명해주세요. -->
+
+## 실제 동작 (Actual Behavior)
+
+<!-- 실제로 발생한 결과를 설명해주세요. -->
+
+## 영향 범위 (Impact)
+
+- [ ] 데몬 전체 중단
+- [ ] 특정 레포 처리 불가
+- [ ] 특정 기능 오동작
+- [ ] UI/UX 문제
+- [ ] 기타
+
+## 환경 (Environment)
+
+- OS:
+- autodev version:
+- Rust version (if applicable):
+
+## 추가 정보 (Additional Context)
+
+<!-- 로그, 스크린샷, 관련 이슈 등을 첨부해주세요. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,35 @@
+---
+name: Feature Request
+about: Suggest a new feature for autodev
+title: "feat: "
+labels: autodev:analyze
+assignees: ""
+---
+
+## 배경 (Background)
+
+<!-- 이 기능이 필요한 배경을 설명해주세요. 어떤 문제를 해결하려는 건가요? -->
+
+## 요구사항 (Requirements)
+
+<!-- 구현해야 할 핵심 요구사항을 나열해주세요. -->
+
+1.
+2.
+3.
+
+## 기대 동작 (Expected Behavior)
+
+<!-- 이 기능이 구현되면 어떤 결과를 기대하는지 설명해주세요. -->
+
+## 수정 대상 (Affected Components)
+
+- [ ] CLI (`plugins/autodev/cli/`)
+- [ ] Daemon
+- [ ] GitHub Collector
+- [ ] Claw
+- [ ] 기타: <!-- 설명 -->
+
+## 추가 정보 (Additional Context)
+
+<!-- 관련 이슈, 참고 자료 등을 첨부해주세요. -->

--- a/plugins/autodev/cli/Cargo.lock
+++ b/plugins/autodev/cli/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autodev"
-version = "0.50.1"
+version = "0.52.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/plugins/autodev/cli/src/core/config/models.rs
+++ b/plugins/autodev/cli/src/core/config/models.rs
@@ -908,7 +908,7 @@ sources:
         trigger:
           label: "custom:implement"
 "#;
-        let cfg: WorkflowConfig = serde_yaml::from_str(yaml).unwrap();
+        let cfg: WorkflowConfig = serde_yml::from_str(yaml).unwrap();
         assert_eq!(
             cfg.sources.github.trigger_label("analyze"),
             Some("custom:analyze")
@@ -937,7 +937,7 @@ sources:
       analyze:
         trigger: {}
 "#;
-        let cfg: WorkflowConfig = serde_yaml::from_str(yaml).unwrap();
+        let cfg: WorkflowConfig = serde_yml::from_str(yaml).unwrap();
         // trigger exists but label is None
         assert_eq!(cfg.sources.github.trigger_label("analyze"), None);
     }

--- a/plugins/autodev/cli/src/core/issue_title.rs
+++ b/plugins/autodev/cli/src/core/issue_title.rs
@@ -1,0 +1,263 @@
+//! Issue 타이틀 기반 자동 분류 모듈.
+//!
+//! `<type>: <설명>` 형식의 이슈 타이틀에서 type을 파싱하여
+//! autodev의 `TaskKind`로 매핑한다.
+//!
+//! ## 매핑 규칙
+//! - `bug:` → TaskKind::Analyze (fix 목적의 분석)
+//! - `fix:` → TaskKind::Analyze (fix 목적의 분석)
+//! - `feat:` → TaskKind::Implement (구현)
+//! - `docs:` → TaskKind::Analyze (문서 분석)
+//! - `refactor:` → TaskKind::Analyze (리팩토링 분석)
+//! - `chore:` → TaskKind::Analyze (기본 분석)
+//! - 파싱 실패 → TaskKind::Analyze (기본값)
+
+use std::fmt;
+
+use super::phase::TaskKind;
+
+/// 이슈 타이틀에서 파싱된 type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IssueType {
+    Bug,
+    Feat,
+    Fix,
+    Refactor,
+    Docs,
+    Chore,
+}
+
+impl IssueType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            IssueType::Bug => "bug",
+            IssueType::Feat => "feat",
+            IssueType::Fix => "fix",
+            IssueType::Refactor => "refactor",
+            IssueType::Docs => "docs",
+            IssueType::Chore => "chore",
+        }
+    }
+
+    /// IssueType을 autodev TaskKind로 변환한다.
+    ///
+    /// - `bug`, `fix` → Analyze (수정 방안 분석 후 구현으로 이어짐)
+    /// - `feat` → Implement (바로 구현 단계로 진입)
+    /// - `docs`, `refactor`, `chore` → Analyze (분석 먼저)
+    pub fn to_task_kind(self) -> TaskKind {
+        match self {
+            IssueType::Bug => TaskKind::Analyze,
+            IssueType::Fix => TaskKind::Analyze,
+            IssueType::Feat => TaskKind::Implement,
+            IssueType::Docs => TaskKind::Analyze,
+            IssueType::Refactor => TaskKind::Analyze,
+            IssueType::Chore => TaskKind::Analyze,
+        }
+    }
+}
+
+impl fmt::Display for IssueType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// 이슈 타이틀에서 `<type>: <설명>` 패턴을 파싱한다.
+///
+/// 콜론 뒤 공백은 선택적이다. type은 대소문자 무시.
+/// 파싱 실패 시 `None`을 반환한다.
+pub fn parse_issue_type(title: &str) -> Option<IssueType> {
+    let colon_pos = title.find(':')?;
+    let type_str = title[..colon_pos].trim().to_lowercase();
+
+    match type_str.as_str() {
+        "bug" => Some(IssueType::Bug),
+        "feat" => Some(IssueType::Feat),
+        "fix" => Some(IssueType::Fix),
+        "refactor" => Some(IssueType::Refactor),
+        "docs" => Some(IssueType::Docs),
+        "chore" => Some(IssueType::Chore),
+        _ => None,
+    }
+}
+
+/// 이슈 타이틀에서 TaskKind를 결정한다.
+///
+/// 타이틀이 `<type>: <설명>` 형식이면 type에 따라 TaskKind를 결정하고,
+/// 파싱 실패 시 기본값 `TaskKind::Analyze`를 반환한다.
+pub fn task_kind_from_title(title: &str) -> TaskKind {
+    parse_issue_type(title)
+        .map(|t| t.to_task_kind())
+        .unwrap_or(TaskKind::Analyze)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ─── parse_issue_type tests ───
+
+    #[test]
+    fn parse_bug_type() {
+        assert_eq!(
+            parse_issue_type("bug: something broken"),
+            Some(IssueType::Bug)
+        );
+    }
+
+    #[test]
+    fn parse_feat_type() {
+        assert_eq!(
+            parse_issue_type("feat: add new feature"),
+            Some(IssueType::Feat)
+        );
+    }
+
+    #[test]
+    fn parse_fix_type() {
+        assert_eq!(parse_issue_type("fix: resolve crash"), Some(IssueType::Fix));
+    }
+
+    #[test]
+    fn parse_refactor_type() {
+        assert_eq!(
+            parse_issue_type("refactor: simplify logic"),
+            Some(IssueType::Refactor)
+        );
+    }
+
+    #[test]
+    fn parse_docs_type() {
+        assert_eq!(
+            parse_issue_type("docs: update readme"),
+            Some(IssueType::Docs)
+        );
+    }
+
+    #[test]
+    fn parse_chore_type() {
+        assert_eq!(
+            parse_issue_type("chore: update deps"),
+            Some(IssueType::Chore)
+        );
+    }
+
+    #[test]
+    fn parse_case_insensitive() {
+        assert_eq!(parse_issue_type("BUG: uppercase"), Some(IssueType::Bug));
+        assert_eq!(parse_issue_type("Feat: mixed case"), Some(IssueType::Feat));
+    }
+
+    #[test]
+    fn parse_no_space_after_colon() {
+        assert_eq!(parse_issue_type("bug:no space"), Some(IssueType::Bug));
+    }
+
+    #[test]
+    fn parse_extra_spaces() {
+        assert_eq!(parse_issue_type("  bug  : spaced"), Some(IssueType::Bug));
+    }
+
+    #[test]
+    fn parse_unknown_type_returns_none() {
+        assert_eq!(parse_issue_type("unknown: something"), None);
+    }
+
+    #[test]
+    fn parse_no_colon_returns_none() {
+        assert_eq!(parse_issue_type("just a title"), None);
+    }
+
+    #[test]
+    fn parse_empty_returns_none() {
+        assert_eq!(parse_issue_type(""), None);
+    }
+
+    // ─── task_kind_from_title tests ───
+
+    #[test]
+    fn bug_maps_to_analyze() {
+        assert_eq!(
+            task_kind_from_title("bug: crash on startup"),
+            TaskKind::Analyze
+        );
+    }
+
+    #[test]
+    fn fix_maps_to_analyze() {
+        assert_eq!(
+            task_kind_from_title("fix: resolve path issue"),
+            TaskKind::Analyze
+        );
+    }
+
+    #[test]
+    fn feat_maps_to_implement() {
+        assert_eq!(
+            task_kind_from_title("feat: add multi-LLM support"),
+            TaskKind::Implement
+        );
+    }
+
+    #[test]
+    fn docs_maps_to_analyze() {
+        assert_eq!(
+            task_kind_from_title("docs: update architecture"),
+            TaskKind::Analyze
+        );
+    }
+
+    #[test]
+    fn refactor_maps_to_analyze() {
+        assert_eq!(
+            task_kind_from_title("refactor: simplify config"),
+            TaskKind::Analyze
+        );
+    }
+
+    #[test]
+    fn chore_maps_to_analyze() {
+        assert_eq!(
+            task_kind_from_title("chore: update deps"),
+            TaskKind::Analyze
+        );
+    }
+
+    #[test]
+    fn unparseable_defaults_to_analyze() {
+        assert_eq!(
+            task_kind_from_title("just a regular title"),
+            TaskKind::Analyze
+        );
+    }
+
+    // ─── IssueType display ───
+
+    #[test]
+    fn issue_type_display() {
+        assert_eq!(IssueType::Bug.to_string(), "bug");
+        assert_eq!(IssueType::Feat.to_string(), "feat");
+        assert_eq!(IssueType::Fix.to_string(), "fix");
+        assert_eq!(IssueType::Refactor.to_string(), "refactor");
+        assert_eq!(IssueType::Docs.to_string(), "docs");
+        assert_eq!(IssueType::Chore.to_string(), "chore");
+    }
+
+    // ─── IssueType::to_task_kind exhaustive ───
+
+    #[test]
+    fn all_issue_types_have_task_kind_mapping() {
+        // Ensure every variant maps to a valid TaskKind
+        let types = [
+            IssueType::Bug,
+            IssueType::Feat,
+            IssueType::Fix,
+            IssueType::Refactor,
+            IssueType::Docs,
+            IssueType::Chore,
+        ];
+        for t in types {
+            let _ = t.to_task_kind(); // should not panic
+        }
+    }
+}

--- a/plugins/autodev/cli/src/core/mod.rs
+++ b/plugins/autodev/cli/src/core/mod.rs
@@ -6,6 +6,7 @@ pub mod config;
 pub mod datasource;
 pub mod dependency;
 pub mod handler;
+pub mod issue_title;
 pub mod labels;
 pub mod lifecycle;
 pub mod models;

--- a/plugins/autodev/cli/src/service/tasks/helpers/git_ops.rs
+++ b/plugins/autodev/cli/src/service/tasks/helpers/git_ops.rs
@@ -259,16 +259,20 @@ impl GitRepository {
                 self.gh_host.as_deref(),
             )
             .await;
+            let task_kind = crate::core::issue_title::task_kind_from_title(&issue.title);
             self.enqueue_issue(
                 db,
                 issue.number,
-                TaskKind::Analyze,
+                task_kind,
                 issue.title.clone(),
                 issue.body.clone(),
                 label_names,
                 issue.user.login.clone(),
             );
-            tracing::info!("issue #{}: {effective_label} → wip (Pending)", issue.number);
+            tracing::info!(
+                "issue #{}: {effective_label} → wip (Pending, task_kind={task_kind})",
+                issue.number
+            );
         }
 
         let now = chrono::Utc::now().to_rfc3339();


### PR DESCRIPTION
## Summary
- Add `.github/ISSUE_TEMPLATE/` with `bug_report.md` and `feature_request.md` templates enforcing `<type>: <description>` title convention
- Add `core::issue_title` module with `IssueType` enum, `parse_issue_type()`, and `task_kind_from_title()` for automatic classification
- Integrate title-based `TaskKind` routing into `scan_issues`: `bug:/fix:` -> Analyze, `feat:` -> Implement, `docs:/refactor:/chore:` -> Analyze

## Test plan
- [x] 21 unit tests for `parse_issue_type` and `task_kind_from_title` (case-insensitive, edge cases, all type mappings)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] Full test suite passes with no regressions

Closes #395

🤖 Generated with [Claude Code](https://claude.com/claude-code)