### PR TITLE
feat(github-autopilot): add analyze-issue command for issue analysis and labeling

### DIFF
--- a/plugins/github-autopilot/.claude-plugin/plugin.json
+++ b/plugins/github-autopilot/.claude-plugin/plugin.json
@@ -7,7 +7,8 @@
     "./agents/pr-merger.md",
     "./agents/ci-failure-analyzer.md",
     "./agents/qa-test-writer.md",
-    "./agents/issue-dependency-analyzer.md"
+    "./agents/issue-dependency-analyzer.md",
+    "./agents/issue-analyzer.md"
   ],
   "author": {
     "name": "kys0213"
@@ -19,7 +20,8 @@
     "./commands/ci-watch.md",
     "./commands/qa-boost.md",
     "./commands/autopilot.md",
-    "./commands/setup.md"
+    "./commands/setup.md",
+    "./commands/analyze-issue.md"
   ],
   "description": "CronCreate 기반 자율 개발 루프 - gap 탐지, issue 구현, PR 머지, CI 감시, QA 보강",
   "name": "github-autopilot",

--- a/plugins/github-autopilot/agents/issue-analyzer.md
+++ b/plugins/github-autopilot/agents/issue-analyzer.md
@@ -1,0 +1,82 @@
+---
+description: (내부용) GitHub 이슈를 분석하여 autopilot 구현 가능성을 판단하고, 분석 코멘트를 작성하는 에이전트
+model: sonnet
+tools: ["Read", "Glob", "Grep", "Bash"]
+---
+
+# Issue Analyzer
+
+GitHub 이슈의 내용을 분석하고, 코드베이스와 매핑하여 autopilot으로 자동 구현 가능한지 판단합니다.
+
+## 입력
+
+프롬프트로 전달받는 정보:
+- issue_number: 이슈 번호
+- issue_title: 이슈 제목
+- issue_body: 이슈 본문
+
+## 프로세스
+
+### Phase 1: 요구사항 분석
+
+이슈 본문에서 다음을 추출합니다:
+
+- **구현 항목**: 구체적으로 무엇을 만들어야 하는가
+- **수용 기준**: 어떤 조건을 만족해야 완료인가
+- **명확성 평가**: 모호한 부분이 있는가
+
+### Phase 2: 코드베이스 매핑
+
+1. **관련 파일 탐색**: 이슈에서 언급된 모듈/기능과 관련된 코드 검색
+2. **영향 범위 파악**: 변경이 필요한 파일과 영향받는 의존성 식별
+3. **기존 패턴 확인**: 유사한 기능이 어떻게 구현되어 있는지 파악
+
+### Phase 3: 판정
+
+다음 세 가지 중 하나로 판정합니다:
+
+| 판정 | 기준 |
+|------|------|
+| `ready` | 요구사항이 명확하고, 코드베이스에서 변경 지점이 특정되며, 단일 이슈로 구현 가능 |
+| `needs-clarification` | 요구사항이 모호하거나, 구현 방향이 여러 가지로 해석 가능 |
+| `too-complex` | 변경 범위가 넓어 단일 이슈로 처리하기 어려움 (분할 필요) |
+
+## 출력
+
+JSON 형식으로 출력합니다:
+
+### ready 판정
+
+```json
+{
+  "verdict": "ready",
+  "issue_number": 42,
+  "comment": "## Autopilot 분석 결과\n\n### 판정: ✅ Ready\n\n### 요구사항 정리\n\n- [추출된 구현 항목들]\n\n### 영향 범위\n\n- [관련 파일 목록과 변경 필요 사항]\n\n### 구현 가이드\n\n- [기존 패턴 기반 구현 방향]\n- [주의할 사이드이펙트]"
+}
+```
+
+### needs-clarification 판정
+
+```json
+{
+  "verdict": "needs-clarification",
+  "issue_number": 42,
+  "comment": "## Autopilot 분석 결과\n\n### 판정: ❓ Needs Clarification\n\n### 모호한 부분\n\n- [질문 사항들]\n\n### 명확해지면 구현 가능한 범위\n\n- [현재 파악 가능한 범위]"
+}
+```
+
+### too-complex 판정
+
+```json
+{
+  "verdict": "too-complex",
+  "issue_number": 42,
+  "comment": "## Autopilot 분석 결과\n\n### 판정: 🔀 Too Complex (분할 권장)\n\n### 분석\n\n- [복잡도 사유]\n\n### 분할 제안\n\n1. [하위 이슈 1 제안]\n2. [하위 이슈 2 제안]\n..."
+}
+```
+
+## 주의사항
+
+- 파일 내용 읽기는 이 에이전트 내에서 수행 (MainAgent context 보호)
+- 코드를 수정하지 않는다 (읽기 전용 분석)
+- comment 필드의 마크다운은 GitHub 코멘트로 직접 사용됨

