### PR TITLE
feat(github-autopilot): add issue overlap detection via simhash similarity

### DIFF
--- a/plugins/github-autopilot/cli/Cargo.lock
+++ b/plugins/github-autopilot/cli/Cargo.lock
@@ -60,7 +60,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "autopilot"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/plugins/github-autopilot/cli/src/cmd/issue.rs
+++ b/plugins/github-autopilot/cli/src/cmd/issue.rs
@@ -302,40 +302,36 @@ pub fn detect_overlap(args: &DetectOverlapArgs) -> Result<i32> {
 
 /// Pure function for testability: compute pairwise overlaps.
 pub fn compute_overlaps(issues: &[Value], threshold: u32) -> Value {
-    // Compute simhash for each issue from title + body
-    let hashed: Vec<(u64, &Value)> = issues
+    let hashes: Vec<u64> = issues
         .iter()
         .map(|issue| {
             let title = issue["title"].as_str().unwrap_or("");
             let body = issue["body"].as_str().unwrap_or("");
             let text = format!("{title}\n{body}");
             let tokens = super::simhash::tokenize_weighted(&text);
-            let hash = super::simhash::weighted_simhash(&tokens);
-            (hash, issue)
+            super::simhash::weighted_simhash(&tokens)
         })
         .collect();
 
     let mut review_required: Vec<Value> = Vec::new();
 
-    for i in 0..hashed.len() {
-        for j in (i + 1)..hashed.len() {
-            let distance = super::simhash::hamming_distance(hashed[i].0, hashed[j].0);
+    for i in 0..hashes.len() {
+        for j in (i + 1)..hashes.len() {
+            let distance = super::simhash::hamming_distance(hashes[i], hashes[j]);
             if distance <= threshold {
-                let num_a = hashed[i].1["number"].as_u64().unwrap_or(0);
-                let num_b = hashed[j].1["number"].as_u64().unwrap_or(0);
                 review_required.push(serde_json::json!({
-                    "pair": [num_a, num_b],
+                    "pair": [issues[i]["number"], issues[j]["number"]],
                     "distance": distance,
                     "issues": [
                         {
-                            "number": num_a,
-                            "title": hashed[i].1["title"],
-                            "body": hashed[i].1["body"],
+                            "number": issues[i]["number"],
+                            "title": issues[i]["title"],
+                            "body": issues[i]["body"],
                         },
                         {
-                            "number": num_b,
-                            "title": hashed[j].1["title"],
-                            "body": hashed[j].1["body"],
+                            "number": issues[j]["number"],
+                            "title": issues[j]["title"],
+                            "body": issues[j]["body"],
                         }
                     ]
                 }));
@@ -343,7 +339,6 @@ pub fn compute_overlaps(issues: &[Value], threshold: u32) -> Value {
         }
     }
 
-    // Sort by distance ascending (most similar first)
     review_required.sort_by_key(|r| r["distance"].as_u64().unwrap_or(64));
 
     let total = issues.len();

--- a/plugins/github-autopilot/cli/src/cmd/issue.rs
+++ b/plugins/github-autopilot/cli/src/cmd/issue.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 use clap::Args;
 use serde_json::Value;
+use std::io::Read as _;
 
 use crate::gh::GhOps;
 
@@ -276,6 +277,85 @@ fn extract_issue_number(url: &str) -> u64 {
         .unwrap_or(0)
 }
 
+#[derive(Args)]
+pub struct DetectOverlapArgs {
+    /// Hamming distance threshold — pairs at or below this are flagged
+    #[arg(long, default_value = "15")]
+    pub threshold: u32,
+}
+
+/// Detect overlapping issues by simhash text similarity.
+/// Reads issues from stdin as JSON array: `[{"number":N,"title":"...","body":"..."}]`
+/// Outputs pairs whose hamming distance is at or below the threshold.
+pub fn detect_overlap(args: &DetectOverlapArgs) -> Result<i32> {
+    let mut input = String::new();
+    std::io::stdin()
+        .read_to_string(&mut input)
+        .context("failed to read stdin")?;
+
+    let issues: Vec<Value> = serde_json::from_str(&input).context("failed to parse stdin JSON")?;
+
+    let result = compute_overlaps(&issues, args.threshold);
+    println!("{result}");
+    Ok(0)
+}
+
+/// Pure function for testability: compute pairwise overlaps.
+pub fn compute_overlaps(issues: &[Value], threshold: u32) -> Value {
+    // Compute simhash for each issue from title + body
+    let hashed: Vec<(u64, &Value)> = issues
+        .iter()
+        .map(|issue| {
+            let title = issue["title"].as_str().unwrap_or("");
+            let body = issue["body"].as_str().unwrap_or("");
+            let text = format!("{title}\n{body}");
+            let tokens = super::simhash::tokenize_weighted(&text);
+            let hash = super::simhash::weighted_simhash(&tokens);
+            (hash, issue)
+        })
+        .collect();
+
+    let mut review_required: Vec<Value> = Vec::new();
+
+    for i in 0..hashed.len() {
+        for j in (i + 1)..hashed.len() {
+            let distance = super::simhash::hamming_distance(hashed[i].0, hashed[j].0);
+            if distance <= threshold {
+                let num_a = hashed[i].1["number"].as_u64().unwrap_or(0);
+                let num_b = hashed[j].1["number"].as_u64().unwrap_or(0);
+                review_required.push(serde_json::json!({
+                    "pair": [num_a, num_b],
+                    "distance": distance,
+                    "issues": [
+                        {
+                            "number": num_a,
+                            "title": hashed[i].1["title"],
+                            "body": hashed[i].1["body"],
+                        },
+                        {
+                            "number": num_b,
+                            "title": hashed[j].1["title"],
+                            "body": hashed[j].1["body"],
+                        }
+                    ]
+                }));
+            }
+        }
+    }
+
+    // Sort by distance ascending (most similar first)
+    review_required.sort_by_key(|r| r["distance"].as_u64().unwrap_or(64));
+
+    let total = issues.len();
+    let pairs_checked = total * (total.saturating_sub(1)) / 2;
+
+    serde_json::json!({
+        "review_required": review_required,
+        "total_issues": total,
+        "pairs_checked": pairs_checked,
+    })
+}
+
 /// Extract branch name from CI failure issue title.
 /// Expected format: "fix: CI failure in {workflow} on {branch}"
 pub fn extract_branch_from_ci_title(title: &str) -> String {
@@ -335,6 +415,108 @@ mod tests {
             42
         );
         assert_eq!(extract_issue_number("not-a-url"), 0);
+    }
+
+    #[test]
+    fn detect_overlap_flags_similar_issues() {
+        let issues = vec![
+            serde_json::json!({"number": 1, "title": "JWT token refresh middleware 추가", "body": "middleware 레이어에 JWT refresh token 로직을 추가합니다. src/auth/middleware.rs 수정 필요"}),
+            serde_json::json!({"number": 2, "title": "JWT token refresh handler 구현", "body": "JWT refresh token 처리 handler를 구현합니다. src/auth/handler.rs에 추가"}),
+            serde_json::json!({"number": 3, "title": "데이터베이스 마이그레이션 스크립트 작성", "body": "PostgreSQL 스키마 변경을 위한 마이그레이션 파일을 생성합니다. migrations/001_add_users.sql"}),
+        ];
+        // Use generous threshold to find the actual distance, then verify
+        let debug = compute_overlaps(&issues, 64);
+        let all_pairs = debug["review_required"].as_array().unwrap();
+        // Find the distance between issues 1 and 2
+        let pair_12 = all_pairs
+            .iter()
+            .find(|r| {
+                let p = r["pair"].as_array().unwrap();
+                p[0].as_u64() == Some(1) && p[1].as_u64() == Some(2)
+            })
+            .expect("pair 1-2 should exist");
+        let dist_12 = pair_12["distance"].as_u64().unwrap();
+        // Find the distance between issues 1 and 3
+        let pair_13 = all_pairs
+            .iter()
+            .find(|r| {
+                let p = r["pair"].as_array().unwrap();
+                p[0].as_u64() == Some(1) && p[1].as_u64() == Some(3)
+            })
+            .expect("pair 1-3 should exist");
+        let dist_13 = pair_13["distance"].as_u64().unwrap();
+        // Similar issues (1,2) should have smaller distance than dissimilar (1,3)
+        assert!(
+            dist_12 < dist_13,
+            "issues 1&2 (dist={dist_12}) should be more similar than 1&3 (dist={dist_13})"
+        );
+
+        // Now use a threshold that captures 1-2 but not 1-3
+        let result = compute_overlaps(&issues, dist_12 as u32);
+        let review = result["review_required"].as_array().unwrap();
+        assert!(
+            review.iter().any(|r| {
+                let pair = r["pair"].as_array().unwrap();
+                pair[0].as_u64() == Some(1) && pair[1].as_u64() == Some(2)
+            }),
+            "expected issues 1 and 2 to be flagged, got: {review:?}"
+        );
+        // Issue 3 should not overlap with 1 or 2
+        assert!(
+            !review.iter().any(|r| {
+                let pair = r["pair"].as_array().unwrap();
+                pair.iter().any(|n| n.as_u64() == Some(3))
+            }),
+            "issue 3 should not be in any overlap pair"
+        );
+    }
+
+    #[test]
+    fn detect_overlap_empty_input() {
+        let result = compute_overlaps(&[], 15);
+        assert_eq!(result["review_required"].as_array().unwrap().len(), 0);
+        assert_eq!(result["total_issues"], 0);
+        assert_eq!(result["pairs_checked"], 0);
+    }
+
+    #[test]
+    fn detect_overlap_single_issue() {
+        let issues = vec![serde_json::json!({"number": 1, "title": "test", "body": "body"})];
+        let result = compute_overlaps(&issues, 15);
+        assert_eq!(result["review_required"].as_array().unwrap().len(), 0);
+        assert_eq!(result["pairs_checked"], 0);
+    }
+
+    #[test]
+    fn detect_overlap_threshold_filters() {
+        let issues = vec![
+            serde_json::json!({"number": 1, "title": "JWT token refresh middleware 추가", "body": "middleware 레이어에 JWT refresh"}),
+            serde_json::json!({"number": 2, "title": "JWT token refresh handler 구현", "body": "JWT refresh token handler 구현"}),
+        ];
+        // Very strict threshold should filter out
+        let strict = compute_overlaps(&issues, 0);
+        assert_eq!(strict["review_required"].as_array().unwrap().len(), 0);
+
+        // Generous threshold should include
+        let generous = compute_overlaps(&issues, 30);
+        assert!(!generous["review_required"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn detect_overlap_includes_issue_context() {
+        let issues = vec![
+            serde_json::json!({"number": 10, "title": "same task A", "body": "same body content here"}),
+            serde_json::json!({"number": 11, "title": "same task A", "body": "same body content here"}),
+        ];
+        let result = compute_overlaps(&issues, 64);
+        let review = result["review_required"].as_array().unwrap();
+        assert_eq!(review.len(), 1);
+        let pair = &review[0];
+        assert_eq!(pair["distance"], 0);
+        // Verify full context is included
+        let pair_issues = pair["issues"].as_array().unwrap();
+        assert_eq!(pair_issues[0]["title"], "same task A");
+        assert_eq!(pair_issues[1]["body"], "same body content here");
     }
 
     #[test]

--- a/plugins/github-autopilot/cli/src/cmd/mod.rs
+++ b/plugins/github-autopilot/cli/src/cmd/mod.rs
@@ -100,6 +100,8 @@ pub enum IssueCommands {
     },
     /// Search for similar issues by fingerprint and rank by simhash distance
     SearchSimilar(issue::SearchSimilarArgs),
+    /// Detect overlapping issues by text similarity (stdin JSON)
+    DetectOverlap(issue::DetectOverlapArgs),
 }
 
 #[derive(Subcommand)]

--- a/plugins/github-autopilot/cli/src/main.rs
+++ b/plugins/github-autopilot/cli/src/main.rs
@@ -11,21 +11,21 @@ fn main() {
     let result = match cli.command {
         Commands::Issue { command } => match command {
             IssueCommands::DetectOverlap(args) => cmd::issue::detect_overlap(&args),
-            _ => {
+            IssueCommands::CheckDup { fingerprint } => {
                 let client = gh::real();
-                match command {
-                    IssueCommands::CheckDup { fingerprint } => {
-                        cmd::issue::check_dup(client.as_ref(), &fingerprint)
-                    }
-                    IssueCommands::Create(args) => cmd::issue::create(client.as_ref(), &args),
-                    IssueCommands::CloseResolved { label_prefix } => {
-                        cmd::issue::close_resolved(client.as_ref(), &label_prefix)
-                    }
-                    IssueCommands::SearchSimilar(args) => {
-                        cmd::issue::search_similar(client.as_ref(), &args)
-                    }
-                    IssueCommands::DetectOverlap(_) => unreachable!(),
-                }
+                cmd::issue::check_dup(client.as_ref(), &fingerprint)
+            }
+            IssueCommands::Create(args) => {
+                let client = gh::real();
+                cmd::issue::create(client.as_ref(), &args)
+            }
+            IssueCommands::CloseResolved { label_prefix } => {
+                let client = gh::real();
+                cmd::issue::close_resolved(client.as_ref(), &label_prefix)
+            }
+            IssueCommands::SearchSimilar(args) => {
+                let client = gh::real();
+                cmd::issue::search_similar(client.as_ref(), &args)
             }
         },
         Commands::Pipeline { command } => {

--- a/plugins/github-autopilot/cli/src/main.rs
+++ b/plugins/github-autopilot/cli/src/main.rs
@@ -9,21 +9,25 @@ fn main() {
     let cli = Cli::parse();
 
     let result = match cli.command {
-        Commands::Issue { command } => {
-            let client = gh::real();
-            match command {
-                IssueCommands::CheckDup { fingerprint } => {
-                    cmd::issue::check_dup(client.as_ref(), &fingerprint)
-                }
-                IssueCommands::Create(args) => cmd::issue::create(client.as_ref(), &args),
-                IssueCommands::CloseResolved { label_prefix } => {
-                    cmd::issue::close_resolved(client.as_ref(), &label_prefix)
-                }
-                IssueCommands::SearchSimilar(args) => {
-                    cmd::issue::search_similar(client.as_ref(), &args)
+        Commands::Issue { command } => match command {
+            IssueCommands::DetectOverlap(args) => cmd::issue::detect_overlap(&args),
+            _ => {
+                let client = gh::real();
+                match command {
+                    IssueCommands::CheckDup { fingerprint } => {
+                        cmd::issue::check_dup(client.as_ref(), &fingerprint)
+                    }
+                    IssueCommands::Create(args) => cmd::issue::create(client.as_ref(), &args),
+                    IssueCommands::CloseResolved { label_prefix } => {
+                        cmd::issue::close_resolved(client.as_ref(), &label_prefix)
+                    }
+                    IssueCommands::SearchSimilar(args) => {
+                        cmd::issue::search_similar(client.as_ref(), &args)
+                    }
+                    IssueCommands::DetectOverlap(_) => unreachable!(),
                 }
             }
-        }
+        },
         Commands::Pipeline { command } => {
             let client = gh::real();
             match command {

--- a/plugins/github-autopilot/commands/build-issues.md
+++ b/plugins/github-autopilot/commands/build-issues.md
@@ -128,6 +128,24 @@ issue-dependency-analyzer 에이전트를 호출합니다 (background=false):
 
 결과: 배치 목록 (병렬 실행 가능한 이슈 그룹)
 
+### Step 6.5: 이슈 간 유사도 검사
+
+첫 번째 배치(병렬 실행 대상) 내 이슈들의 텍스트 유사도를 측정합니다:
+
+```bash
+echo '${BATCH_ISSUES_JSON}' | autopilot issue detect-overlap --threshold 15
+```
+
+- 입력: 배치 내 이슈들의 `[{"number", "title", "body"}]` JSON
+- 출력: `review_required` 배열에 유사도가 높은 이슈 쌍 + 양쪽 본문 포함
+
+`review_required`가 비어있으면 Step 7로 진행합니다.
+
+`review_required`에 항목이 있으면:
+1. 해당 이슈 쌍의 **제목, 본문, 유사도 distance**를 issue-dependency-analyzer에 추가 context로 전달합니다.
+2. "이 이슈들이 유사한 내용을 다루고 있습니다. 같은 파일을 수정할 가능성이 있으므로 병렬/순차 실행 여부를 판단해주세요."
+3. dependency-analyzer가 순차 실행이 필요하다고 판단하면 배치를 재구성합니다.
+
 ### Step 7: WIP 라벨 추가
 
 현재 배치의 이슈들에 wip 라벨을 추가합니다 (중복 작업 방지):


### PR DESCRIPTION
## Summary
- Add `autopilot issue detect-overlap --threshold N` CLI command
- Reuses existing simhash infrastructure (`tokenize_weighted` + `hamming_distance`) to measure issue text similarity
- Outputs `review_required` pairs with full title+body context for LLM-based scheduling review
- build-issues Step 6.5 integrates this before batch execution

## How it works
1. CLI reads `[{"number","title","body"}]` from stdin
2. Computes 64-bit simhash per issue from `title + body` text
3. Calculates pairwise hamming distance for all issue pairs
4. Pairs at or below threshold (default: 15) are flagged with full context
5. Dependency analyzer uses this to decide parallel vs sequential scheduling

## Test plan
- [x] `detect_overlap_flags_similar_issues` — similar JWT issues flagged, unrelated DB issue not
- [x] `detect_overlap_empty_input` — empty array handled
- [x] `detect_overlap_single_issue` — no pairs to check
- [x] `detect_overlap_threshold_filters` — strict threshold excludes, generous includes
- [x] `detect_overlap_includes_issue_context` — identical issues have distance 0, full context included
- [x] All 115 tests pass, clippy clean

Closes #613

🤖 Generated with [Claude Code](https://claude.com/claude-code)