### PR TITLE
fix(autodev): connect spec decompose to issue auto-creation e2e path

### DIFF
--- a/plugins/autodev/cli/src/cli/spec.rs
+++ b/plugins/autodev/cli/src/cli/spec.rs
@@ -117,6 +117,52 @@ pub fn spec_list(db: &Database, repo: Option<&str>, json: bool) -> Result<String
     Ok(output)
 }
 
+/// List active specs that have no linked issues (need decomposition).
+///
+/// A spec is "undecomposed" when:
+/// - status == Active
+/// - no entries in spec_issues table for that spec_id
+///
+/// Optionally filtered by repo name.
+pub fn spec_list_undecomposed(db: &Database, repo: Option<&str>, json: bool) -> Result<String> {
+    let active_specs = db.spec_list_by_status(SpecStatus::Active)?;
+    let issue_counts = db.spec_issue_counts()?;
+
+    let undecomposed: Vec<&Spec> = active_specs
+        .iter()
+        .filter(|s| {
+            let has_issues = issue_counts.get(&s.id).copied().unwrap_or(0) > 0;
+            if has_issues {
+                return false;
+            }
+            if let Some(repo_name) = repo {
+                // Filter by repo: resolve repo_id from name
+                match crate::cli::resolve_repo_id(db, repo_name) {
+                    Ok(rid) => s.repo_id == rid,
+                    Err(_) => false,
+                }
+            } else {
+                true
+            }
+        })
+        .collect();
+
+    if json {
+        let owned: Vec<_> = undecomposed.into_iter().cloned().collect();
+        return Ok(serde_json::to_string_pretty(&owned)?);
+    }
+
+    let mut output = String::new();
+    if undecomposed.is_empty() {
+        output.push_str("No undecomposed specs found.\n");
+    } else {
+        for s in &undecomposed {
+            output.push_str(&format!("  [{}] {} — {}\n", s.status, s.id, s.title));
+        }
+    }
+    Ok(output)
+}
+
 /// Show a single spec
 pub fn spec_show(db: &Database, id: &str, json: bool) -> Result<String> {
     let spec = db

--- a/plugins/autodev/cli/src/main.rs
+++ b/plugins/autodev/cli/src/main.rs
@@ -613,6 +613,15 @@ enum SpecAction {
         #[arg(long)]
         create_issues: bool,
     },
+    /// 분해 대기 스펙 조회 (이슈 미생성 Active 스펙)
+    ListUndecomposed {
+        /// 레포 이름 필터 (org/repo)
+        #[arg(long)]
+        repo: Option<String>,
+        /// JSON 출력
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -973,6 +982,10 @@ async fn main() -> Result<()> {
                 let gh_host = cfg.sources.github.gh_host.as_deref();
                 let output =
                     client::spec::spec_verify(&db, &gh_arc, &id, create_issues, gh_host).await?;
+                println!("{output}");
+            }
+            SpecAction::ListUndecomposed { repo, json } => {
+                let output = client::spec::spec_list_undecomposed(&db, repo.as_deref(), json)?;
                 println!("{output}");
             }
         },

--- a/plugins/autodev/templates/crons/claw-evaluate.sh
+++ b/plugins/autodev/templates/crons/claw-evaluate.sh
@@ -1,21 +1,39 @@
 #!/bin/bash
 # Built-in cron: claw-evaluate (per-repo)
-# 주기: 60초 | Guard: 큐에 pending 아이템이 있거나 HITL이 존재할 때
+# 주기: 60초 | Guard: 큐에 pending 아이템이 있거나 HITL이 존재하거나 분해 대기 스펙이 있을 때
 #
 # Claw headless 큐 평가 — 큐 상태를 분석하고 다음 작업을 결정합니다.
+# 새로 등록된 스펙이 있으면 decompose skill로 이슈를 분해합니다.
 # 중복 실행 방지는 daemon cron engine이 내부 상태로 보장합니다.
 
 set -euo pipefail
 
-# Guard: 큐에 pending 아이템이 있거나 HITL이 존재할 때만 실행
+# Guard: 큐에 pending 아이템이 있거나 HITL이 존재하거나 분해 대기 스펙이 있을 때만 실행
 PENDING=$(autodev queue list --repo "$AUTODEV_REPO_NAME" --json | jq 'length')
 HITL=$(autodev hitl list --repo "$AUTODEV_REPO_NAME" --json | jq 'length')
+UNDECOMPOSED=$(autodev spec list-undecomposed --repo "$AUTODEV_REPO_NAME" --json | jq 'length')
 
-if [ "$PENDING" = "0" ] && [ "$HITL" = "0" ]; then
-  echo "skip: $AUTODEV_REPO_NAME 큐 비어있고 HITL 없음"
+if [ "$PENDING" = "0" ] && [ "$HITL" = "0" ] && [ "$UNDECOMPOSED" = "0" ]; then
+  echo "skip: $AUTODEV_REPO_NAME 큐 비어있고 HITL 없고 분해 대기 스펙 없음"
   exit 0
 fi
 
-echo "evaluate: $AUTODEV_REPO_NAME (pending=$PENDING, hitl=$HITL)"
+echo "evaluate: $AUTODEV_REPO_NAME (pending=$PENDING, hitl=$HITL, undecomposed=$UNDECOMPOSED)"
 
-autodev agent --repo "$AUTODEV_REPO_NAME" -p "큐를 평가하고 다음 작업을 결정해줘"
+# Build prompt based on what needs attention
+PROMPT=""
+
+if [ "$UNDECOMPOSED" -gt "0" ]; then
+  SPEC_IDS=$(autodev spec list-undecomposed --repo "$AUTODEV_REPO_NAME" --json | jq -r '.[].id')
+  PROMPT="새로 등록된 스펙이 ${UNDECOMPOSED}개 있습니다. decompose skill을 사용하여 각 스펙을 구현 가능한 단위의 GitHub 이슈로 분해해주세요. 각 이슈에는 autodev:analyze 라벨을 부여해야 합니다. 분해 대상 스펙 ID: ${SPEC_IDS}."
+fi
+
+if [ "$PENDING" -gt "0" ] || [ "$HITL" -gt "0" ]; then
+  if [ -n "$PROMPT" ]; then
+    PROMPT="${PROMPT} 그리고 큐를 평가하고 다음 작업을 결정해주세요."
+  else
+    PROMPT="큐를 평가하고 다음 작업을 결정해줘"
+  fi
+fi
+
+autodev agent --repo "$AUTODEV_REPO_NAME" -p "$PROMPT"


### PR DESCRIPTION
## Summary

- Add `autodev spec list-undecomposed` CLI subcommand that finds active specs with no linked issues (needing decomposition)
- Update `claw-evaluate.sh` cron script to detect undecomposed specs as an additional guard condition, preventing premature skip when only new specs exist
- Build targeted Claw agent prompt that instructs decompose skill execution with `autodev:analyze` label assignment

Closes #414

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (722 tests, 0 failures)
- [ ] Manual: register a spec with `autodev spec add`, verify `autodev spec list-undecomposed --repo <name> --json` returns it
- [ ] Manual: verify claw-evaluate cron triggers decompose when undecomposed specs exist
- [ ] Manual: verify created issues have `autodev:analyze` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)