### PR TITLE
fix(github-autopilot): filter out test fixture specs from gap detection

### DIFF
--- a/plugins/github-autopilot/agents/gap-detector.md
+++ b/plugins/github-autopilot/agents/gap-detector.md
@@ -19,9 +19,7 @@ spec-kit의 3단계 분석 패턴(spec-parser → structure-mapper → gap-analy
 
 ### Phase 1: 스펙 파싱
 
-#### Step 0: 테스트 fixture 필터링
-
-전달받은 spec_files 각각에 대해 아래 조건에 해당하면 **skip**합니다:
+요구사항을 추출하기 전에, 전달받은 spec_files 각각에 대해 아래 조건에 해당하면 **skip**합니다:
 
 1. **테스트 디렉토리 경로**: 경로에 `tests/`, `test_fixtures/`, `benches/`가 포함된 파일
 2. **테스트 파일 패턴**: 파일명이 `*_test.*`, `*_spec.*`인 파일
@@ -34,11 +32,7 @@ skip된 파일은 리포트의 맨 앞에 다음 형식으로 기록합니다:
 - Filtered: test_fixtures/sample_spec.md (test directory)
 ```
 
-> 이 단계를 통해 `make_active_spec` 등 테스트용 fixture가 실제 요구사항으로 오인되는 것을 방지합니다.
-
-#### Step 1: 요구사항 추출
-
-각 스펙 파일을 읽고 구조화된 요구사항을 추출합니다:
+필터링을 통과한 각 스펙 파일을 읽고 구조화된 요구사항을 추출합니다:
 
 - **컴포넌트 목록**: 스펙에서 언급된 모듈/서비스/기능 단위
 - **요구사항**: 각 컴포넌트의 기능 요구사항 (명시적 + 암시적)

--- a/plugins/github-autopilot/agents/gap-detector.md
+++ b/plugins/github-autopilot/agents/gap-detector.md
@@ -19,6 +19,25 @@ spec-kit의 3단계 분석 패턴(spec-parser → structure-mapper → gap-analy
 
 ### Phase 1: 스펙 파싱
 
+#### Step 0: 테스트 fixture 필터링
+
+전달받은 spec_files 각각에 대해 아래 조건에 해당하면 **skip**합니다:
+
+1. **테스트 디렉토리 경로**: 경로에 `tests/`, `test_fixtures/`, `benches/`가 포함된 파일
+2. **테스트 파일 패턴**: 파일명이 `*_test.*`, `*_spec.*`인 파일
+3. **테스트 코드 내 fixture**: 파일 내용에 `#[cfg(test)]`, `mod tests {`, `#[test]`가 포함된 파일
+
+skip된 파일은 리포트의 맨 앞에 다음 형식으로 기록합니다:
+```
+## Filtered Files
+- Filtered: tests/gap_detection.rs (test fixture)
+- Filtered: test_fixtures/sample_spec.md (test directory)
+```
+
+> 이 단계를 통해 `make_active_spec` 등 테스트용 fixture가 실제 요구사항으로 오인되는 것을 방지합니다.
+
+#### Step 1: 요구사항 추출
+
 각 스펙 파일을 읽고 구조화된 요구사항을 추출합니다:
 
 - **컴포넌트 목록**: 스펙에서 언급된 모듈/서비스/기능 단위

--- a/plugins/github-autopilot/agents/gap-detector.md
+++ b/plugins/github-autopilot/agents/gap-detector.md
@@ -22,8 +22,8 @@ spec-kit의 3단계 분석 패턴(spec-parser → structure-mapper → gap-analy
 요구사항을 추출하기 전에, 전달받은 spec_files 각각에 대해 아래 조건에 해당하면 **skip**합니다:
 
 1. **테스트 디렉토리 경로**: 경로에 `tests/`, `test_fixtures/`, `benches/`가 포함된 파일
-2. **테스트 파일 패턴**: 파일명이 `*_test.*`, `*_spec.*`인 파일
-3. **테스트 코드 내 fixture**: 파일 내용에 `#[cfg(test)]`, `mod tests {`, `#[test]`가 포함된 파일
+2. **테스트 파일 패턴**: 파일명이 `*_test.*`, `*_spec.{rs,ts,js,go,py}`인 파일 (`.md` 파일은 제외 -- `auth_spec.md` 같은 정상 스펙 파일의 false negative 방지)
+3. **테스트 코드 내 fixture** (비-마크다운 파일에만 적용): 파일 내용에 `#[cfg(test)]`, `mod tests {`, `#[test]`가 포함된 파일. `.md` 파일은 코드 예시로 이러한 키워드를 포함할 수 있으므로 콘텐츠 체크를 적용하지 않음
 
 skip된 파일은 리포트의 맨 앞에 다음 형식으로 기록합니다:
 ```

--- a/plugins/github-autopilot/commands/gap-watch.md
+++ b/plugins/github-autopilot/commands/gap-watch.md
@@ -49,6 +49,12 @@ Glob으로 spec_paths에서 마크다운 파일을 수집합니다:
 - `spec/**/*.md`
 - `docs/spec/**/*.md`
 
+> **필터링 규칙**: spec_paths에 명시된 디렉토리에서만 스펙 파일을 수집합니다.
+> 다음 패턴에 해당하는 경로는 자동 제외합니다:
+> - 테스트 디렉토리: `tests/`, `test_fixtures/`, `benches/`
+> - 테스트 파일: `*_test.*`, `*_spec.*` (테스트 코드 자체)
+> - 인라인 fixture: `src/` 내부에서 `make_*_spec`, `mock_spec` 등으로 생성된 fixture는 실제 스펙이 아니므로 gap-detector가 Phase 1에서 추가 검증합니다.
+
 스펙 파일이 없으면 에러 메시지 출력 후 종료.
 
 ### Step 4: 갭 분석 (Agent)

--- a/plugins/github-autopilot/commands/gap-watch.md
+++ b/plugins/github-autopilot/commands/gap-watch.md
@@ -52,7 +52,7 @@ Glob으로 spec_paths에서 마크다운 파일을 수집합니다:
 > **필터링 규칙**: spec_paths에 명시된 디렉토리에서만 스펙 파일을 수집합니다.
 > 다음 패턴에 해당하는 경로는 자동 제외합니다:
 > - 테스트 디렉토리: `tests/`, `test_fixtures/`, `benches/`
-> - 테스트 파일: `*_test.*`, `*_spec.*` (테스트 코드 자체)
+> - 테스트 파일: `*_test.*`, `*_spec.{rs,ts,js,go,py}` (테스트 코드 자체, `.md`는 제외)
 > - 인라인 fixture: gap-detector가 Phase 1에서 추가 검증합니다.
 
 스펙 파일이 없으면 에러 메시지 출력 후 종료.

--- a/plugins/github-autopilot/commands/gap-watch.md
+++ b/plugins/github-autopilot/commands/gap-watch.md
@@ -53,7 +53,7 @@ Glob으로 spec_paths에서 마크다운 파일을 수집합니다:
 > 다음 패턴에 해당하는 경로는 자동 제외합니다:
 > - 테스트 디렉토리: `tests/`, `test_fixtures/`, `benches/`
 > - 테스트 파일: `*_test.*`, `*_spec.*` (테스트 코드 자체)
-> - 인라인 fixture: `src/` 내부에서 `make_*_spec`, `mock_spec` 등으로 생성된 fixture는 실제 스펙이 아니므로 gap-detector가 Phase 1에서 추가 검증합니다.
+> - 인라인 fixture: gap-detector가 Phase 1에서 추가 검증합니다.
 
 스펙 파일이 없으면 에러 메시지 출력 후 종료.
 


### PR DESCRIPTION
## Summary
- gap-watch의 Step 3에 테스트 디렉토리/파일 패턴 필터링 규칙 추가 (`tests/`, `test_fixtures/`, `benches/`, `*_test.*`, `*_spec.*`)
- gap-detector의 Phase 1에 Step 0 (테스트 fixture 필터링) 추가 — `#[cfg(test)]`, `mod tests {`, `#[test]` 포함 파일을 skip하고 리포트에 기록
- `make_active_spec` 등 테스트용 fixture가 실제 요구사항으로 오인되어 false positive 이슈가 생성되는 문제 해결

Closes #593

## Test plan
- [ ] gap-watch 실행 시 `tests/` 디렉토리 내 스펙 파일이 수집되지 않는지 확인
- [ ] gap-detector가 `#[cfg(test)]` 포함 파일을 skip하고 Filtered Files 섹션에 기록하는지 확인
- [ ] 정상 스펙 파일은 기존과 동일하게 분석되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)