### PR TITLE
feat(build-issues): add max_parallel_agents setting

### DIFF
--- a/plugins/github-autopilot/commands/build-issues.md
+++ b/plugins/github-autopilot/commands/build-issues.md
@@ -33,7 +33,7 @@ autopilot 라벨이 붙은 GitHub 이슈를 가져와 의존성을 분석하고,
 
 - `max_parallel_agents`: 동시에 실행할 최대 에이전트 수 (기본값: 3)
 
-### Step 2.5: Pipeline Idle Check
+### Step 3: Pipeline Idle Check
 
 ```bash
 autopilot pipeline idle --label-prefix "{label_prefix}"
@@ -41,9 +41,9 @@ autopilot pipeline idle --label-prefix "{label_prefix}"
 
 - **exit 0 (idle)**: `notification` 설정이 있으면 "autopilot 파이프라인 완료 — build-issues cycle 중단" 알림 발송 후 종료합니다.
 - **exit 2 (error)**: 스크립트 실행 환경 오류. 에러 메시지를 출력하고 이번 cycle을 skip합니다.
-- **exit 1 (active)**: Step 3부터 정상 진행
+- **exit 1 (active)**: Step 4부터 정상 진행
 
-### Step 3: Skip 이슈 알림
+### Step 4: Skip 이슈 알림
 
 설정에서 `notification` 값을 확인합니다 (비어있으면 이 Step을 건너뜁니다).
 
@@ -73,7 +73,7 @@ gh issue list \
 gh issue comment ${ISSUE_NUMBER} --body "<!-- notified -->"
 ```
 
-### Step 4: Ready 이슈 조회
+### Step 5: Ready 이슈 조회
 
 설정에서 label_prefix를 확인합니다 (기본값: `autopilot:`).
 
@@ -89,9 +89,9 @@ gh issue list \
 
 이슈가 없으면 "구현 대상 이슈 없음" 출력 후 종료.
 
-### Step 4.5: 코멘트 기반 재작업 감지
+### Step 5.5: 코멘트 기반 재작업 감지
 
-Step 4에서 제외된 이슈(ready 라벨 없음) 중, 코멘트에 재작업 요청이 포함된 이슈를 탐색합니다.
+Step 5에서 제외된 이슈(ready 라벨 없음) 중, 코멘트에 재작업 요청이 포함된 이슈를 탐색합니다.
 
 ```bash
 gh issue list \
@@ -117,9 +117,9 @@ gh issue list \
 
    <!-- autopilot:rework-detected -->"
    ```
-3. Step 4 결과 목록에 해당 이슈를 추가합니다.
+3. Step 5 결과 목록에 해당 이슈를 추가합니다.
 
-### Step 5: 의존성 분석 (Agent)
+### Step 6: 의존성 분석 (Agent)
 
 issue-dependency-analyzer 에이전트를 호출합니다 (background=false):
 
@@ -128,7 +128,7 @@ issue-dependency-analyzer 에이전트를 호출합니다 (background=false):
 
 결과: 배치 목록 (병렬 실행 가능한 이슈 그룹)
 
-### Step 6: WIP 라벨 추가
+### Step 7: WIP 라벨 추가
 
 현재 배치의 이슈들에 wip 라벨을 추가합니다 (중복 작업 방지):
 
