### PR TITLE
fix(github-autopilot): auto-cleanup worktrees after PR merge

### DIFF
--- a/plugins/github-autopilot/cli/Cargo.lock
+++ b/plugins/github-autopilot/cli/Cargo.lock
@@ -60,7 +60,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "autopilot"
-version = "0.11.4"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/plugins/github-autopilot/cli/src/cmd/mod.rs
+++ b/plugins/github-autopilot/cli/src/cmd/mod.rs
@@ -5,6 +5,7 @@ pub mod pipeline;
 pub mod preflight;
 pub mod simhash;
 pub mod watch;
+pub mod worktree;
 
 use clap::{Args, Parser, Subcommand};
 
@@ -40,6 +41,11 @@ pub enum Commands {
     Preflight(PreflightArgs),
     /// Watch for push, CI, and issue events (event-driven autopilot)
     Watch(watch::WatchArgs),
+    /// Worktree lifecycle management
+    Worktree {
+        #[command(subcommand)]
+        command: WorktreeCommands,
+    },
 }
 
 #[derive(Subcommand)]
@@ -94,6 +100,16 @@ pub enum IssueCommands {
     },
     /// Search for similar issues by fingerprint and rank by simhash distance
     SearchSimilar(issue::SearchSimilarArgs),
+}
+
+#[derive(Subcommand)]
+pub enum WorktreeCommands {
+    /// Clean up worktree and local branch after PR merge
+    Cleanup {
+        /// Branch name to clean up
+        #[arg(long)]
+        branch: String,
+    },
 }
 
 #[derive(Subcommand)]

--- a/plugins/github-autopilot/cli/src/cmd/worktree.rs
+++ b/plugins/github-autopilot/cli/src/cmd/worktree.rs
@@ -1,0 +1,53 @@
+use crate::git::GitOps;
+use anyhow::Result;
+
+pub struct WorktreeService {
+    git: Box<dyn GitOps>,
+}
+
+pub struct CleanupResult {
+    pub worktree_removed: bool,
+    pub branch_deleted: bool,
+}
+
+impl WorktreeService {
+    pub fn new(git: Box<dyn GitOps>) -> Self {
+        Self { git }
+    }
+
+    /// CLI entry point: clean up and print summary.
+    pub fn cleanup(&self, branch: &str) -> Result<i32> {
+        let result = self.cleanup_branch(branch)?;
+
+        if result.worktree_removed {
+            eprintln!("Removed worktree for branch '{branch}'");
+        }
+        if result.branch_deleted {
+            eprintln!("Deleted local branch '{branch}'");
+        }
+
+        Ok(0)
+    }
+
+    /// Clean up the worktree associated with the given branch, delete the local
+    /// branch, and prune stale worktree metadata.
+    pub fn cleanup_branch(&self, branch: &str) -> Result<CleanupResult> {
+        let entries = self.git.worktree_list()?;
+        let mut worktree_removed = false;
+
+        for entry in &entries {
+            if entry.branch.as_deref() == Some(branch) {
+                worktree_removed = self.git.worktree_remove(&entry.path).is_ok();
+                break;
+            }
+        }
+
+        let branch_deleted = self.git.branch_delete(branch).is_ok();
+        let _ = self.git.worktree_prune();
+
+        Ok(CleanupResult {
+            worktree_removed,
+            branch_deleted,
+        })
+    }
+}

--- a/plugins/github-autopilot/cli/src/git.rs
+++ b/plugins/github-autopilot/cli/src/git.rs
@@ -26,6 +26,25 @@ pub trait GitOps: Send + Sync {
 
     /// Count commits in a range (from..to).
     fn rev_list_count(&self, from: &str, to: &str) -> Result<u64>;
+
+    /// List all worktrees and their associated branches.
+    fn worktree_list(&self) -> Result<Vec<WorktreeEntry>>;
+
+    /// Force-remove a worktree at the given path.
+    fn worktree_remove(&self, path: &str) -> Result<()>;
+
+    /// Prune stale worktree metadata.
+    fn worktree_prune(&self) -> Result<()>;
+
+    /// Delete a local branch.
+    fn branch_delete(&self, name: &str) -> Result<()>;
+}
+
+/// A worktree entry from `git worktree list --porcelain`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorktreeEntry {
+    pub path: String,
+    pub branch: Option<String>,
 }
 
 /// Real implementation that shells out to `git`.
