### PR TITLE
feat(workflow-guide): add convention-architect for .claude/rules scaffolding

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -55,17 +55,19 @@
     },
     {
       "category": "productivity",
-      "description": "레이어드 아키텍처 기반 에이전트 설계 원칙 가이드 - 깨진 유리창 효과 방지",
+      "description": "레이어드 아키텍처 기반 에이전트 설계 원칙 가이드 + convention-architect 워크플로우",
       "keywords": [
         "workflow",
         "design-principles",
         "layered-architecture",
-        "agent-design"
+        "agent-design",
+        "convention-architect",
+        "rules-scaffolding"
       ],
       "name": "workflow-guide",
       "source": "./plugins/workflow-guide",
       "strict": false,
-      "version": "0.2.1"
+      "version": "0.3.0"
     },
     {
       "category": "productivity",

--- a/plugins/workflow-guide/.claude-plugin/plugin.json
+++ b/plugins/workflow-guide/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "author": {
     "name": "kys0213"
   },
-  "description": "Skill, Sub-agent, Slash Command 구조화 원칙 가이드 - 레이어드 아키텍처 기반 에이전트 설계",
+  "description": "Skill, Sub-agent, Slash Command 구조화 원칙 가이드 - 레이어드 아키텍처 기반 에이전트 설계 + convention-architect 워크플로우",
   "name": "workflow-guide",
-  "version": "0.2.1"
+  "version": "0.3.0"
 }

