### PR TITLE
fix(github-autopilot): add CronDelete to idle handler to stop infinite cron loops

### DIFF
--- a/plugins/github-autopilot/commands/autopilot.md
+++ b/plugins/github-autopilot/commands/autopilot.md
@@ -1,7 +1,7 @@
 ---
 description: "autopilot 루프를 설정된 인터벌로 모두 시작합니다 (기본 6개 + test_watch)"
 argument-hint: ""
-allowed-tools: ["Read", "CronCreate"]
+allowed-tools: ["Read", "CronCreate", "CronDelete", "CronList"]
 ---
 
 # Autopilot

--- a/plugins/github-autopilot/commands/build-issues.md
+++ b/plugins/github-autopilot/commands/build-issues.md
@@ -1,7 +1,7 @@
 ---
 description: "autopilot 이슈를 분석하고 draft 브랜치에서 구현 후 PR을 생성합니다"
 argument-hint: "[interval: 15m, 30m, ...]"
-allowed-tools: ["Bash", "Read", "Agent", "CronCreate"]
+allowed-tools: ["Bash", "Read", "Agent", "CronCreate", "CronDelete", "CronList"]
 ---
 
 # Build Issues
@@ -46,7 +46,12 @@ git fetch origin
 bash ${CLAUDE_PLUGIN_ROOT}/scripts/check-idle.sh "{label_prefix}"
 ```
 
-- **exit 0 (idle)**: `notification` 설정이 있으면 "autopilot 파이프라인 완료 — build-issues cycle 중단" 알림 발송. CronCreate를 등록하지 않고 종료.
+- **exit 0 (idle)**: 기존 cron을 정리한 뒤 종료합니다.
+  1. CronList로 현재 등록된 cron 목록을 조회
+  2. `build-issues`가 포함된 cron job을 찾아 CronDelete로 삭제
+  3. `notification` 설정이 있으면 "autopilot 파이프라인 완료 — build-issues cycle 중단" 알림 발송
+  4. CronCreate를 등록하지 않고 종료
+- **exit 2 (error)**: 스크립트 실행 환경 오류. 에러 메시지를 출력하고 이번 cycle을 skip합니다 (CronCreate는 등록하여 다음 cycle에서 재시도).
 - **exit 1 (active)**: Step 4부터 정상 진행.
 
 ### Step 4: Skip 이슈 알림

--- a/plugins/github-autopilot/commands/ci-watch.md
+++ b/plugins/github-autopilot/commands/ci-watch.md
@@ -1,7 +1,7 @@
 ---
 description: "CI 실패를 모니터링하고 분석하여 GitHub issue를 생성합니다"
 argument-hint: "[interval: 20m, 1h, ...]"
-allowed-tools: ["Bash", "Read", "Agent", "CronCreate"]
+allowed-tools: ["Bash", "Read", "Agent", "CronCreate", "CronDelete", "CronList"]
 ---
 
 # CI Watch
@@ -41,7 +41,12 @@ git fetch origin
 bash ${CLAUDE_PLUGIN_ROOT}/scripts/check-idle.sh "{label_prefix}"
 ```
 
-- **exit 0 (idle)**: `notification` 설정이 있으면 "autopilot 파이프라인 완료 — ci-watch cycle 중단" 알림 발송. CronCreate를 등록하지 않고 종료.
+- **exit 0 (idle)**: 기존 cron을 정리한 뒤 종료합니다.
+  1. CronList로 현재 등록된 cron 목록을 조회
+  2. `ci-watch`가 포함된 cron job을 찾아 CronDelete로 삭제
+  3. `notification` 설정이 있으면 "autopilot 파이프라인 완료 — ci-watch cycle 중단" 알림 발송
+  4. CronCreate를 등록하지 않고 종료
+- **exit 2 (error)**: 스크립트 실행 환경 오류. 에러 메시지를 출력하고 이번 cycle을 skip합니다 (CronCreate는 등록하여 다음 cycle에서 재시도).
 - **exit 1 (active)**: Step 3부터 정상 진행.
 
 ### Step 3: CI 실패 목록 조회

