### PR TITLE
fix(autodev): implement Claw issue dependency analysis and spec_issues auto-link

### DIFF
--- a/plugins/autodev/cli/src/core/dependency.rs
+++ b/plugins/autodev/cli/src/core/dependency.rs
@@ -1,0 +1,624 @@
+//! Issue dependency analysis and spec auto-linking.
+//!
+//! Provides pure functions for:
+//! 1. Extracting target file/module paths from issue body text
+//! 2. Detecting conflicts between issues based on overlapping paths
+//! 3. Matching issues to specs by keyword and path overlap
+//!
+//! These are consumed by the collector to automate spec_issues linking
+//! and sequential/parallel processing decisions.
+
+use std::collections::{HashMap, HashSet};
+
+use super::models::{QueuePhase, QueueType, Spec, SpecStatus};
+use super::queue_item::QueueItem;
+use super::state_queue::StateQueue;
+
+/// Result of dependency analysis for a newly enqueued issue.
+#[derive(Debug, Clone)]
+pub struct DependencyAnalysis {
+    /// Issue number being analyzed.
+    pub issue_number: i64,
+    /// File/module paths inferred from the issue body.
+    pub inferred_paths: Vec<String>,
+    /// work_ids of existing queue items that conflict (share paths).
+    pub conflicting_work_ids: Vec<String>,
+    /// spec_ids that match this issue (for auto-linking).
+    pub matching_spec_ids: Vec<String>,
+    /// Whether this issue should be processed sequentially (has conflicts).
+    pub requires_sequential: bool,
+}
+
+/// Extract file/module paths from issue body text.
+///
+/// Heuristic-based extraction that looks for:
+/// - Backtick-quoted paths (e.g., `src/foo/bar.rs`)
+/// - Paths with file extensions mentioned in prose
+/// - Module references like `mod::submod`
+///
+/// Returns deduplicated, sorted list of paths.
+pub fn extract_paths_from_body(body: &str) -> Vec<String> {
+    let mut paths = HashSet::new();
+
+    // Extract backtick-quoted content that looks like file paths
+    for segment in body.split('`') {
+        // Every other segment (odd indices) is inside backticks in a simple split.
+        // But since we can't track index cleanly, just check each segment.
+        let trimmed = segment.trim();
+        if looks_like_path(trimmed) {
+            paths.insert(normalize_path(trimmed));
+        }
+    }
+
+    // Extract paths from prose lines (lines containing path-like tokens)
+    for line in body.lines() {
+        for word in line.split_whitespace() {
+            let cleaned = word.trim_matches(|c: char| c == ',' || c == '.' || c == ')' || c == '(');
+            if looks_like_path(cleaned) && !is_url(cleaned) {
+                paths.insert(normalize_path(cleaned));
+            }
+        }
+    }
+
+    let mut result: Vec<String> = paths.into_iter().collect();
+    result.sort();
+    result
+}
+
+/// Check if a string looks like a file/module path.
+fn looks_like_path(s: &str) -> bool {
+    if s.is_empty() || s.len() < 3 {
+        return false;
+    }
+
+    // Must contain a slash or a known file extension
+    let has_slash = s.contains('/');
+    let has_extension = KNOWN_EXTENSIONS
+        .iter()
+        .any(|ext| s.ends_with(ext) && s.len() > ext.len());
+
+    // Filter out things that are clearly not paths
+    if s.contains(' ') || s.contains('\n') {
+        return false;
+    }
+
+    // Reject pure numbers, URLs, labels
+    if s.chars().all(|c| c.is_ascii_digit() || c == '.') {
+        return false;
+    }
+
+    has_slash || has_extension
+}
+
+/// Known source file extensions.
+const KNOWN_EXTENSIONS: &[&str] = &[
+    ".rs", ".ts", ".tsx", ".js", ".jsx", ".py", ".go", ".java", ".toml", ".yaml", ".yml", ".json",
+    ".md", ".sql", ".sh", ".css", ".scss", ".html",
+];
+
+/// Check if a string looks like a URL.
+fn is_url(s: &str) -> bool {
+    s.starts_with("http://") || s.starts_with("https://") || s.starts_with("git@")
+}
+
+/// Normalize a path by removing leading `./` and trailing slashes.
+fn normalize_path(s: &str) -> String {
+    let mut p = s.to_string();
+    while p.starts_with("./") {
+        p = p[2..].to_string();
+    }
+    while p.ends_with('/') {
+        p.pop();
+    }
+    p
+}
+
+/// Check if two paths overlap (same path, parent-child, or shared directory).
+///
+/// For file paths: checks if they share a common directory prefix.
+/// For module paths: checks if one contains the other.
+fn paths_overlap(a: &str, b: &str) -> bool {
+    if a == b {
+        return true;
+    }
+
+    // Parent-child check
+    let a_is_parent = b.starts_with(a) && b.as_bytes().get(a.len()) == Some(&b'/');
+    let b_is_parent = a.starts_with(b) && a.as_bytes().get(b.len()) == Some(&b'/');
+    if a_is_parent || b_is_parent {
+        return true;
+    }
+
+    // Same immediate parent directory (e.g., "src/foo/a.rs" and "src/foo/b.rs")
+    if let (Some(dir_a), Some(dir_b)) = (parent_dir(a), parent_dir(b)) {
+        return dir_a == dir_b;
+    }
+
+    false
+}
+
+/// Get parent directory of a path.
+fn parent_dir(path: &str) -> Option<&str> {
+    path.rfind('/').map(|i| &path[..i])
+}
+
+/// Find existing queue items whose inferred paths conflict with the given paths.
+///
+/// Scans all active (non-done/skipped) items in the queue and compares
+/// their issue bodies for overlapping file references.
+pub fn find_conflicting_items(
+    queue: &StateQueue<QueueItem>,
+    new_paths: &[String],
+    exclude_work_id: &str,
+) -> Vec<String> {
+    if new_paths.is_empty() {
+        return Vec::new();
+    }
+
+    let mut conflicts = Vec::new();
+
+    for phase in &[QueuePhase::Pending, QueuePhase::Ready, QueuePhase::Running] {
+        for item in queue.iter(*phase) {
+            if item.work_id == exclude_work_id {
+                continue;
+            }
+            if item.queue_type != QueueType::Issue {
+                continue;
+            }
+
+            let existing_paths = match item.body() {
+                Some(body) => extract_paths_from_body(body),
+                None => continue,
+            };
+
+            if has_path_overlap(new_paths, &existing_paths) {
+                conflicts.push(item.work_id.clone());
+            }
+        }
+    }
+
+    conflicts
+}
+
+/// Check if two sets of paths have any overlap.
+fn has_path_overlap(paths_a: &[String], paths_b: &[String]) -> bool {
+    for a in paths_a {
+        for b in paths_b {
+            if paths_overlap(a, b) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Match an issue to relevant specs based on:
+/// 1. Spec source_path overlapping with issue's inferred paths
+/// 2. Spec title/body keywords appearing in issue title/body
+///
+/// Returns spec IDs that should be linked to this issue.
+pub fn find_matching_specs(
+    specs: &[Spec],
+    issue_title: &str,
+    issue_body: Option<&str>,
+    inferred_paths: &[String],
+) -> Vec<String> {
+    let mut matches = Vec::new();
+    let issue_text = format!(
+        "{} {}",
+        issue_title.to_lowercase(),
+        issue_body.unwrap_or("").to_lowercase()
+    );
+
+    for spec in specs {
+        if spec.status != SpecStatus::Active {
+            continue;
+        }
+
+        // Check 1: source_path overlap
+        if let Some(ref source_path) = spec.source_path {
+            for path in inferred_paths {
+                if paths_overlap(source_path, path) {
+                    matches.push(spec.id.clone());
+                    break;
+                }
+            }
+            if matches.last().map(|id| id == &spec.id).unwrap_or(false) {
+                continue; // already matched
+            }
+        }
+
+        // Check 2: keyword matching (spec title words in issue text)
+        if matches_by_keywords(&spec.title, &issue_text) {
+            matches.push(spec.id.clone());
+        }
+    }
+
+    matches
+}
+
+/// Check if significant keywords from spec title appear in the issue text.
+///
+/// Requires at least 2 non-trivial words from the spec title to match.
+fn matches_by_keywords(spec_title: &str, issue_text: &str) -> bool {
+    let spec_words: Vec<&str> = spec_title
+        .split_whitespace()
+        .map(|w| w.trim_matches(|c: char| !c.is_alphanumeric()))
+        .filter(|w| w.len() >= 3 && !STOP_WORDS.contains(&w.to_lowercase().as_str()))
+        .collect();
+
+    if spec_words.is_empty() {
+        return false;
+    }
+
+    let match_count = spec_words
+        .iter()
+        .filter(|w| issue_text.contains(&w.to_lowercase()))
+        .count();
+
+    // Require at least 2 matching words, or all words if spec title is short
+    let threshold = if spec_words.len() <= 2 {
+        spec_words.len()
+    } else {
+        2
+    };
+
+    match_count >= threshold
+}
+
+/// Common stop words to exclude from keyword matching.
+const STOP_WORDS: &[&str] = &[
+    "the", "and", "for", "with", "from", "into", "this", "that", "have", "has", "are", "was",
+    "were", "been", "being", "not", "but", "all", "can", "will", "just", "should", "would",
+    "could", "may", "add", "fix", "update", "new", "use",
+];
+
+/// Perform full dependency analysis for a newly enqueued issue.
+///
+/// This is the main entry point called by the collector after scanning.
+pub fn analyze_issue_dependencies(
+    queue: &StateQueue<QueueItem>,
+    specs: &[Spec],
+    issue: &QueueItem,
+    already_linked: &HashMap<String, Vec<i64>>,
+) -> DependencyAnalysis {
+    let body = issue.body().unwrap_or("");
+    let inferred_paths = extract_paths_from_body(body);
+
+    let conflicting_work_ids = find_conflicting_items(queue, &inferred_paths, &issue.work_id);
+
+    let matching_spec_ids: Vec<String> =
+        find_matching_specs(specs, &issue.title, issue.body(), &inferred_paths)
+            .into_iter()
+            .filter(|spec_id| {
+                // Skip if already linked
+                !already_linked
+                    .get(spec_id)
+                    .map(|issues| issues.contains(&issue.github_number))
+                    .unwrap_or(false)
+            })
+            .collect();
+
+    let requires_sequential = !conflicting_work_ids.is_empty();
+
+    DependencyAnalysis {
+        issue_number: issue.github_number,
+        inferred_paths,
+        conflicting_work_ids,
+        matching_spec_ids,
+        requires_sequential,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::models::SpecStatus;
+    use crate::core::phase::TaskKind;
+    use crate::core::queue_item::testing::{test_issue, test_repo};
+    use crate::core::queue_item::QueueItem;
+
+    #[test]
+    fn extract_backtick_paths() {
+        let body = "Fix the bug in `src/core/collector.rs` and update `src/cli/mod.rs`";
+        let paths = extract_paths_from_body(body);
+        assert!(paths.contains(&"src/core/collector.rs".to_string()));
+        assert!(paths.contains(&"src/cli/mod.rs".to_string()));
+    }
+
+    #[test]
+    fn extract_prose_paths() {
+        let body = "Changes needed in src/service/daemon/collectors/github.rs for the fix";
+        let paths = extract_paths_from_body(body);
+        assert!(paths.contains(&"src/service/daemon/collectors/github.rs".to_string()));
+    }
+
+    #[test]
+    fn extract_ignores_urls() {
+        let body = "See https://github.com/org/repo/blob/main/src/lib.rs for details";
+        let paths = extract_paths_from_body(body);
+        assert!(!paths.iter().any(|p| p.contains("https://")));
+    }
+
+    #[test]
+    fn extract_normalizes_leading_dot_slash() {
+        let body = "Update `./src/main.rs` file";
+        let paths = extract_paths_from_body(body);
+        assert!(paths.contains(&"src/main.rs".to_string()));
+    }
+
+    #[test]
+    fn extract_deduplicates() {
+        let body = "`src/lib.rs` is referenced twice: src/lib.rs";
+        let paths = extract_paths_from_body(body);
+        assert_eq!(paths.iter().filter(|p| *p == "src/lib.rs").count(), 1);
+    }
+
+    #[test]
+    fn paths_overlap_same() {
+        assert!(paths_overlap("src/core/mod.rs", "src/core/mod.rs"));
+    }
+
+    #[test]
+    fn paths_overlap_parent_child() {
+        assert!(paths_overlap("src/core", "src/core/mod.rs"));
+        assert!(paths_overlap("src/core/mod.rs", "src/core"));
+    }
+
+    #[test]
+    fn paths_overlap_same_directory() {
+        assert!(paths_overlap("src/core/a.rs", "src/core/b.rs"));
+    }
+
+    #[test]
+    fn paths_no_overlap() {
+        assert!(!paths_overlap("src/core/a.rs", "src/cli/b.rs"));
+    }
+
+    #[test]
+    fn find_conflicting_items_detects_overlap() {
+        let mut queue: StateQueue<QueueItem> = StateQueue::new();
+        let repo = test_repo();
+
+        let existing = QueueItem::new_issue(
+            &repo,
+            1,
+            TaskKind::Analyze,
+            "Existing issue".into(),
+            Some("Fix `src/core/collector.rs`".into()),
+            vec![],
+            "user".into(),
+        );
+        queue.push(QueuePhase::Pending, existing);
+
+        let new_paths = vec!["src/core/collector.rs".to_string()];
+        let conflicts = find_conflicting_items(&queue, &new_paths, "issue:org/repo:2");
+
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(conflicts[0], "issue:org/repo:1");
+    }
+
+    #[test]
+    fn find_conflicting_items_excludes_self() {
+        let mut queue: StateQueue<QueueItem> = StateQueue::new();
+        let repo = test_repo();
+
+        let item = QueueItem::new_issue(
+            &repo,
+            1,
+            TaskKind::Analyze,
+            "Issue".into(),
+            Some("Fix `src/core/collector.rs`".into()),
+            vec![],
+            "user".into(),
+        );
+        queue.push(QueuePhase::Pending, item);
+
+        let paths = vec!["src/core/collector.rs".to_string()];
+        let conflicts = find_conflicting_items(&queue, &paths, "issue:org/repo:1");
+
+        assert!(conflicts.is_empty());
+    }
+
+    #[test]
+    fn find_conflicting_items_no_conflict() {
+        let mut queue: StateQueue<QueueItem> = StateQueue::new();
+        let repo = test_repo();
+
+        let existing = QueueItem::new_issue(
+            &repo,
+            1,
+            TaskKind::Analyze,
+            "Existing".into(),
+            Some("Fix `src/cli/mod.rs`".into()),
+            vec![],
+            "user".into(),
+        );
+        queue.push(QueuePhase::Pending, existing);
+
+        let new_paths = vec!["src/service/daemon.rs".to_string()];
+        let conflicts = find_conflicting_items(&queue, &new_paths, "issue:org/repo:2");
+
+        assert!(conflicts.is_empty());
+    }
+
+    fn make_spec(id: &str, title: &str, source_path: Option<&str>) -> Spec {
+        Spec {
+            id: id.to_string(),
+            repo_id: "r1".to_string(),
+            title: title.to_string(),
+            body: String::new(),
+            status: SpecStatus::Active,
+            source_path: source_path.map(|s| s.to_string()),
+            test_commands: None,
+            acceptance_criteria: None,
+            priority: None,
+            created_at: String::new(),
+            updated_at: String::new(),
+        }
+    }
+
+    #[test]
+    fn find_matching_specs_by_path() {
+        let specs = vec![make_spec(
+            "s1",
+            "Collector refactor",
+            Some("src/core/collector.rs"),
+        )];
+
+        let matches = find_matching_specs(
+            &specs,
+            "Fix collector bug",
+            Some("Error in `src/core/collector.rs`"),
+            &["src/core/collector.rs".to_string()],
+        );
+
+        assert_eq!(matches, vec!["s1"]);
+    }
+
+    #[test]
+    fn find_matching_specs_by_keywords() {
+        let specs = vec![make_spec("s1", "Issue dependency analysis", None)];
+
+        let matches = find_matching_specs(
+            &specs,
+            "Implement issue dependency detection",
+            Some("We need dependency analysis for issues"),
+            &[],
+        );
+
+        assert_eq!(matches, vec!["s1"]);
+    }
+
+    #[test]
+    fn find_matching_specs_skips_inactive() {
+        let mut spec = make_spec("s1", "Collector refactor", Some("src/core/collector.rs"));
+        spec.status = SpecStatus::Paused;
+
+        let matches = find_matching_specs(
+            &[spec],
+            "Fix collector",
+            Some("Error in `src/core/collector.rs`"),
+            &["src/core/collector.rs".to_string()],
+        );
+
+        assert!(matches.is_empty());
+    }
+
+    #[test]
+    fn analyze_issue_dependencies_full() {
+        let mut queue: StateQueue<QueueItem> = StateQueue::new();
+        let repo = test_repo();
+
+        let existing = QueueItem::new_issue(
+            &repo,
+            1,
+            TaskKind::Analyze,
+            "Existing".into(),
+            Some("Fix `src/core/collector.rs`".into()),
+            vec![],
+            "user".into(),
+        );
+        queue.push(QueuePhase::Pending, existing);
+
+        let specs = vec![make_spec(
+            "s1",
+            "Collector improvement",
+            Some("src/core/collector.rs"),
+        )];
+
+        let new_issue = QueueItem::new_issue(
+            &repo,
+            2,
+            TaskKind::Analyze,
+            "New collector issue".into(),
+            Some("Bug in `src/core/collector.rs` line 42".into()),
+            vec![],
+            "user".into(),
+        );
+
+        let analysis = analyze_issue_dependencies(&queue, &specs, &new_issue, &HashMap::new());
+
+        assert_eq!(analysis.issue_number, 2);
+        assert!(analysis
+            .inferred_paths
+            .contains(&"src/core/collector.rs".to_string()));
+        assert_eq!(analysis.conflicting_work_ids, vec!["issue:org/repo:1"]);
+        assert_eq!(analysis.matching_spec_ids, vec!["s1"]);
+        assert!(analysis.requires_sequential);
+    }
+
+    #[test]
+    fn analyze_issue_dependencies_no_conflicts() {
+        let queue: StateQueue<QueueItem> = StateQueue::new();
+        let repo = test_repo();
+        let specs = vec![make_spec("s1", "CLI improvement", Some("src/cli"))];
+
+        let issue = QueueItem::new_issue(
+            &repo,
+            5,
+            TaskKind::Analyze,
+            "Fix service layer".into(),
+            Some("Update `src/service/daemon.rs`".into()),
+            vec![],
+            "user".into(),
+        );
+
+        let analysis = analyze_issue_dependencies(&queue, &specs, &issue, &HashMap::new());
+
+        assert!(!analysis.requires_sequential);
+        assert!(analysis.conflicting_work_ids.is_empty());
+        assert!(analysis.matching_spec_ids.is_empty());
+    }
+
+    #[test]
+    fn analyze_skips_already_linked_specs() {
+        let queue: StateQueue<QueueItem> = StateQueue::new();
+        let repo = test_repo();
+        let specs = vec![make_spec(
+            "s1",
+            "Collector refactor",
+            Some("src/core/collector.rs"),
+        )];
+
+        let issue = QueueItem::new_issue(
+            &repo,
+            3,
+            TaskKind::Analyze,
+            "Collector fix".into(),
+            Some("Fix `src/core/collector.rs`".into()),
+            vec![],
+            "user".into(),
+        );
+
+        let mut already_linked: HashMap<String, Vec<i64>> = HashMap::new();
+        already_linked.insert("s1".to_string(), vec![3]);
+
+        let analysis = analyze_issue_dependencies(&queue, &specs, &issue, &already_linked);
+
+        assert!(analysis.matching_spec_ids.is_empty());
+    }
+
+    #[test]
+    fn keyword_matching_requires_threshold() {
+        // Single short word in spec title should not match
+        let specs = vec![make_spec("s1", "Fix", None)];
+
+        let matches = find_matching_specs(&specs, "Fix something", Some("body"), &[]);
+
+        // "Fix" is in STOP_WORDS, so no match
+        assert!(matches.is_empty());
+    }
+
+    #[test]
+    fn keyword_matching_needs_multiple_words() {
+        let specs = vec![make_spec("s1", "dependency analysis implementation", None)];
+
+        // Only 1 keyword match should not be enough (threshold is 2)
+        let matches =
+            find_matching_specs(&specs, "unrelated dependency title", Some("nothing"), &[]);
+
+        // "dependency" matches but only 1 word, threshold is 2
+        assert!(matches.is_empty());
+    }
+}

--- a/plugins/autodev/cli/src/core/mod.rs
+++ b/plugins/autodev/cli/src/core/mod.rs
@@ -2,6 +2,7 @@ pub mod board;
 pub mod collector;
 pub mod config;
 pub mod datasource;
+pub mod dependency;
 pub mod handler;
 pub mod labels;
 pub mod models;

--- a/plugins/autodev/cli/src/service/daemon/collectors/github.rs
+++ b/plugins/autodev/cli/src/service/daemon/collectors/github.rs
@@ -12,9 +12,12 @@ use async_trait::async_trait;
 use crate::core::collector::Collector;
 use crate::core::config::models::ClawConfig;
 use crate::core::config::{self, ConfigLoader, Env};
+use crate::core::dependency;
 use crate::core::models::{QueuePhase, QueueType};
 use crate::core::phase::TaskKind;
-use crate::core::repository::{QueueRepository, RepoRepository, ScanCursorRepository};
+use crate::core::repository::{
+    QueueRepository, RepoRepository, ScanCursorRepository, SpecRepository,
+};
 use crate::core::task::{QueueOp, Task, TaskResult};
 use crate::infra::gh::Gh;
 use crate::infra::git::Git;
@@ -31,7 +34,9 @@ use crate::service::tasks::review::ReviewTask;
 /// GitHub 이슈/PR 스캔 기반 Collector.
 ///
 /// per-repo 큐를 소유하고, 스캔 → Task 생성 → 큐 적용 생명주기를 관리한다.
-pub struct GitHubTaskSource<DB: RepoRepository + ScanCursorRepository + QueueRepository> {
+pub struct GitHubTaskSource<
+    DB: RepoRepository + ScanCursorRepository + QueueRepository + SpecRepository,
+> {
     workspace: Arc<dyn WorkspaceOps>,
     gh: Arc<dyn Gh>,
     config: Arc<dyn ConfigLoader>,
@@ -48,7 +53,9 @@ pub struct GitHubTaskSource<DB: RepoRepository + ScanCursorRepository + QueueRep
     recovery_interval_secs: u64,
 }
 
-impl<DB: RepoRepository + ScanCursorRepository + QueueRepository + Send> GitHubTaskSource<DB> {
+impl<DB: RepoRepository + ScanCursorRepository + QueueRepository + SpecRepository + Send>
+    GitHubTaskSource<DB>
+{
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         workspace: Arc<dyn WorkspaceOps>,
@@ -209,6 +216,104 @@ impl<DB: RepoRepository + ScanCursorRepository + QueueRepository + Send> GitHubT
                         }
                     }
                     _ => {}
+                }
+            }
+        }
+    }
+
+    /// Claw enabled일 때 새로 enqueue된 이슈의 의존성을 분석하고 spec_issues를 자동 링크한다.
+    ///
+    /// 각 repo의 Pending 큐에 있는 Issue 아이템에 대해:
+    /// 1. 이슈 body에서 변경 대상 파일/모듈 경로를 추론
+    /// 2. 기존 큐 아이템과의 경로 충돌을 감지
+    /// 3. 관련 스펙을 자동 매칭하여 spec_issues에 링크
+    /// 4. 충돌 시 로그로 순차 처리 필요성을 기록
+    fn analyze_and_link_dependencies(&self) {
+        if !self.claw_enabled {
+            return;
+        }
+
+        for repo in self.repos.values() {
+            // Load active specs for this repo
+            let specs = match self.db.spec_list(None) {
+                Ok(s) => s
+                    .into_iter()
+                    .filter(|s| s.repo_id == repo.id())
+                    .collect::<Vec<_>>(),
+                Err(e) => {
+                    tracing::error!("spec_list failed for dependency analysis: {e}");
+                    continue;
+                }
+            };
+
+            if specs.is_empty() {
+                continue;
+            }
+
+            // Load existing spec-issue links to avoid duplicates
+            let already_linked = match self.db.spec_issues_all() {
+                Ok(m) => m
+                    .into_iter()
+                    .map(|(k, v)| (k, v.into_iter().map(|si| si.issue_number).collect()))
+                    .collect::<std::collections::HashMap<String, Vec<i64>>>(),
+                Err(e) => {
+                    tracing::error!("spec_issues_all failed: {e}");
+                    std::collections::HashMap::new()
+                }
+            };
+
+            // Analyze each pending issue
+            let pending_issues: Vec<_> = repo
+                .queue
+                .iter(QueuePhase::Pending)
+                .filter(|item| item.queue_type == QueueType::Issue)
+                .collect();
+
+            for item in pending_issues {
+                let analysis = dependency::analyze_issue_dependencies(
+                    &repo.queue,
+                    &specs,
+                    item,
+                    &already_linked,
+                );
+
+                // Auto-link matching specs
+                for spec_id in &analysis.matching_spec_ids {
+                    match self.db.spec_link_issue(spec_id, analysis.issue_number) {
+                        Ok(()) => {
+                            tracing::info!(
+                                "auto-linked issue #{} to spec {spec_id}",
+                                analysis.issue_number
+                            );
+                        }
+                        Err(e) => {
+                            // UNIQUE constraint violation means already linked (race condition safe)
+                            if !e.to_string().contains("UNIQUE constraint") {
+                                tracing::warn!(
+                                    "spec_link_issue failed for spec={spec_id} issue=#{}: {e}",
+                                    analysis.issue_number
+                                );
+                            }
+                        }
+                    }
+                }
+
+                // Log dependency conflicts for sequential processing
+                if analysis.requires_sequential {
+                    tracing::info!(
+                        "issue #{} has path conflicts with {} item(s): {:?} — sequential processing recommended",
+                        analysis.issue_number,
+                        analysis.conflicting_work_ids.len(),
+                        analysis.conflicting_work_ids
+                    );
+                }
+
+                if !analysis.inferred_paths.is_empty() {
+                    tracing::debug!(
+                        "issue #{}: inferred paths {:?}",
+                        analysis.issue_number,
+                        analysis.inferred_paths
+                    );
                 }
             }
         }
@@ -444,7 +549,7 @@ impl<DB: RepoRepository + ScanCursorRepository + QueueRepository + Send> GitHubT
 }
 
 #[async_trait(?Send)]
-impl<DB: RepoRepository + ScanCursorRepository + QueueRepository + Send> Collector
+impl<DB: RepoRepository + ScanCursorRepository + QueueRepository + SpecRepository + Send> Collector
     for GitHubTaskSource<DB>
 {
     async fn poll(&mut self) -> Vec<Box<dyn Task>> {
@@ -460,6 +565,7 @@ impl<DB: RepoRepository + ScanCursorRepository + QueueRepository + Send> Collect
         }
 
         self.run_scans().await;
+        self.analyze_and_link_dependencies();
         self.sync_queue_phases();
         self.auto_advance_pending();
         Vec::new()
@@ -693,6 +799,61 @@ mod tests {
         }
         fn queue_get_failure_count(&self, _: &str) -> anyhow::Result<i32> {
             Ok(0)
+        }
+    }
+
+    impl SpecRepository for MockDb {
+        fn spec_add(&self, _: &crate::core::models::NewSpec) -> anyhow::Result<String> {
+            Ok("spec-1".to_string())
+        }
+        fn spec_list(&self, _: Option<&str>) -> anyhow::Result<Vec<crate::core::models::Spec>> {
+            Ok(vec![])
+        }
+        fn spec_show(&self, _: &str) -> anyhow::Result<Option<crate::core::models::Spec>> {
+            Ok(None)
+        }
+        fn spec_update(
+            &self,
+            _: &str,
+            _: &str,
+            _: Option<&str>,
+            _: Option<&str>,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn spec_set_status(
+            &self,
+            _: &str,
+            _: crate::core::models::SpecStatus,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn spec_issues(&self, _: &str) -> anyhow::Result<Vec<crate::core::models::SpecIssue>> {
+            Ok(vec![])
+        }
+        fn spec_issues_all(
+            &self,
+        ) -> anyhow::Result<std::collections::HashMap<String, Vec<crate::core::models::SpecIssue>>>
+        {
+            Ok(std::collections::HashMap::new())
+        }
+        fn spec_issue_counts(&self) -> anyhow::Result<std::collections::HashMap<String, usize>> {
+            Ok(std::collections::HashMap::new())
+        }
+        fn spec_link_issue(&self, _: &str, _: i64) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn spec_unlink_issue(&self, _: &str, _: i64) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn spec_list_by_status(
+            &self,
+            _: crate::core::models::SpecStatus,
+        ) -> anyhow::Result<Vec<crate::core::models::Spec>> {
+            Ok(vec![])
+        }
+        fn spec_set_priority(&self, _: &str, _: i32) -> anyhow::Result<()> {
+            Ok(())
         }
     }
 


### PR DESCRIPTION
## Summary
- Add `dependency.rs` module with keyword-based file/module inference from issue content
- Auto-link issues to matching specs via `spec_issues` table during collection
- Detect conflicts between queue items targeting same modules
- Case-insensitive stop-word filtering for keyword extraction

## Test plan
- [x] `cargo check` passes
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes

Closes #413

🤖 Generated with [Claude Code](https://claude.com/claude-code)