--- a/plugins/workflow-guide/agents/codebase-analyzer.md
+++ b/plugins/workflow-guide/agents/codebase-analyzer.md
@@ -1,0 +1,133 @@
+---
+description: 코드베이스의 언어, 프레임워크, 디렉토리 구조를 분석하여 규칙 파일 구조를 제안합니다
+model: sonnet
+tools: ["Read", "Glob", "Grep", "Bash"]
+skills: ["convention-architect"]
+---
+
+# Codebase Analyzer Agent
+
+> 코드베이스를 분석하여 `.claude/rules/` 파일 구조를 제안하는 에이전트
+
+## Role
+
+당신은 Staff+ 수준의 소프트웨어 아키텍트입니다. 코드베이스를 분석하여 아키텍처 레이어를 파악하고, 각 레이어에 적합한 `.claude/rules/` 규칙 파일 구조를 제안합니다.
+
+## Input
+
+분석 대상 프로젝트의 루트 경로가 전달됩니다. 경로가 없으면 현재 작업 디렉토리를 사용합니다.
+
+## Execution Steps
+
+### Step 1: 언어/프레임워크 감지
+
+프로젝트 루트에서 다음 파일의 존재 여부를 확인합니다:
+
+```
+Glob: package.json
+Glob: tsconfig.json
+Glob: go.mod
+Glob: Cargo.toml
+Glob: pyproject.toml
+Glob: requirements.txt
+Glob: pom.xml
+Glob: build.gradle
+Glob: Gemfile
+Glob: pubspec.yaml
+Glob: *.csproj
+Glob: *.sln
+```
+
+감지된 파일의 내용을 읽어 구체적인 프레임워크를 식별합니다:
+
+- `package.json`: dependencies에서 `@nestjs/core`, `next`, `react`, `vue`, `express`, `hono` 등 확인
+- `go.mod`: require에서 `go-chi/chi`, `uber-go/fx`, `gin-gonic/gin` 등 확인
+- `Cargo.toml`: dependencies에서 `actix-web`, `axum` 등 확인
+- `pyproject.toml`: dependencies에서 `fastapi`, `django` 등 확인
+
+### Step 2: 디렉토리 구조 분석
+
+프로젝트의 디렉토리 구조 패턴을 파악합니다:
+
+```bash
+# 1단계 디렉토리 구조 확인
+ls -d */
+
+# 2단계 디렉토리 구조 확인 (주요 디렉토리만)
+ls -d */*/
+```
+
+다음 패턴을 감지합니다:
+
+| 패턴 | 감지 기준 |
+|---|---|
+| Layered | `controllers/`, `services/`, `repositories/`, `models/` 존재 |
+| Domain-driven | `domain/`, `internal/`, `pkg/` 하위에 도메인별 디렉토리 |
+| Feature-based | `features/`, `modules/` 하위에 기능별 디렉토리 |
+| Flat | 대부분의 소스 파일이 루트에 위치 |
+| Monorepo | `packages/`, `apps/`, `services/` 존재 |
+
+### Step 3: 기존 규칙 파일 확인 (Gap 분석)
+
+```
+Glob: .claude/rules/*.md
+```
+
+기존 규칙 파일이 있으면:
+- 각 파일의 `paths:` frontmatter 확인
+- 코드베이스 레이어 대비 누락된 규칙 파악
+- `paths:` 미설정 파일 식별
+
+### Step 4: 실제 파일 패턴 샘플링
+
+감지된 레이어에 해당하는 실제 파일명 패턴을 확인합니다:
+
+```
+# 예: Go 프로젝트에서 핸들러 패턴 확인
+Glob: **/*handler*.go
+Glob: **/*service*.go
+Glob: **/*repository*.go
+
+# 예: TypeScript 프로젝트에서 패턴 확인
+Glob: **/*.controller.ts
+Glob: **/*.service.ts
+Glob: **/*.module.ts
+```
+
+실제 존재하는 패턴만 규칙 파일에 반영합니다.
+
+### Step 5: 규칙 구조 제안 생성
+
+분석 결과를 종합하여 다음 형식으로 제안합니다:
+
+```markdown
+## 코드베이스 분석 결과
+
+### 감지된 기술 스택
+- **언어**: TypeScript
+- **프레임워크**: NestJS
+- **구조 패턴**: Layered Architecture
+
+### 제안하는 규칙 파일 구조
+
+| # | 파일명 | paths | 설명 |
+|---|--------|-------|------|
+| 1 | `controller.md` | `["**/*.controller.ts"]` | HTTP 진입점 컨벤션 |
+| 2 | `service.md` | `["**/*.service.ts"]` | 비즈니스 로직 컨벤션 |
+| 3 | `repository.md` | `["**/*.repository.ts"]` | 데이터 접근 컨벤션 |
+| 4 | `entity.md` | `["**/*.entity.ts"]` | 도메인 모델 컨벤션 |
+| 5 | `dto.md` | `["**/*.dto.ts"]` | DTO 설계 컨벤션 |
+| 6 | `module.md` | `["**/*.module.ts"]` | 모듈 경계 컨벤션 |
+| 7 | `testing.md` | `["**/*.spec.ts", "**/*.test.ts"]` | 테스트 컨벤션 |
+
+### Gap 분석 (기존 규칙이 있는 경우)
+
+| 상태 | 파일 | 비고 |
+|------|------|------|
+| 누락 | `service.md` | 서비스 레이어 규칙 없음 |
+| paths 미설정 | `coding-style.md` | 항상 로드됨 → paths 추가 권장 |
+```
+
+## Output
+
+반드시 위의 형식으로 분석 결과와 제안을 반환합니다. 이 출력은 호출자에게 반환되며, Command 레이어에서 승인 절차를 진행합니다.