@@ -80,6 +99,52 @@ impl GitOps for RealGit {
         let range = format!("{from}..{to}");
         let output = run_git(&["rev-list", "--count", &range])?;
         output.parse().context("failed to parse rev-list count")
+    }
+
+    fn worktree_list(&self) -> Result<Vec<WorktreeEntry>> {
+        let output = run_git(&["worktree", "list", "--porcelain"])?;
+        let mut entries = Vec::new();
+        let mut current_path: Option<String> = None;
+        let mut current_branch: Option<String> = None;
+
+        for line in output.lines() {
+            if let Some(path) = line.strip_prefix("worktree ") {
+                // Flush previous entry
+                if let Some(p) = current_path.take() {
+                    entries.push(WorktreeEntry {
+                        path: p,
+                        branch: current_branch.take(),
+                    });
+                }
+                current_path = Some(path.to_string());
+                current_branch = None;
+            } else if let Some(branch) = line.strip_prefix("branch refs/heads/") {
+                current_branch = Some(branch.to_string());
+            }
+        }
+        // Flush last entry
+        if let Some(p) = current_path {
+            entries.push(WorktreeEntry {
+                path: p,
+                branch: current_branch,
+            });
+        }
+        Ok(entries)
+    }
+
+    fn worktree_remove(&self, path: &str) -> Result<()> {
+        run_git(&["worktree", "remove", path, "--force"])?;
+        Ok(())
+    }
+
+    fn worktree_prune(&self) -> Result<()> {
+        run_git(&["worktree", "prune"])?;
+        Ok(())
+    }
+
+    fn branch_delete(&self, name: &str) -> Result<()> {
+        run_git(&["branch", "-D", name])?;
+        Ok(())
     }
 }
 