--- a/plugins/github-autopilot/commands/gap-watch.md
+++ b/plugins/github-autopilot/commands/gap-watch.md
@@ -1,7 +1,7 @@
 ---
 description: "스펙 기반 구현 갭을 탐지하여 GitHub issue를 자동 생성합니다"
 argument-hint: "[interval: 30m, 1h, ...]"
-allowed-tools: ["Bash", "Glob", "Read", "Agent", "CronCreate"]
+allowed-tools: ["Bash", "Glob", "Read", "Agent", "CronCreate", "CronDelete", "CronList"]
 ---
 
 # Gap Watch
@@ -41,7 +41,12 @@ git pull --rebase origin $(git branch --show-current) 2>/dev/null || true
 bash ${CLAUDE_PLUGIN_ROOT}/scripts/check-idle.sh "{label_prefix}"
 ```
 
-- **exit 0 (idle)**: `notification` 설정이 있으면 "autopilot 파이프라인 완료 — gap-watch cycle 중단" 알림 발송. CronCreate를 등록하지 않고 종료.
+- **exit 0 (idle)**: 기존 cron을 정리한 뒤 종료합니다.
+  1. CronList로 현재 등록된 cron 목록을 조회
+  2. `gap-watch`가 포함된 cron job을 찾아 CronDelete로 삭제
+  3. `notification` 설정이 있으면 "autopilot 파이프라인 완료 — gap-watch cycle 중단" 알림 발송
+  4. CronCreate를 등록하지 않고 종료
+- **exit 2 (error)**: 스크립트 실행 환경 오류. 에러 메시지를 출력하고 이번 cycle을 skip합니다 (CronCreate는 등록하여 다음 cycle에서 재시도).
 - **exit 1 (active)**: Step 3부터 정상 진행.
 
 ### Step 3: 설정 로딩

--- a/plugins/github-autopilot/commands/merge-prs.md
+++ b/plugins/github-autopilot/commands/merge-prs.md
@@ -1,7 +1,7 @@
 ---
 description: "autopilot PR을 CI/리뷰 상태 확인 후 머지합니다"
 argument-hint: "[interval: 10m, 30m, ...]"
-allowed-tools: ["Bash", "Read", "Agent", "CronCreate"]
+allowed-tools: ["Bash", "Read", "Agent", "CronCreate", "CronDelete", "CronList"]
 ---
 
 # Merge PRs
@@ -39,7 +39,12 @@ git fetch origin
 bash ${CLAUDE_PLUGIN_ROOT}/scripts/check-idle.sh "{label_prefix}"
 ```
 
-- **exit 0 (idle)**: `notification` 설정이 있으면 "autopilot 파이프라인 완료 — merge-prs cycle 중단" 알림 발송. CronCreate를 등록하지 않고 종료.
+- **exit 0 (idle)**: 기존 cron을 정리한 뒤 종료합니다.
+  1. CronList로 현재 등록된 cron 목록을 조회
+  2. `merge-prs`가 포함된 cron job을 찾아 CronDelete로 삭제
+  3. `notification` 설정이 있으면 "autopilot 파이프라인 완료 — merge-prs cycle 중단" 알림 발송
+  4. CronCreate를 등록하지 않고 종료
+- **exit 2 (error)**: 스크립트 실행 환경 오류. 에러 메시지를 출력하고 이번 cycle을 skip합니다 (CronCreate는 등록하여 다음 cycle에서 재시도).
 - **exit 1 (active)**: Step 3부터 정상 진행.
 
 ### Step 3: PR 목록 조회

--- a/plugins/github-autopilot/commands/qa-boost.md
+++ b/plugins/github-autopilot/commands/qa-boost.md
@@ -1,7 +1,7 @@
 ---
 description: "최근 변경사항의 테스트 커버리지를 분석하고 누락된 테스트를 이슈로 발행합니다"
 argument-hint: "[commit_hash] [interval: 1h, 2h, ...]"