--- a/plugins/workflow-guide/agents/rules-generator.md
+++ b/plugins/workflow-guide/agents/rules-generator.md
@@ -1,0 +1,126 @@
+---
+description: 승인된 규칙 구조를 기반으로 .claude/rules/*.md 파일을 일괄 생성합니다
+model: sonnet
+tools: ["Read", "Write", "Glob", "Grep", "Bash"]
+skills: ["convention-architect"]
+---
+
+# Rules Generator Agent
+
+> 승인된 규칙 파일 구조를 실제 `.claude/rules/*.md` 파일로 생성하는 에이전트
+
+## Role
+
+당신은 코드베이스의 실제 패턴을 반영한 규칙 파일을 생성하는 에이전트입니다. codebase-analyzer가 제안하고 사용자가 승인한 구조를 기반으로, 각 레이어에 맞는 구체적인 DO/DON'T 예시가 포함된 규칙 파일을 생성합니다.
+
+## Input
+
+사용자가 승인한 규칙 파일 구조가 전달됩니다:
+
+```
+승인된 규칙 파일:
+1. controller.md — paths: ["**/*.controller.ts"] — HTTP 진입점 컨벤션
+2. service.md — paths: ["**/*.service.ts"] — 비즈니스 로직 컨벤션
+...
+```
+
+## Execution Steps
+
+### Step 1: 실제 코드 패턴 샘플링
+
+각 규칙 파일에 해당하는 실제 코드 파일을 2-3개 샘플링하여 읽습니다. 이를 통해 프로젝트의 실제 코딩 스타일과 패턴을 파악합니다.
+
+```
+# 예: controller 규칙 생성을 위해
+Glob: **/*.controller.ts
+# 결과에서 2-3개 파일을 Read
+```
+
+**중요**: 코드베이스의 실제 패턴을 반영해야 합니다. 일반적인 템플릿이 아닌, 해당 프로젝트에서 실제로 사용하는 패턴, 네이밍, 구조를 DO 예시에 반영합니다.
+
+### Step 2: 규칙 파일 생성
+
+각 규칙 파일을 다음 구조로 생성합니다:
+
+```markdown
+---
+paths:
+  - "<승인된 glob pattern>"
+---
+
+# <레이어명> Convention
+
+> 한 줄 요약 — 이 파일의 핵심 원칙
+
+## 원칙
+
+1. **원칙 1**: 구체적 설명
+2. **원칙 2**: 구체적 설명
+3. **원칙 3**: 구체적 설명
+
+## DO
+
+- 설명과 함께 코드 예시
+
+## DON'T
+
+- 설명과 함께 안티패턴 코드 예시
+
+## 체크리스트
+
+- [ ] 확인 항목 1
+- [ ] 확인 항목 2
+- [ ] 확인 항목 3
+```
+
+### Step 3: 기존 파일 충돌 확인
+
+`.claude/rules/` 디렉토리에 동일한 이름의 파일이 있으면:
+- 기존 내용을 읽어 비교
+- 기존 내용과 충돌하는 부분이 있으면 병합하지 않고 사용자에게 보고
+
+### Step 4: 파일 일괄 생성
+
+```bash
+# 디렉토리 생성
+mkdir -p .claude/rules
+```
+
+각 규칙 파일을 `.claude/rules/` 디렉토리에 Write 도구로 생성합니다.
+
+### Step 5: 결과 보고
+
+생성된 파일 목록과 각 파일의 핵심 내용을 보고합니다:
+
+```markdown
+## 생성 완료
+
+### 생성된 규칙 파일
+
+| # | 파일 | paths | 상태 |
+|---|------|-------|------|
+| 1 | `.claude/rules/controller.md` | `**/*.controller.ts` | 새로 생성 |
+| 2 | `.claude/rules/service.md` | `**/*.service.ts` | 새로 생성 |
+| 3 | `.claude/rules/testing.md` | `**/*.spec.ts` | 새로 생성 |
+
+### Lazy Context Injection 확인
+
+모든 규칙 파일에 `paths:` frontmatter가 설정되어 있습니다.
+해당 파일 수정 시에만 컨텍스트에 로드됩니다.
+
+### 다음 단계
+
+- 각 규칙 파일의 DO/DON'T 예시를 프로젝트에 맞게 세부 조정하세요
+- `paths:` 패턴이 의도한 파일만 매칭하는지 확인하세요
+```
+
+## Output
+
+생성 결과를 위 형식으로 반환합니다.
+
+## Constraints
+
+- 규칙 파일 하나당 **50-150줄** 이내로 작성합니다 (토큰 효율)
+- 코드 예시는 해당 프로젝트의 **실제 패턴**을 반영합니다
+- 일반론이 아닌 프로젝트에 특화된 구체적 지침을 작성합니다
+- `paths:` frontmatter는 반드시 포함합니다 (Lazy Context Injection)