--- a/plugins/github-autopilot/cli/src/git.rs
+++ b/plugins/github-autopilot/cli/src/git.rs
@@ -103,33 +103,7 @@ impl GitOps for RealGit {
 
     fn worktree_list(&self) -> Result<Vec<WorktreeEntry>> {
         let output = run_git(&["worktree", "list", "--porcelain"])?;
-        let mut entries = Vec::new();
-        let mut current_path: Option<String> = None;
-        let mut current_branch: Option<String> = None;
-
-        for line in output.lines() {
-            if let Some(path) = line.strip_prefix("worktree ") {
-                // Flush previous entry
-                if let Some(p) = current_path.take() {
-                    entries.push(WorktreeEntry {
-                        path: p,
-                        branch: current_branch.take(),
-                    });
-                }
-                current_path = Some(path.to_string());
-                current_branch = None;
-            } else if let Some(branch) = line.strip_prefix("branch refs/heads/") {
-                current_branch = Some(branch.to_string());
-            }
-        }
-        // Flush last entry
-        if let Some(p) = current_path {
-            entries.push(WorktreeEntry {
-                path: p,
-                branch: current_branch,
-            });
-        }
-        Ok(entries)
+        Ok(parse_worktree_porcelain(&output))
     }
 
     fn worktree_remove(&self, path: &str) -> Result<()> {
@@ -165,4 +139,136 @@ fn run_git(args: &[&str]) -> Result<String> {
 /// Convenience: create a boxed real client.
 pub fn real() -> Box<dyn GitOps> {
     Box::new(RealGit)
+}
+
+/// Parse `git worktree list --porcelain` output into structured entries.
+pub fn parse_worktree_porcelain(output: &str) -> Vec<WorktreeEntry> {
+    let mut entries = Vec::new();
+    let mut current_path: Option<String> = None;
+    let mut current_branch: Option<String> = None;
+
+    for line in output.lines() {
+        if let Some(path) = line.strip_prefix("worktree ") {
+            if let Some(p) = current_path.take() {
+                entries.push(WorktreeEntry {
+                    path: p,
+                    branch: current_branch.take(),
+                });
+            }
+            current_path = Some(path.to_string());
+            current_branch = None;
+        } else if let Some(branch) = line.strip_prefix("branch refs/heads/") {
+            current_branch = Some(branch.to_string());
+        }
+    }
+    if let Some(p) = current_path {
+        entries.push(WorktreeEntry {
+            path: p,
+            branch: current_branch,
+        });
+    }
+    entries
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_single_main_worktree() {
+        let output = "\
+worktree /repo
+HEAD abc1234
+branch refs/heads/main
+";
+        let entries = parse_worktree_porcelain(output);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].path, "/repo");
+        assert_eq!(entries[0].branch.as_deref(), Some("main"));
+    }
+
+    #[test]
+    fn parse_multiple_worktrees() {
+        let output = "\
+worktree /repo
+HEAD abc1234
+branch refs/heads/main
+
+worktree /repo/.claude/worktrees/agent-1
+HEAD def5678
+branch refs/heads/feature/issue-42
+
+worktree /repo/.claude/worktrees/agent-2
+HEAD 9ab0123
+branch refs/heads/draft/issue-99
+";
+        let entries = parse_worktree_porcelain(output);
+        assert_eq!(entries.len(), 3);
+        assert_eq!(entries[1].path, "/repo/.claude/worktrees/agent-1");
+        assert_eq!(entries[1].branch.as_deref(), Some("feature/issue-42"));
+        assert_eq!(entries[2].branch.as_deref(), Some("draft/issue-99"));
+    }
+
+    #[test]
+    fn parse_detached_head_worktree() {
+        let output = "\
+worktree /repo
+HEAD abc1234
+branch refs/heads/main
+
+worktree /repo/.claude/worktrees/agent-1
+HEAD def5678
+detached
+";
+        let entries = parse_worktree_porcelain(output);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[1].path, "/repo/.claude/worktrees/agent-1");
+        assert!(entries[1].branch.is_none());
+    }
+
+    #[test]
+    fn parse_bare_worktree() {
+        let output = "\
+worktree /repo.git
+bare
+";
+        let entries = parse_worktree_porcelain(output);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].path, "/repo.git");
+        assert!(entries[0].branch.is_none());
+    }
+
+    #[test]
+    fn parse_empty_output() {
+        let entries = parse_worktree_porcelain("");
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn parse_path_with_spaces() {
+        let output = "\
+worktree /home/user/my project/repo
+HEAD abc1234
+branch refs/heads/main
+";
+        let entries = parse_worktree_porcelain(output);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].path, "/home/user/my project/repo");
+        assert_eq!(entries[0].branch.as_deref(), Some("main"));
+    }
+
+    #[test]
+    fn parse_nested_branch_name() {
+        let output = "\
+worktree /repo/.claude/worktrees/agent-1
+HEAD abc1234
+branch refs/heads/feat/autopilot/deep-nested
+";
+        let entries = parse_worktree_porcelain(output);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(
+            entries[0].branch.as_deref(),
+            Some("feat/autopilot/deep-nested")
+        );
+    }
 }

--- a/plugins/github-autopilot/cli/src/main.rs
+++ b/plugins/github-autopilot/cli/src/main.rs
@@ -1,5 +1,5 @@
 use autopilot::cmd::{
-    CheckCommands, Cli, Commands, IssueCommands, PipelineCommands, PreflightArgs,
+    CheckCommands, Cli, Commands, IssueCommands, PipelineCommands, PreflightArgs, WorktreeCommands,
 };
 use autopilot::{cmd, fs, gh, git, github};
 use clap::Parser;
@@ -69,6 +69,13 @@ fn main() {
                 &args.label_prefix,
                 args.poll_sec,
             )