@@ -136,7 +136,7 @@ issue-dependency-analyzer 에이전트를 호출합니다 (background=false):
 gh issue edit ${ISSUE_NUMBER} --add-label "{label_prefix}wip"
 ```
 
-### Step 7: 구현 (Agent Team)
+### Step 8: 구현 (Agent Team)
 
 첫 번째 배치(의존성 없는 이슈들)부터 순서대로 처리합니다.
 
@@ -158,12 +158,12 @@ gh issue edit ${ISSUE_NUMBER} --add-label "{label_prefix}wip"
 - issue_number
 - issue_title
 - issue_body (요구사항, 영향 범위, 구현 가이드)
-- **issue_comments**: Step 4에서 가져온 comments 배열 **전체**를 반드시 포함한다. 분석 코멘트, 재작업 요청, 추가 컨텍스트가 포함되어 있으므로 절대 생략하지 않는다
+- **issue_comments**: Step 5에서 가져온 comments 배열 **전체**를 반드시 포함한다. 분석 코멘트, 재작업 요청, 추가 컨텍스트가 포함되어 있으므로 절대 생략하지 않는다
 - draft_branch: `draft/issue-{number}`
 - base_branch: Step 1에서 결정한 base 브랜치
 - quality_gate_command: 설정에서 읽은 값 (비어있으면 자동 감지)
 
-### Step 8: 결과 수집
+### Step 9: 결과 수집
 
 모든 에이전트의 결과를 수집합니다.
 
@@ -174,7 +174,7 @@ gh issue edit ${ISSUE_NUMBER} --add-label "{label_prefix}wip"
 실패한 이슈:
 - wip 라벨 제거
 
-### Step 8.5: 에스컬레이션 체크
+### Step 9.5: 에스컬레이션 체크
 
 실패한 이슈 각각에 대해 연속 실패 횟수를 확인합니다.
 
@@ -224,7 +224,7 @@ gh issue view ${ISSUE_NUMBER} --json comments --jq '.comments[].body' | grep -o 
   ```
 - `{label_prefix}ready` 라벨 유지 (다음 cycle 재시도)
 
-### Step 9: 승격 (Agent Team)
+### Step 10: 승격 (Agent Team)
 
 성공한 각 이슈에 대해 branch-promoter 에이전트를 호출합니다:
 
@@ -236,14 +236,16 @@ gh issue view ${ISSUE_NUMBER} --json comments --jq '.comments[].body' | grep -o 
 - label_prefix
 - pr_type: "auto"
 
-성공한 이슈들을 Step 7과 동일한 `max_parallel_agents` 서브그룹 방식으로 실행합니다.
+성공한 이슈들을 Step 8과 동일한 `max_parallel_agents` 서브그룹 방식으로 실행합니다.
+- 이슈 수가 `max_parallel_agents` 이하: 순차 호출 (background=false)
+- 이슈 수가 `max_parallel_agents` 초과: 서브그룹 분할 후 병렬 실행
 
-### Step 10: 라벨 정리
+### Step 11: 라벨 정리
 
 - 승격 성공: `{label_prefix}wip` 제거, `{label_prefix}ready` 제거
 - 승격 실패: `{label_prefix}wip` 제거 (다음 cycle에서 재시도)
 
-### Step 11: 결과 보고
+### Step 12: 결과 보고
 
 ```
 ## Build Issues 결과

--- a/plugins/github-autopilot/commands/build-issues.md
+++ b/plugins/github-autopilot/commands/build-issues.md
@@ -236,10 +236,7 @@ gh issue view ${ISSUE_NUMBER} --json comments --jq '.comments[].body' | grep -o 
 - label_prefix
 - pr_type: "auto"
 
-성공한 이슈들을 `max_parallel_agents` 단위로 분할하여 순차 그룹으로 실행합니다:
-
-- 이슈 수가 `max_parallel_agents` 이하: 순차 호출
-- 이슈 수가 `max_parallel_agents` 초과: `max_parallel_agents` 크기의 서브그룹으로 분할하여 각 서브그룹을 병렬 실행 (background=true) → 완료 대기 → 다음 서브그룹 실행
+성공한 이슈들을 Step 7과 동일한 `max_parallel_agents` 서브그룹 방식으로 실행합니다.
 
 ### Step 10: 라벨 정리
 

--- a/plugins/github-autopilot/commands/build-issues.md
+++ b/plugins/github-autopilot/commands/build-issues.md
@@ -27,7 +27,13 @@ autopilot 라벨이 붙은 GitHub 이슈를 가져와 의존성을 분석하고,
 
 **branch-sync** 스킬의 절차를 수행합니다.
 
-### Step 2: Pipeline Idle Check
+### Step 2: 설정 로딩
+
+설정 파일(`github-autopilot.local.md`)에서 다음 값을 읽습니다:
+
+- `max_parallel_agents`: 동시에 실행할 최대 에이전트 수 (기본값: 3)
+
+### Step 2.5: Pipeline Idle Check
 
 ```bash
 autopilot pipeline idle --label-prefix "{label_prefix}"