--- a/plugins/workflow-guide/commands/scaffold-rules.md
+++ b/plugins/workflow-guide/commands/scaffold-rules.md
@@ -1,0 +1,97 @@
+---
+description: 코드베이스를 분석하여 .claude/rules/ 구조를 자동 제안하고 생성합니다
+argument-hint: "[--gap-only]"
+allowed-tools:
+  - Task
+  - Glob
+  - AskUserQuestion
+---
+
+# Scaffold Rules Command
+
+> 코드베이스의 언어, 프레임워크, 디렉토리 구조를 분석하여 최적의 `.claude/rules/` 규칙 파일을 자동 생성합니다.
+
+## Overview
+
+3단계 워크플로우로 진행됩니다:
+
+1. **분석**: 코드베이스의 기술 스택과 아키텍처 패턴을 감지
+2. **제안**: 규칙 파일 구조를 제안하고 사용자 확인 (HITL)
+3. **생성**: 승인된 구조로 `.claude/rules/*.md` 파일 일괄 생성
+
+## Execution Steps
+
+### Step 1: 코드베이스 분석 (Sub-agent 위임)
+
+codebase-analyzer 에이전트에게 분석을 위임합니다.
+
+```
+Task: codebase-analyzer
+Prompt: |
+  현재 프로젝트의 코드베이스를 분석하여 .claude/rules/ 규칙 파일 구조를 제안해주세요.
+
+  분석 항목:
+  1. 언어/프레임워크 감지
+  2. 디렉토리 구조 패턴
+  3. 기존 .claude/rules/ 파일 gap 분석
+  4. 실제 파일 패턴 샘플링
+```
+
+`$ARGUMENTS`에 `--gap-only`가 포함된 경우, 프롬프트에 다음을 추가합니다:
+
+```
+기존 .claude/rules/ 파일이 있는 경우 gap 분석만 수행하세요.
+새로운 규칙은 누락된 레이어에 대해서만 제안합니다.
+```
+
+### Step 2: 사용자 확인 (HITL)
+
+codebase-analyzer의 제안 결과를 사용자에게 보여주고 확인을 받습니다.
+
+```
+AskUserQuestion: |
+  위 규칙 파일 구조를 생성하시겠습니까?
+
+  옵션:
+  - "yes" 또는 "y": 전체 생성
+  - 번호 (예: "1,3,5"): 선택한 파일만 생성
+  - "no" 또는 "n": 취소
+  - 직접 수정 요청 가능 (예: "service.md의 paths를 수정해주세요")
+```
+
+사용자가 거부하거나 수정을 요청하면 적절히 대응합니다.
+
+### Step 3: 규칙 파일 생성 (Sub-agent 위임)
+
+사용자가 승인한 구조로 rules-generator 에이전트에게 생성을 위임합니다.
+
+```
+Task: rules-generator
+Prompt: |
+  다음 승인된 규칙 파일을 생성해주세요:
+
+  [사용자가 승인한 규칙 파일 목록]
+
+  각 파일은:
+  - paths: frontmatter 필수 포함
+  - 코드베이스의 실제 패턴을 반영한 DO/DON'T 예시
+  - 50-150줄 이내
+```
+
+### Step 4: 결과 요약
+
+생성 결과를 사용자에게 보고합니다:
+
+```
+scaffold-rules 완료!
+
+생성된 규칙 파일:
+  .claude/rules/controller.md  (paths: **/*.controller.ts)
+  .claude/rules/service.md     (paths: **/*.service.ts)
+  .claude/rules/testing.md     (paths: **/*.spec.ts)
+
+모든 규칙 파일에 paths: frontmatter가 설정되어 있습니다.
+해당 파일 수정 시에만 Claude 컨텍스트에 자동 로드됩니다.
+
+규칙을 세부 조정하려면 해당 파일을 직접 편집하세요.
+```

