### PR TITLE
fix(github-autopilot): register draft-branch skill in agents

### DIFF
--- a/plugins/github-autopilot/agents/branch-promoter.md
+++ b/plugins/github-autopilot/agents/branch-promoter.md
@@ -2,6 +2,7 @@
 description: (내부용) draft 브랜치를 feature 브랜치로 승격하고 PR을 생성하는 에이전트
 model: haiku
 tools: ["Bash"]
+skills: ["draft-branch"]
 ---
 
 # Branch Promoter

--- a/plugins/github-autopilot/agents/issue-implementer.md
+++ b/plugins/github-autopilot/agents/issue-implementer.md
@@ -2,6 +2,7 @@
 description: (내부용) GitHub issue의 요구사항을 분석하고 draft 브랜치에서 코드를 구현하는 에이전트
 model: opus
 tools: ["Read", "Glob", "Grep", "Bash", "Write", "Edit"]
+skills: ["draft-branch"]
 ---
 
 # Issue Implementer

--- a/plugins/github-autopilot/agents/qa-test-writer.md
+++ b/plugins/github-autopilot/agents/qa-test-writer.md
@@ -2,6 +2,7 @@
 description: (내부용) 코드 변경사항을 분석하여 누락된 테스트를 작성하는 QA 전문 에이전트
 model: sonnet
 tools: ["Read", "Glob", "Grep", "Bash", "Write", "Edit"]
+skills: ["draft-branch"]
 ---
 
 # QA Test Writer


### PR DESCRIPTION
## Summary

- `issue-implementer`, `branch-promoter`, `qa-test-writer` 에이전트 frontmatter에 `skills: ["draft-branch"]` 추가
- `workflow-guide` 플러그인의 에이전트들은 skills 필드로 스킬을 참조하고 있었으나, `github-autopilot` 에이전트들은 누락되어 있었음
- 이 변경으로 draft branch 라이프사이클 스킬이 에이전트 컨텍스트에 정상 로드됨

## Test plan

- [ ] issue-implementer 에이전트 실행 시 draft-branch 스킬 컨텍스트가 로드되는지 확인
- [ ] branch-promoter 에이전트 실행 시 draft-branch 스킬 컨텍스트가 로드되는지 확인
- [ ] qa-test-writer 에이전트 실행 시 draft-branch 스킬 컨텍스트가 로드되는지 확인

https://claude.ai/code/session_01KJYxFbyugH7NSdy5zNpdum