--- a/plugins/github-autopilot/agents/issue-implementer.md
+++ b/plugins/github-autopilot/agents/issue-implementer.md
@@ -14,13 +14,14 @@ tools: ["Read", "Glob", "Grep", "Bash", "Write", "Edit"]
 - issue_number: 이슈 번호
 - issue_title: 이슈 제목
 - issue_body: 이슈 본문 (요구사항, 영향 범위, 구현 가이드)
+- issue_comments: 이슈 코멘트 (analyze-issue의 분석 결과 포함 — 영향 범위, 구현 가이드 참조)
 - draft_branch: 작업할 draft 브랜치명
 
 ## 프로세스
 
 ### Phase 1: 분석
 
-1. **이슈 요구사항 정리**: body에서 구현 항목, 수용 기준 추출
+1. **이슈 요구사항 정리**: body와 comments에서 구현 항목, 수용 기준 추출 (comments의 "Autopilot 분석 결과" 섹션에 영향 범위와 구현 가이드가 포함되어 있을 수 있음)
 2. **코드베이스 파악**:
    - 영향 범위의 파일/모듈 읽기
    - 관련 인터페이스, 타입 정의 확인

--- a/plugins/github-autopilot/commands/analyze-issue.md
+++ b/plugins/github-autopilot/commands/analyze-issue.md
@@ -1,0 +1,121 @@
+---
+description: "GitHub 이슈를 분석하여 autopilot 구현 가능 여부를 판단하고 autopilot:ready 라벨을 추가합니다"
+argument-hint: "<issue-numbers: #42 #43, 42 43, ...>"
+allowed-tools: ["Bash", "Read", "Agent"]
+---
+
+# Analyze Issue
+
+GitHub 이슈를 분석하여 autopilot으로 자동 구현 가능한지 판단합니다. 가능하면 `autopilot:ready` 라벨을 추가하고, 분석 결과를 코멘트로 남깁니다.
+
+## 사용법
+
+```bash
+/github-autopilot:analyze-issue 42          # 단일 이슈
+/github-autopilot:analyze-issue 42 43 44    # 복수 이슈
+/github-autopilot:analyze-issue #42 #43     # # 접두사 허용
+```
+
+## Context
+
+- 설정 파일: !`cat github-autopilot.local.md 2>/dev/null | head -20 || echo "설정 파일 없음 - 기본값 사용"`
+- 현재 브랜치: !`git branch --show-current`
+
+## 작업 프로세스
+
+### Step 1: 인자 파싱
+
+`$ARGUMENTS`에서 이슈 번호를 추출합니다.
+- `#` 접두사 제거
+- 숫자만 추출하여 목록 생성
+- 이슈 번호가 없으면 에러 메시지 출력 후 종료
+
+### Step 2: 최신 상태 동기화
+
+```bash
+git fetch origin
+```
+
+### Step 3: 설정 로딩
+
+`github-autopilot.local.md`에서 설정을 읽습니다.
+- `label_prefix`: 라벨 접두사 (기본값: `"autopilot:"`)
+
+### Step 4: 이슈 조회
+
+각 이슈의 정보를 조회합니다:
+
+```bash
+gh issue view ${ISSUE_NUMBER} --json number,title,body,labels,state
+```
+
+- 존재하지 않는 이슈는 스킵하고 경고 출력
+- 이미 `{label_prefix}ready` 또는 `{label_prefix}wip` 라벨이 붙은 이슈는 스킵
+- closed 상태 이슈는 스킵
+
+### Step 5: 분석 (Agent)
+
+이슈가 3개 이하이면 순차, 4개 이상이면 병렬로 issue-analyzer 에이전트를 호출합니다.
+
+각 이슈에 대해 전달:
+- issue_number
+- issue_title
+- issue_body
+
+**3개 이하**: 순차 호출 (background=false)
+**4개 이상**: 병렬 호출 (background=true)
+
+### Step 6: 결과 처리
+
+각 이슈의 판정 결과에 따라 처리합니다:
+
+#### ready 판정
+
+```bash
+# 분석 코멘트 추가
+gh issue comment ${ISSUE_NUMBER} --body "${ANALYSIS_COMMENT}"
+
+# autopilot:ready 라벨 추가
+gh issue edit ${ISSUE_NUMBER} --add-label "{label_prefix}ready"
+```
+
+#### needs-clarification 판정
+
+```bash
+# 질문 코멘트 추가
+gh issue comment ${ISSUE_NUMBER} --body "${ANALYSIS_COMMENT}"
+```
+
+라벨은 추가하지 않습니다.
+
+#### too-complex 판정
+
+```bash
+# 분할 제안 코멘트 추가
+gh issue comment ${ISSUE_NUMBER} --body "${ANALYSIS_COMMENT}"
+```
+
+라벨은 추가하지 않습니다.
+
+### Step 7: 결과 보고
+
+```
+## Analyze Issue 결과
+
+| Issue | Title | 판정 |
+|-------|-------|------|
+| #42 | Add user auth | ✅ Ready |
+| #43 | Redesign entire system | 🔀 Too Complex |
+| #44 | Fix something | ❓ Needs Clarification |
+
+- Ready: 1건 (autopilot:ready 라벨 추가됨)
+- Needs Clarification: 1건
+- Too Complex: 1건
+- Skipped: 0건
+```
+
+## 주의사항
+
+- 토큰 최적화: MainAgent는 이슈 메타데이터만 조회, 코드 분석은 Agent에 위임
+- 이미 autopilot 파이프라인에 있는 이슈는 중복 처리하지 않음
+- 분석 코멘트는 이력으로 남아 issue-implementer가 참조할 수 있음