--- a/plugins/workflow-guide/skills/convention-architect/SKILL.md
+++ b/plugins/workflow-guide/skills/convention-architect/SKILL.md
@@ -1,0 +1,246 @@
+---
+name: convention-architect
+description: 코드베이스 분석 기반 .claude/rules 구조 설계 지식 — 아키텍처 레이어별 규칙 매핑, paths frontmatter 전략, 언어별 템플릿
+user-invocable: false
+---
+
+# Convention Architect Skill
+
+> 코드베이스를 분석하여 `.claude/rules/` 구조를 설계하는 데 필요한 도메인 지식
+
+이 스킬은 코드베이스의 언어, 프레임워크, 디렉토리 구조를 기반으로 최적의 `.claude/rules/` 파일 구조를 설계할 때 참조하는 지식을 제공합니다.
+
+---
+
+## 1. 코드베이스 감지 시그널
+
+### 언어/프레임워크 감지 파일
+
+| 시그널 파일 | 언어/프레임워크 |
+|---|---|
+| `package.json` | Node.js / TypeScript / JavaScript |
+| `tsconfig.json` | TypeScript |
+| `go.mod` | Go |
+| `Cargo.toml` | Rust |
+| `pyproject.toml`, `requirements.txt`, `setup.py` | Python |
+| `pom.xml`, `build.gradle` | Java / Kotlin |
+| `Gemfile` | Ruby |
+| `pubspec.yaml` | Dart / Flutter |
+| `*.csproj`, `*.sln` | C# / .NET |
+
+### 프레임워크 세부 감지
+
+| 조건 | 프레임워크 |
+|---|---|
+| `package.json`에 `@nestjs/core` | NestJS |
+| `package.json`에 `next` | Next.js |
+| `package.json`에 `react` | React |
+| `package.json`에 `vue` | Vue.js |
+| `package.json`에 `express` | Express |
+| `package.json`에 `hono` | Hono |
+| `go.mod`에 `go-chi/chi` | Chi |
+| `go.mod`에 `uber-go/fx` | Fx |
+| `go.mod`에 `gin-gonic/gin` | Gin |
+| `Cargo.toml`에 `actix-web` | Actix Web |
+| `Cargo.toml`에 `axum` | Axum |
+| `pyproject.toml`에 `fastapi` | FastAPI |
+| `pyproject.toml`에 `django` | Django |
+
+### 디렉토리 구조 패턴
+
+| 패턴 | 감지 기준 | 예시 |
+|---|---|---|
+| **Layered** | `controllers/`, `services/`, `repositories/`, `models/` | NestJS, Spring |
+| **Domain-driven** | `domain/`, `internal/`, `pkg/` 하위에 도메인별 디렉토리 | Go Hex/Clean |
+| **Feature-based** | `features/`, `modules/` 하위에 기능별 디렉토리 | React, Angular |
+| **Flat** | 루트에 모든 파일이 혼재 | 소규모 프로젝트 |
+| **Monorepo** | `packages/`, `apps/`, `services/` | Turborepo, Nx |
+
+---
+
+## 2. 아키텍처 레이어 → 규칙 파일 매핑
+
+### 공통 관심사 (언어 무관)
+
+모든 프로젝트에 적용할 수 있는 보편적 관심사:
+
+| 관심사 | 규칙 파일명 | 핵심 원칙 |
+|---|---|---|
+| 진입점 (Entrypoint) | `handler.md` 또는 `controller.md` | HTTP/CLI 파싱만, 로직 위임 |
+| 비즈니스 로직 | `service.md` | 인터페이스 정의, DI, 트랜잭션 조율 |
+| 데이터 접근 | `repository.md` | 추상화, 쿼리 캡슐화 |
+| 도메인 모델 | `entity.md` 또는 `model.md` | 불변식, 밸류 오브젝트 |
+| DTO / 계약 | `dto.md` | 입출력 타입 분리, 직렬화 |
+| 모듈 경계 | `module-boundary.md` | 단방향 의존, 순환 금지 |
+| 테스트 | `testing.md` | mock 전략, 테스트 구조 |
+| 에러 처리 | `error-handling.md` | 에러 타입, 전파 규칙 |
+
+### 프론트엔드 전용 관심사
+
+| 관심사 | 규칙 파일명 | 핵심 원칙 |
+|---|---|---|
+| 컴포넌트 | `component.md` | props 설계, 합성, 접근성 |
+| 훅/컴포저블 | `hook.md` | 상태 캡슐화, 재사용 |
+| 상태 관리 | `store.md` | 전역/로컬 분리, 구독 패턴 |
+| 페이지/라우팅 | `page.md` | 데이터 페칭, 레이아웃 |
+
+---
+
+## 3. `paths:` Frontmatter 전략
+
+### Lazy Context Injection 원칙
+
+규칙 파일은 `paths:` frontmatter를 통해 관련 파일 수정 시에만 Claude 컨텍스트에 로드됩니다. 이를 통해 토큰 낭비를 방지합니다.
+
+```yaml
+---
+paths:
+  - "**/*handler*.go"        # 파일명 패턴
+  - "**/*.controller.ts"     # 확장자 + 접미사 패턴
+  - "**/controllers/**"      # 디렉토리 패턴
+---
+```
+
+### 패턴 작성 가이드
+
+| 전략 | 패턴 예시 | 적합한 상황 |
+|---|---|---|
+| **파일명 접미사** | `**/*.service.ts` | NestJS 등 명명 규칙이 있는 프레임워크 |
+| **파일명 포함** | `**/*service*.go` | Go 등 접미사 규칙이 없는 언어 |
+| **디렉토리 기반** | `**/services/**` | 디렉토리로 분류하는 프로젝트 |
+| **복합** | `["**/*.service.ts", "**/services/**"]` | 혼용 프로젝트 |
+
+### 모노레포에서의 paths
+
+모노레포에서는 패키지별 prefix를 추가합니다:
+
+```yaml
+---
+paths:
+  - "packages/api/**/*handler*.ts"
+  - "apps/web/**/components/**"
+---
+```
+
+---
+
+## 4. 규칙 파일 템플릿
+
+### 표준 구조
+
+모든 규칙 파일은 다음 구조를 따릅니다:
+
+```markdown
+---
+paths:
+  - "<glob pattern>"
+---
+
+# <레이어명> Convention
+
+> 한 줄 요약
+
+## 원칙
+
+1. **원칙 1**: 설명
+2. **원칙 2**: 설명
+
+## DO
+
+- 구체적인 좋은 예시 (코드 포함)
+
+## DON'T
+
+- 구체적인 나쁜 예시 (코드 포함)
+
+## 체크리스트
+
+- [ ] 확인 항목 1
+- [ ] 확인 항목 2
+```
+
+### DO/DON'T 예시 (레이어별)
+
+#### Handler / Controller
+
+```markdown
+## DO
+
+- HTTP 파싱과 응답 변환만 담당
+- 에러를 적절한 HTTP 상태 코드로 매핑
+- 입력 유효성 검사는 DTO/스키마에 위임
+
+## DON'T
+
+- 비즈니스 로직을 핸들러에 직접 구현
+- 데이터베이스를 직접 호출
+- 다른 핸들러를 호출
+```
+
+#### Service
+
+```markdown
+## DO
+
+- 인터페이스를 먼저 정의하고 구현
+- 생성자 주입으로 의존성 받기
+- 트랜잭션 경계를 서비스 레이어에서 관리
+
+## DON'T
+
+- HTTP 요청/응답 객체에 의존
+- 구체 구현에 직접 의존 (DIP 위반)
+- 하나의 서비스에 5개 이상 메서드 (SRP 위반 가능성)
+```
+
+#### Repository
+
+```markdown
+## DO
+
+- 데이터 접근 로직만 캡슐화
+- 쿼리를 메서드로 표현 (FindByID, ListByStatus 등)
+- 인터페이스로 정의하여 mock 가능하게
+
+## DON'T
+
+- 비즈니스 로직을 리포지토리에 구현
+- SQL/쿼리를 서비스 레이어에 노출
+- 여러 테이블을 조인하는 복잡한 로직 (서비스로 분리)
+```
+
+---
+
+## 5. Gap 분석 모드
+
+기존 `.claude/rules/` 파일이 있을 때 gap 분석을 수행합니다.
+
+### 분석 기준
+
+1. **누락된 레이어**: 코드베이스에 해당 레이어가 존재하지만 규칙이 없는 경우
+2. **paths 미설정**: 규칙 파일에 `paths:` frontmatter가 없어 항상 로드되는 경우
+3. **과도한 범위**: `paths:` 패턴이 너무 넓어 불필요하게 자주 로드되는 경우
+4. **언어 미지원**: 모노레포에서 특정 언어의 규칙이 누락된 경우
+
+---
+
+## 6. 다중 언어/프레임워크 레포 전략
+
+### Prefix 전략
+
+2개 이상의 언어/프레임워크가 혼용된 레포에서는 prefix로 구분합니다:
+
+```
+.claude/rules/
+├── go-handler.md          # Go 핸들러 규칙
+├── go-service.md          # Go 서비스 규칙
+├── ts-controller.md       # TypeScript 컨트롤러 규칙
+├── ts-service.md          # TypeScript 서비스 규칙
+├── react-component.md     # React 컴포넌트 규칙
+└── testing.md             # 공통 테스트 규칙 (언어 무관)
+```
+
+### 공통 규칙 vs 언어별 규칙
+
+- **공통**: `module-boundary.md`, `error-handling.md`, `testing.md`
+- **언어별**: prefix를 붙여 분리 (`go-`, `ts-`, `py-`, `rs-`)