@@ -134,7 +140,15 @@ gh issue edit ${ISSUE_NUMBER} --add-label "{label_prefix}wip"
 
 첫 번째 배치(의존성 없는 이슈들)부터 순서대로 처리합니다.
 
-각 배치 내 이슈들은 병렬로 구현합니다:
+각 배치 내 이슈들을 `max_parallel_agents` 단위로 분할하여 순차 그룹으로 실행합니다:
+
+- 배치 내 이슈가 `max_parallel_agents`보다 많으면:
+  1. 이슈를 `max_parallel_agents` 크기의 서브그룹으로 분할
+  2. 서브그룹 1 병렬 실행 → 완료 대기
+  3. 서브그룹 2 병렬 실행 → 완료 대기
+  4. ...반복
+- 예: `max_parallel_agents=3`, 배치 이슈 7개
+  → 그룹1: #1,#2,#3 (병렬) → 그룹2: #4,#5,#6 (병렬) → 그룹3: #7 (단독)
 
 각 이슈에 대해 issue-implementer 에이전트를 호출합니다:
 - `isolation: "worktree"` 로 독립 작업 공간 확보
@@ -222,8 +236,10 @@ gh issue view ${ISSUE_NUMBER} --json comments --jq '.comments[].body' | grep -o 
 - label_prefix
 - pr_type: "auto"
 
-**성공한 이슈 수가 3개 이하**: 순차 호출
-**4개 이상**: 병렬 호출 (background=true)
+성공한 이슈들을 `max_parallel_agents` 단위로 분할하여 순차 그룹으로 실행합니다:
+
+- 이슈 수가 `max_parallel_agents` 이하: 순차 호출
+- 이슈 수가 `max_parallel_agents` 초과: `max_parallel_agents` 크기의 서브그룹으로 분할하여 각 서브그룹을 병렬 실행 (background=true) → 완료 대기 → 다음 서브그룹 실행
 
 ### Step 10: 라벨 정리
 
@@ -241,6 +257,9 @@ gh issue view ${ISSUE_NUMBER} --json comments --jq '.comments[].body' | grep -o 
 ### 구현 대상
 - 대상 이슈: 5개
 - 배치: 3개 (batch 1: #42, #44 | batch 2: #43 | batch 3: #45)
+
+### 설정
+- max_parallel_agents: 3
 
 ### 구현
 - 성공: #42, #43, #44 (3건)

--- a/plugins/github-autopilot/skills/draft-branch/SKILL.md
+++ b/plugins/github-autopilot/skills/draft-branch/SKILL.md
@@ -29,6 +29,7 @@ default_intervals:                   # autopilot dispatcher 기본 인터벌
 notification: ""                     # skip 이슈 알림 방법 (자연어, 예: "Slack DM으로 @irene에게 알려줘")
 quality_gate_command: ""             # 커스텀 quality gate 명령어 (비어있으면 자동 감지)
 max_consecutive_failures: 3          # 연속 실패 허용 횟수, 초과 시 에스컬레이션
+max_parallel_agents: 3               # 동시에 실행할 최대 에이전트 수
 max_ci_fix_retries: 3                # CI fix 루프 최대 재시도 횟수
 test_watch: []                       # 테스트 스위트 정의 (아래 예시 참조)
 # test_watch:


### PR DESCRIPTION
## Summary
- 7개 agent 동시 launch 시 429 rate limit 실패 방지를 위해 `max_parallel_agents` 설정 추가 (기본값: 3)
- Step 7 (구현)과 Step 9 (승격) 모두 `max_parallel_agents` 단위의 서브그룹으로 분할하여 순차 실행
- 결과 보고(Step 11)에 사용된 설정값 표시

## Test plan
- [ ] `max_parallel_agents=3`으로 7개 이슈 배치 실행 시 3+3+1 그룹으로 분할되는지 확인
- [ ] `max_parallel_agents` 미설정 시 기본값 3 적용 확인
- [ ] 승격 단계에서도 동일한 서브그룹 분할 적용 확인
- [ ] 결과 보고에 `max_parallel_agents` 값 출력 확인

Closes #595

🤖 Generated with [Claude Code](https://claude.com/claude-code)