-allowed-tools: ["Bash", "Glob", "Read", "Grep", "CronCreate"]
+allowed-tools: ["Bash", "Glob", "Read", "Grep", "CronCreate", "CronDelete", "CronList"]
 ---
 
 # QA Boost
@@ -45,7 +45,12 @@ git pull --rebase origin $(git branch --show-current) 2>/dev/null || true
 bash ${CLAUDE_PLUGIN_ROOT}/scripts/check-idle.sh "{label_prefix}"
 ```
 
-- **exit 0 (idle)**: `notification` 설정이 있으면 "autopilot 파이프라인 완료 — qa-boost cycle 중단" 알림 발송. CronCreate를 등록하지 않고 종료.
+- **exit 0 (idle)**: 기존 cron을 정리한 뒤 종료합니다.
+  1. CronList로 현재 등록된 cron 목록을 조회
+  2. `qa-boost`가 포함된 cron job을 찾아 CronDelete로 삭제
+  3. `notification` 설정이 있으면 "autopilot 파이프라인 완료 — qa-boost cycle 중단" 알림 발송
+  4. CronCreate를 등록하지 않고 종료
+- **exit 2 (error)**: 스크립트 실행 환경 오류. 에러 메시지를 출력하고 이번 cycle을 skip합니다 (CronCreate는 등록하여 다음 cycle에서 재시도).
 - **exit 1 (active)**: Step 3부터 정상 진행.
 
 ### Step 3: 변경사항 수집

--- a/plugins/github-autopilot/commands/test-watch.md
+++ b/plugins/github-autopilot/commands/test-watch.md
@@ -1,7 +1,7 @@
 ---
 description: "설정된 테스트 스위트를 주기적으로 실행하고 실패 시 이슈를 생성합니다"
 argument-hint: "<test_name> [interval]"
-allowed-tools: ["Bash", "Read", "Agent", "CronCreate"]
+allowed-tools: ["Bash", "Read", "Agent", "CronCreate", "CronDelete", "CronList"]
 ---
 
 # Test Watch
@@ -42,7 +42,12 @@ git fetch origin
 bash ${CLAUDE_PLUGIN_ROOT}/scripts/check-idle.sh "{label_prefix}"
 ```
 
-- **exit 0 (idle)**: `notification` 설정이 있으면 "autopilot 파이프라인 완료 — test-watch cycle 중단" 알림 발송. CronCreate를 등록하지 않고 종료.
+- **exit 0 (idle)**: 기존 cron을 정리한 뒤 종료합니다.
+  1. CronList로 현재 등록된 cron 목록을 조회
+  2. `test-watch`가 포함된 cron job을 찾아 CronDelete로 삭제
+  3. `notification` 설정이 있으면 "autopilot 파이프라인 완료 — test-watch cycle 중단" 알림 발송
+  4. CronCreate를 등록하지 않고 종료
+- **exit 2 (error)**: 스크립트 실행 환경 오류. 에러 메시지를 출력하고 이번 cycle을 skip합니다 (CronCreate는 등록하여 다음 cycle에서 재시도).
 - **exit 1 (active)**: Step 3부터 정상 진행.
 
 ### Step 3: 테스트 스위트 로딩


### PR DESCRIPTION
## Summary
- 7개 autopilot loop 커맨드의 `allowed-tools`에 `CronDelete`, `CronList` 추가
- Step 2.5 idle 핸들러에 기존 cron 삭제 로직 추가 (CronList → CronDelete)
- `check-idle.sh` exit 2 (환경 오류) 핸들링 추가

## Test plan
- [ ] interval 모드로 loop 커맨드 실행 후 idle 상태 진입 시 cron이 자동 삭제되는지 확인
- [ ] check-idle.sh 누락/실패 시 exit 2 핸들링이 정상 동작하는지 확인
- [ ] 기존 정상 흐름(active 상태)에서 cron이 유지되는지 확인

Closes #552, Closes #551, Closes #546

🤖 Generated with [Claude Code](https://claude.com/claude-code)