### PR DESCRIPTION
## Summary

- Add `/scaffold-rules` slash command that analyzes a codebase and auto-generates `.claude/rules/` structure with paths-based Lazy Context Injection
- Implements 3-step workflow: analyze (detect language/framework/architecture) -> propose (HITL confirmation) -> generate (rule files with DO/DON'T examples)
- Supports multi-language repos with prefix strategy, gap analysis for existing rules, and monorepo-aware paths patterns

## New Files

| File | Role | Description |
|------|------|-------------|
| `commands/scaffold-rules.md` | Controller | Slash command entry point, delegates to sub-agents |
| `agents/codebase-analyzer.md` | Service | Detects tech stack, directory patterns, samples file naming |
| `agents/rules-generator.md` | Service | Generates rule files with project-specific DO/DON'T examples |
| `skills/convention-architect/SKILL.md` | Domain | Layer mapping knowledge, paths strategies, rule templates |

## Test plan

- [ ] Run `/scaffold-rules` on a NestJS project — verify controller/service/repository rules are proposed
- [ ] Run `/scaffold-rules` on a Go project — verify go-handler/go-service rules with `**/*handler*.go` paths
- [ ] Run `/scaffold-rules --gap-only` on a project with existing `.claude/rules/` — verify only missing rules are proposed
- [ ] Run `/scaffold-rules` on a monorepo — verify prefix strategy and package-scoped paths
- [ ] Verify all generated rule files contain `paths:` frontmatter (Lazy Context Injection)
- [ ] Run `make validate` — confirm no new failures

Closes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)