### PR TITLE
fix(autodev): remove unused imports causing CI failures

### DIFF
--- a/plugins/autodev/cli/src/cli/hitl.rs
+++ b/plugins/autodev/cli/src/cli/hitl.rs
@@ -301,7 +301,6 @@ fn record_hitl_decision(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::models::*;
     use crate::core::repository::*;
 
     fn setup_test_db() -> (tempfile::TempDir, Database) {

--- a/plugins/autodev/cli/src/core/dependency.rs
+++ b/plugins/autodev/cli/src/core/dependency.rs
@@ -315,7 +315,7 @@ mod tests {
     use super::*;
     use crate::core::models::SpecStatus;
     use crate::core::phase::TaskKind;
-    use crate::core::queue_item::testing::{test_issue, test_repo};
+    use crate::core::queue_item::testing::test_repo;
     use crate::core::queue_item::QueueItem;
 
     #[test]


### PR DESCRIPTION
## Summary
- Remove unused `use crate::core::models::*` import in `src/cli/hitl.rs` test module (redundant with top-level glob import)
- Remove unused `test_issue` from import in `src/core/dependency.rs` test module

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes with no warnings
- [x] `cargo test` — all 738+ tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)