### PR TITLE
fix(github-autopilot): add rate limit backoff between sub-groups

### DIFF
--- a/plugins/github-autopilot/commands/build-issues.md
+++ b/plugins/github-autopilot/commands/build-issues.md
@@ -163,8 +163,9 @@ gh issue edit ${ISSUE_NUMBER} --add-label "{label_prefix}wip"
 - 배치 내 이슈가 `max_parallel_agents`보다 많으면:
   1. 이슈를 `max_parallel_agents` 크기의 서브그룹으로 분할
   2. 서브그룹 1 병렬 실행 → 완료 대기
-  3. 서브그룹 2 병렬 실행 → 완료 대기
-  4. ...반복
+  3. **Rate limit 체크**: 결과에 rate limit(429) 에러가 있으면 → 60초 대기 후 다음 서브그룹 진행
+  4. 서브그룹 2 병렬 실행 → 완료 대기
+  5. ...반복
 - 예: `max_parallel_agents=3`, 배치 이슈 7개
   → 그룹1: #1,#2,#3 (병렬) → 그룹2: #4,#5,#6 (병렬) → 그룹3: #7 (단독)
 
@@ -195,6 +196,11 @@ gh issue edit ${ISSUE_NUMBER} --add-label "{label_prefix}wip"
 ### Step 9.5: 에스컬레이션 체크
 
 실패한 이슈 각각에 대해 연속 실패 횟수를 확인합니다.
+
+**Rate limit(429) 실패는 코드 문제가 아니므로 특별 처리합니다:**
+- 실패 마커(failure count) 증가 없이 wip 라벨만 제거
+- 다음 cycle에서 자동 재시도
+- 에스컬레이션 대상에서 제외
 
 ```bash
 # 이슈 코멘트에서 실패 마커 조회


### PR DESCRIPTION
## Summary
- Add 60s backoff between sub-group executions when rate limit (429) is detected
- Rate limit failures excluded from escalation failure count (transient API issue, not code problem)

## Changes
- **`build-issues.md` Step 8**: Sub-group 실행 후 rate limit 체크 → 60초 대기 후 다음 서브그룹 진행
- **`build-issues.md` Step 9.5**: Rate limit 실패는 failure marker 증가 없이 wip 라벨만 제거, 다음 cycle 자동 재시도

## Context
`max_parallel_agents` 설정은 #600에서 이미 구현 완료. 이 PR은 그래도 429가 발생했을 때의 graceful backoff를 추가합니다.

Closes #612

🤖 Generated with [Claude Code](https://claude.com/claude-code)