### PR TITLE
fix(ci-watch): filter out stale CI failures from old feature branches

### DIFF
--- a/plugins/github-autopilot/commands/ci-watch.md
+++ b/plugins/github-autopilot/commands/ci-watch.md
@@ -53,17 +53,47 @@ autopilot issue close-resolved --label-prefix "{label_prefix}"
 
 ### Step 2.7: 오래된/머지된 PR 필터링
 
-Step 2의 결과에서 다음 조건에 해당하는 실패를 **제외**합니다:
+Step 2의 결과에서 다음 조건에 해당하는 실패를 **제외**합니다.
 
-1. **머지/종료된 PR의 실패 제거**: `event`가 `pull_request`인 run에 대해 해당 `headBranch`의 PR 상태를 확인합니다:
-   ```bash
-   gh pr list --head "${HEAD_BRANCH}" --state merged --json number --limit 1
-   gh pr list --head "${HEAD_BRANCH}" --state closed --json number --limit 1
-   ```
-   - PR이 MERGED 또는 CLOSED → **skip** (이미 종료된 PR의 과거 실패)
-   - PR이 OPEN 또는 PR 없음 → 계속 진행
+설정 예시 (`github-autopilot.local.md`):
+```yaml
+ci_watch:
+  max_age: "24h"             # non-default branch 실패 최대 수집 기간 (기본: 24h)
+  default_branch_max_age: "7d"  # default branch 실패 최대 수집 기간 (기본: 7d)
+  branch_filter: "autopilot"   # "autopilot" | "all" (기본: autopilot)
+```
 
-2. **7일 이상 된 실패 제거**: `createdAt`이 현재 시각 기준 7일 이전이면 **skip** (단, default branch의 실패는 예외 — 만성 CI 실패를 놓치지 않기 위함)
+#### 2.7.1 브랜치 필터 (branch_filter)
+
+`headBranch`가 다음 중 하나에 해당하지 않으면 **skip**:
+
+- **default branch** (main, master, develop 등 `gh repo view --json defaultBranchRef`로 확인)
+- **autopilot 브랜치**: `feature/issue-*` 또는 `draft/issue-*` 패턴에 매칭
+- **설정의 `branch_filter`가 `"all"`**: 모든 브랜치를 허용
+
+`branch_filter`가 `"autopilot"` (기본값)이면 위 조건에 해당하지 않는 브랜치(일반 feature 브랜치 등)는 skip합니다.
+
+#### 2.7.2 머지/종료된 PR의 실패 제거
+
+`event`가 `pull_request`인 run에 대해 해당 `headBranch`의 PR 상태를 확인합니다:
+```bash
+gh pr list --head "${HEAD_BRANCH}" --state merged --json number --limit 1
+gh pr list --head "${HEAD_BRANCH}" --state closed --json number --limit 1
+```
+- PR이 MERGED 또는 CLOSED → **skip** (이미 종료된 PR의 과거 실패)
+- PR이 OPEN 또는 PR 없음 → 계속 진행
+
+#### 2.7.3 시간 기반 필터 (max_age)
+
+`createdAt`이 현재 시각 기준으로 다음 기간을 초과하면 **skip**:
+
+| 브랜치 종류 | 기본 max_age | 설정 키 |
+|---|---|---|
+| default branch | `7d` | `ci_watch.default_branch_max_age` |
+| non-default branch | `24h` | `ci_watch.max_age` |
+
+- default branch의 실패는 `default_branch_max_age` (기본 7일) 이내만 수집 — 만성 CI 실패를 놓치지 않기 위함
+- non-default branch의 실패는 `max_age` (기본 24시간) 이내만 수집 — 오래된 feature 브랜치 실패 방지
 
 필터링 후 남은 실패만 Step 3로 진행합니다.
 


### PR DESCRIPTION
## Summary
- Add `branch_filter` setting (default: `autopilot`) to skip CI failures from non-default, non-autopilot branches
- Differentiate `max_age` by branch type: 24h for non-default branches, 7d for default branch (both configurable)
- Restructure Step 2.7 into clear sub-steps (2.7.1 branch filter, 2.7.2 merged/closed PR filter, 2.7.3 time-based filter)

Closes #587

## Test plan
- [ ] Verify ci-watch skips failures from arbitrary feature branches (e.g. `feat/my-feature`) when `branch_filter` is `autopilot`
- [ ] Verify ci-watch still collects failures from `feature/issue-*` and `draft/issue-*` branches
- [ ] Verify ci-watch still collects default branch failures up to 7 days
- [ ] Verify `branch_filter: "all"` disables the branch filter
- [ ] Verify custom `max_age` and `default_branch_max_age` settings are respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)