+        }
+        Commands::Worktree { command } => {
+            let git_client = git::real();
+            let svc = cmd::worktree::WorktreeService::new(git_client);
+            match command {
+                WorktreeCommands::Cleanup { branch } => svc.cleanup(&branch),
+            }
         }
         Commands::Preflight(PreflightArgs { config, repo_root }) => {
             let client = gh::real();

--- a/plugins/github-autopilot/cli/tests/mock_git.rs
+++ b/plugins/github-autopilot/cli/tests/mock_git.rs
@@ -1,8 +1,9 @@
 #![allow(dead_code)]
 
 use anyhow::{bail, Result};
-use autopilot::git::GitOps;
+use autopilot::git::{GitOps, WorktreeEntry};
 use std::collections::{HashMap, HashSet};
+use std::sync::Mutex;
 
 /// A mock GitOps that returns predefined responses.
 pub struct MockGit {
@@ -13,6 +14,13 @@ pub struct MockGit {
     repo_name: String,
     refs: HashMap<String, String>,
     rev_list_counts: HashMap<String, u64>,
+    worktrees: Vec<WorktreeEntry>,
+    removed_worktrees: Mutex<Vec<String>>,
+    deleted_branches: Mutex<Vec<String>>,
+    pruned: Mutex<bool>,
+    fail_worktree_list: bool,
+    fail_worktree_remove: bool,
+    fail_branch_delete: bool,
 }
 
 impl MockGit {
@@ -25,7 +33,49 @@ impl MockGit {
             repo_name: "repo".to_string(),
             refs: HashMap::new(),
             rev_list_counts: HashMap::new(),
+            worktrees: Vec::new(),
+            removed_worktrees: Mutex::new(Vec::new()),
+            deleted_branches: Mutex::new(Vec::new()),
+            pruned: Mutex::new(false),
+            fail_worktree_list: false,
+            fail_worktree_remove: false,
+            fail_branch_delete: false,
         }
+    }
+
+    pub fn with_fail_worktree_list(mut self) -> Self {
+        self.fail_worktree_list = true;
+        self
+    }
+
+    pub fn with_fail_worktree_remove(mut self) -> Self {
+        self.fail_worktree_remove = true;
+        self
+    }
+
+    pub fn with_fail_branch_delete(mut self) -> Self {
+        self.fail_branch_delete = true;
+        self
+    }
+
+    pub fn with_worktree(mut self, path: &str, branch: Option<&str>) -> Self {
+        self.worktrees.push(WorktreeEntry {
+            path: path.to_string(),
+            branch: branch.map(String::from),
+        });
+        self
+    }
+
+    pub fn removed_worktrees(&self) -> Vec<String> {
+        self.removed_worktrees.lock().unwrap().clone()
+    }
+
+    pub fn deleted_branches(&self) -> Vec<String> {
+        self.deleted_branches.lock().unwrap().clone()
+    }
+
+    pub fn was_pruned(&self) -> bool {
+        *self.pruned.lock().unwrap()
     }
 
     pub fn with_head(mut self, hash: &str) -> Self {
@@ -107,5 +157,36 @@ impl GitOps for MockGit {
     fn rev_list_count(&self, from: &str, to: &str) -> Result<u64> {
         let key = format!("{from}..{to}");
         Ok(self.rev_list_counts.get(&key).copied().unwrap_or(0))
+    }
+
+    fn worktree_list(&self) -> Result<Vec<WorktreeEntry>> {
+        if self.fail_worktree_list {
+            bail!("worktree list failed");
+        }
+        Ok(self.worktrees.clone())
+    }
+
+    fn worktree_remove(&self, path: &str) -> Result<()> {
+        if self.fail_worktree_remove {
+            bail!("worktree remove failed");
+        }
+        self.removed_worktrees
+            .lock()
+            .unwrap()
+            .push(path.to_string());
+        Ok(())
+    }
+
+    fn worktree_prune(&self) -> Result<()> {
+        *self.pruned.lock().unwrap() = true;
+        Ok(())
+    }
+
+    fn branch_delete(&self, name: &str) -> Result<()> {
+        if self.fail_branch_delete {
+            bail!("branch delete failed");
+        }
+        self.deleted_branches.lock().unwrap().push(name.to_string());
+        Ok(())
     }
 }

--- a/plugins/github-autopilot/cli/tests/worktree_tests.rs
+++ b/plugins/github-autopilot/cli/tests/worktree_tests.rs
@@ -1,0 +1,86 @@
+mod mock_git;
+
+use autopilot::cmd::worktree::WorktreeService;
+use mock_git::MockGit;
+
+#[test]
+fn cleanup_removes_worktree_and_branch_when_found() {
+    let git = MockGit::new()
+        .with_worktree("/repo/.claude/worktrees/agent-1", Some("feature/issue-42"))
+        .with_worktree("/repo/.claude/worktrees/agent-2", Some("draft/issue-99"));
+
+    let svc = WorktreeService::new(Box::new(git));
+    let result = svc.cleanup_branch("feature/issue-42").unwrap();
+
+    assert!(result.worktree_removed);
+    assert!(result.branch_deleted);
+}
+
+#[test]
+fn cleanup_skips_remove_when_branch_not_found() {
+    let git =
+        MockGit::new().with_worktree("/repo/.claude/worktrees/agent-1", Some("feature/issue-42"));
+
+    let svc = WorktreeService::new(Box::new(git));
+    let result = svc.cleanup_branch("feature/issue-99").unwrap();
+
+    assert!(!result.worktree_removed);
+    assert!(result.branch_deleted);
+}
+
+#[test]
+fn cleanup_handles_detached_worktree() {
+    let git = MockGit::new().with_worktree("/repo/.claude/worktrees/agent-1", None);
+
+    let svc = WorktreeService::new(Box::new(git));
+    let result = svc.cleanup_branch("feature/issue-42").unwrap();
+
+    assert!(!result.worktree_removed);
+}
+
+#[test]
+fn cleanup_handles_empty_worktree_list() {
+    let git = MockGit::new();
+
+    let svc = WorktreeService::new(Box::new(git));
+    let result = svc.cleanup_branch("feature/issue-42").unwrap();
+
+    assert!(!result.worktree_removed);
+    assert!(result.branch_deleted);
+}
+
+#[test]
+fn cleanup_reports_false_when_worktree_remove_fails() {
+    let git = MockGit::new()
+        .with_worktree("/repo/.claude/worktrees/agent-1", Some("feature/issue-42"))
+        .with_fail_worktree_remove();
+
+    let svc = WorktreeService::new(Box::new(git));
+    let result = svc.cleanup_branch("feature/issue-42").unwrap();
+
+    assert!(!result.worktree_removed);
+    assert!(result.branch_deleted);
+}
+
+#[test]
+fn cleanup_reports_false_when_branch_delete_fails() {
+    let git = MockGit::new()
+        .with_worktree("/repo/.claude/worktrees/agent-1", Some("feature/issue-42"))
+        .with_fail_branch_delete();
+
+    let svc = WorktreeService::new(Box::new(git));
+    let result = svc.cleanup_branch("feature/issue-42").unwrap();
+
+    assert!(result.worktree_removed);
+    assert!(!result.branch_deleted);
+}
+
+#[test]
+fn cleanup_propagates_worktree_list_error() {
+    let git = MockGit::new().with_fail_worktree_list();
+
+    let svc = WorktreeService::new(Box::new(git));
+    let result = svc.cleanup_branch("feature/issue-42");
+
+    assert!(result.is_err());
+}

--- a/plugins/github-autopilot/commands/merge-prs.md
+++ b/plugins/github-autopilot/commands/merge-prs.md
@@ -93,6 +93,15 @@ for ISSUE_NUMBER in $ISSUE_NUMBERS; do
 done
 ```
 
+머지 성공 후 **로컬 worktree 자동 정리**:
+
+머지된 브랜치에 연결된 worktree가 남아있으면 정리합니다. worktree가 남아있으면 `git branch -D`가 실패하고 `cannot delete branch used by worktree` 경고가 반복됩니다.
+
+```bash
+HEAD_BRANCH=$(gh pr view ${PR_NUMBER} --json headRefName --jq '.headRefName')
+autopilot worktree cleanup --branch "${HEAD_BRANCH}"
+```
+
 머지 실패 시 문제 PR로 재분류.
 
 ### Step 5: 문제 PR 해결 (Agent Team)


### PR DESCRIPTION
## Summary
- Add `autopilot worktree cleanup --branch <branch>` CLI command for deterministic worktree cleanup
- merge-prs Step 4 now calls this after successful squash merge
- Prevents `cannot delete branch used by worktree` warnings and disk accumulation

## Changes
- **`src/git.rs`**: Add `worktree_list`, `worktree_remove`, `worktree_prune`, `branch_delete` to `GitOps` trait + `WorktreeEntry` struct
- **`src/cmd/worktree.rs`**: `WorktreeService` with `cleanup_branch()` returning `CleanupResult`
- **`src/cmd/mod.rs` + `main.rs`**: Wire `Worktree::Cleanup` subcommand
- **`tests/worktree_tests.rs`**: 7 black-box tests (happy path, not found, detached, empty, remove fail, delete fail, list error)
- **`commands/merge-prs.md`**: Replace inline bash with CLI call

## Test plan
- [x] `cargo test` — 101 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

Closes #614

🤖 Generated with [Claude Code](https://claude.com/claude-code)