### PR TITLE
feat(hooks): add auth and freshness validation hooks (#545)

### DIFF
--- a/.claude/hooks/branch-freshness-check.sh
+++ b/.claude/hooks/branch-freshness-check.sh
@@ -16,7 +16,7 @@ PROMPT=$(echo "$INPUT" | jq -r '.tool_input.prompt // empty')
 
 # Check if prompt contains autopilot keywords
 AUTOPILOT_KEYWORDS="gap-detect|gap-watch|qa-boost|build-issues|ci-watch|autopilot"
-if ! echo "$PROMPT" | grep -qiE "$AUTOPILOT_KEYWORDS"; then
+if ! printf '%s' "$PROMPT" | grep -qiE "$AUTOPILOT_KEYWORDS"; then
   exit 0
 fi
 

--- a/.claude/hooks/gh-auth-check.sh
+++ b/.claude/hooks/gh-auth-check.sh
@@ -1,19 +1,25 @@
 #!/bin/bash
 # PreToolUse hook: Verify GitHub CLI authentication before Agent/Bash tool use
-# - Agent tool: always check gh auth
 # - Bash tool: only check if command contains "gh " or "git push"
+# - Agent tool: only check if prompt contains GitHub-related keywords
 # exit 0 = allow (no feedback)
 # exit 2 = block (stderr message shown to Claude)
 
 INPUT=$(cat)
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
-COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 
-# For Bash tool: only check commands that need GitHub auth
 if [[ "$TOOL_NAME" == "Bash" ]]; then
+  COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
   if [[ "$COMMAND" != *"gh "* && "$COMMAND" != *"git push"* ]]; then
     exit 0
   fi
+elif [[ "$TOOL_NAME" == "Agent" ]]; then
+  PROMPT=$(echo "$INPUT" | jq -r '.tool_input.prompt // empty')
+  if ! printf '%s' "$PROMPT" | grep -qiE 'gh |github|git push|autopilot|gap-detect|gap-watch|qa-boost|build-issues|ci-watch|merge-pr'; then
+    exit 0
+  fi
+else
+  exit 0
 fi
 
 # Verify gh CLI authentication

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,6 +18,11 @@
             "type": "command",
             "command": "git-utils guard commit --project-dir=${CLAUDE_PROJECT_DIR:-.} --create-branch-script='git-utils branch' --default-branch=main",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "bash ./.claude/hooks/gh-auth-check.sh",
+            "timeout": 10
           }
         ]
       },
@@ -33,16 +38,6 @@
             "type": "command",
             "command": "bash ./.claude/hooks/branch-freshness-check.sh",
             "timeout": 15
-          }
-        ]
-      },
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash ./.claude/hooks/gh-auth-check.sh",
-            "timeout": 10
           }
         ]
       }


### PR DESCRIPTION
## Summary

- Add `gh-auth-check.sh` PreToolUse hook that verifies GitHub CLI authentication before Agent tool use and Bash commands containing `gh` or `git push`
- Add `branch-freshness-check.sh` PreToolUse hook that blocks autopilot Agent tasks (gap-detect, gap-watch, qa-boost, etc.) when the branch is more than 10 commits behind `origin/main`
- Update `.claude/settings.json` with two new PreToolUse entries: Agent matcher (both hooks) and Bash matcher (auth check only)

## Test plan

- [ ] Verify `gh-auth-check.sh` exits 0 when authenticated and running a non-gh Bash command
- [ ] Verify `gh-auth-check.sh` exits 2 when not authenticated and running `gh` or `git push`
- [ ] Verify `branch-freshness-check.sh` exits 0 for non-Agent tools
- [ ] Verify `branch-freshness-check.sh` exits 0 for Agent prompts without autopilot keywords
- [ ] Verify `branch-freshness-check.sh` exits 2 when >10 commits behind with autopilot keyword
- [ ] Verify existing PreToolUse hooks (Write|Edit guard, Bash guard) still work

Closes #545

🤖 Generated with [Claude Code](https://claude.com/claude-code)