--- a/plugins/github-autopilot/commands/build-issues.md
+++ b/plugins/github-autopilot/commands/build-issues.md
@@ -42,7 +42,7 @@ git fetch origin
 gh issue list \
   --label "{label_prefix}ready" \
   --state open \
-  --json number,title,body,labels \
+  --json number,title,body,labels,comments \
   --limit 20
 ```
 
@@ -81,6 +81,7 @@ gh issue edit ${ISSUE_NUMBER} --add-label "{label_prefix}wip"
 - issue_number
 - issue_title
 - issue_body (요구사항, 영향 범위, 구현 가이드)
+- issue_comments (분석 코멘트 포함, analyze-issue에서 생성된 구현 가이드 참조)
 - draft_branch: `draft/issue-{number}`
 
 ### Step 7: 결과 수집


### PR DESCRIPTION
## Summary

- `analyze-issue` 슬래시 커맨드 추가 — 이슈를 분석하여 autopilot 구현 가능 여부를 판정하고 `autopilot:ready` 라벨 추가
- `issue-analyzer` 에이전트 추가 (sonnet) — 코드베이스 매핑 기반 readiness 판정 (ready / needs-clarification / too-complex)
- 분석 결과를 이슈 body 수정 대신 **코멘트**로 기록하여 원본 보존 + 이력 추적
- `build-issues` → `issue-implementer` 경로에 comments 전달 추가 — 구현 시 분석 코멘트 참조 가능

## 변경 파일

| 파일 | 변경 |
|------|------|
| `commands/analyze-issue.md` | 신규 — 슬래시 커맨드 (Controller) |
| `agents/issue-analyzer.md` | 신규 — 분석 에이전트 (Service) |
| `.claude-plugin/plugin.json` | 커맨드/에이전트 등록 |
| `commands/build-issues.md` | comments 필드 조회 및 전달 추가 |
| `agents/issue-implementer.md` | comments 입력 및 참조 로직 추가 |

## Test plan

- [ ] `/github-autopilot:analyze-issue 42` 실행 시 이슈 분석 및 코멘트 생성 확인
- [ ] ready 판정 시 `autopilot:ready` 라벨 추가 확인
- [ ] needs-clarification / too-complex 판정 시 라벨 미추가 확인
- [ ] 이미 `autopilot:ready` 라벨이 있는 이슈 스킵 확인
- [ ] `/github-autopilot:build-issues` 실행 시 comments가 issue-implementer에 전달되는지 확인

https://claude.ai/code/session_015MjgJiVGkkuKxKc56c6z2e