### PR TITLE
fix(github-autopilot): auto-cleanup stale worktrees on cycle start

### DIFF
--- a/plugins/github-autopilot/agents/issue-implementer.md
+++ b/plugins/github-autopilot/agents/issue-implementer.md
@@ -24,6 +24,12 @@ skills: ["draft-branch"]
 
 ### Phase 1: 분석
 
+0. **이전 작업 확인**:
+   - `git branch --list draft/issue-{N}`으로 기존 draft 브랜치 존재 여부 확인
+   - 있으면: checkout 후 `git log --oneline -5`로 이전 작업 내용 파악. `wip: partial work` 커밋이 있으면 이전 cycle에서 중단된 작업이므로 이어서 진행
+   - issue_comments에서 최신 failure marker(`<!-- autopilot:failure:N -->`)의 실패 카테고리와 사유를 읽고, 동일한 실수를 반복하지 않도록 접근 방식을 조정
+   - 없으면: base_branch에서 새 draft 브랜치 생성
+
 1. **이슈 요구사항 정리**: body와 comments에서 구현 항목, 수용 기준 추출 (comments의 "Autopilot 분석 결과" 섹션에 영향 범위와 구현 가이드가 포함되어 있을 수 있음)
 2. **코드베이스 파악**:
    - 영향 범위의 파일/모듈 읽기

--- a/plugins/github-autopilot/cli/Cargo.lock
+++ b/plugins/github-autopilot/cli/Cargo.lock
@@ -60,7 +60,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "autopilot"
-version = "0.12.1"
+version = "0.13.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/plugins/github-autopilot/cli/src/cmd/mod.rs
+++ b/plugins/github-autopilot/cli/src/cmd/mod.rs
@@ -112,6 +112,8 @@ pub enum WorktreeCommands {
         #[arg(long)]
         branch: String,
     },
+    /// Remove stale draft/* worktrees, preserving branches with partial commits
+    CleanupStale,
 }
 
 #[derive(Subcommand)]

--- a/plugins/github-autopilot/cli/src/cmd/worktree.rs
+++ b/plugins/github-autopilot/cli/src/cmd/worktree.rs
@@ -10,9 +10,83 @@ pub struct CleanupResult {
     pub branch_deleted: bool,
 }
 
+pub struct StaleCleanupEntry {
+    pub branch: String,
+    pub path: String,
+    pub had_uncommitted: bool,
+    pub worktree_removed: bool,
+}
+
 impl WorktreeService {
     pub fn new(git: Box<dyn GitOps>) -> Self {
         Self { git }
+    }
+
+    /// CLI entry point: clean up stale draft worktrees and print summary.
+    pub fn cleanup_stale_cmd(&self) -> Result<i32> {
+        let entries = self.cleanup_stale()?;
+
+        if entries.is_empty() {
+            eprintln!("No stale draft worktrees found");
+        } else {
+            for entry in &entries {
+                if entry.had_uncommitted {
+                    eprintln!(
+                        "Committed partial work in '{}' (branch '{}')",
+                        entry.path, entry.branch
+                    );
+                }
+                if entry.worktree_removed {
+                    eprintln!("Removed worktree for branch '{}'", entry.branch);
+                }
+            }
+        }
+
+        Ok(0)
+    }
+
+    /// Clean up all draft/* worktrees. Uncommitted changes are preserved
+    /// as partial commits before removing the worktree. Branches are kept
+    /// so the next cycle can resume work.
+    pub fn cleanup_stale(&self) -> Result<Vec<StaleCleanupEntry>> {
+        let entries = self.git.worktree_list()?;
+        let mut results = Vec::new();
+
+        for entry in &entries {
+            let branch = match &entry.branch {
+                Some(b) if b.starts_with("draft/") => b,
+                _ => continue,
+            };
+
+            let mut had_uncommitted = false;
+
+            // Best-effort: commit uncommitted changes before removing
+            if self
+                .git
+                .has_uncommitted_changes(&entry.path)
+                .unwrap_or(false)
+            {
+                let msg = format!("wip: partial work for {branch}");
+                if self.git.commit_all_in_worktree(&entry.path, &msg).is_ok() {
+                    had_uncommitted = true;
+                }
+            }
+
+            let worktree_removed = self.git.worktree_remove(&entry.path).is_ok();
+
+            results.push(StaleCleanupEntry {
+                branch: branch.clone(),
+                path: entry.path.clone(),
+                had_uncommitted,
+                worktree_removed,
+            });
+        }
+
+        if !results.is_empty() {
+            let _ = self.git.worktree_prune();
+        }
+
+        Ok(results)
     }
 
     /// CLI entry point: clean up and print summary.

--- a/plugins/github-autopilot/cli/src/cmd/worktree.rs
+++ b/plugins/github-autopilot/cli/src/cmd/worktree.rs
@@ -38,6 +38,11 @@ impl WorktreeService {
                 }
                 if entry.worktree_removed {
                     eprintln!("Removed worktree for branch '{}'", entry.branch);
+                } else {
+                    eprintln!(
+                        "Failed to remove worktree for branch '{}' (path '{}')",
+                        entry.branch, entry.path
+                    );
                 }
             }
         }

--- a/plugins/github-autopilot/cli/src/git.rs
+++ b/plugins/github-autopilot/cli/src/git.rs
@@ -38,6 +38,12 @@ pub trait GitOps: Send + Sync {
 
     /// Delete a local branch.
     fn branch_delete(&self, name: &str) -> Result<()>;
+
+    /// Check whether a worktree has uncommitted changes (staged or unstaged).
+    fn has_uncommitted_changes(&self, worktree_path: &str) -> Result<bool>;
+
+    /// Stage all changes and commit in a specific worktree.
+    fn commit_all_in_worktree(&self, worktree_path: &str, message: &str) -> Result<()>;
 }
 
 /// A worktree entry from `git worktree list --porcelain`.
@@ -118,6 +124,17 @@ impl GitOps for RealGit {
 
     fn branch_delete(&self, name: &str) -> Result<()> {
         run_git(&["branch", "-D", name])?;
+        Ok(())
+    }
+
+    fn has_uncommitted_changes(&self, worktree_path: &str) -> Result<bool> {
+        let output = run_git(&["-C", worktree_path, "status", "--porcelain"])?;
+        Ok(!output.is_empty())
+    }
+
+    fn commit_all_in_worktree(&self, worktree_path: &str, message: &str) -> Result<()> {
+        run_git(&["-C", worktree_path, "add", "-A"])?;
+        run_git(&["-C", worktree_path, "commit", "-m", message])?;
         Ok(())
     }
 }

--- a/plugins/github-autopilot/cli/src/main.rs
+++ b/plugins/github-autopilot/cli/src/main.rs
@@ -79,6 +79,7 @@ fn main() {
             let svc = cmd::worktree::WorktreeService::new(git_client);
             match command {
                 WorktreeCommands::Cleanup { branch } => svc.cleanup(&branch),
+                WorktreeCommands::CleanupStale => svc.cleanup_stale_cmd(),
             }
         }
         Commands::Preflight(PreflightArgs { config, repo_root }) => {

--- a/plugins/github-autopilot/cli/tests/mock_git.rs
+++ b/plugins/github-autopilot/cli/tests/mock_git.rs
@@ -21,6 +21,9 @@ pub struct MockGit {
     fail_worktree_list: bool,
     fail_worktree_remove: bool,
     fail_branch_delete: bool,
+    uncommitted_worktrees: HashSet<String>,
+    committed_worktrees: Mutex<Vec<(String, String)>>,
+    fail_commit: bool,
 }
 
 impl MockGit {
@@ -40,6 +43,9 @@ impl MockGit {
             fail_worktree_list: false,
             fail_worktree_remove: false,
             fail_branch_delete: false,
+            uncommitted_worktrees: HashSet::new(),
+            committed_worktrees: Mutex::new(Vec::new()),
+            fail_commit: false,
         }
     }
 
@@ -56,6 +62,20 @@ impl MockGit {
     pub fn with_fail_branch_delete(mut self) -> Self {
         self.fail_branch_delete = true;
         self
+    }
+
+    pub fn with_uncommitted_worktree(mut self, path: &str) -> Self {
+        self.uncommitted_worktrees.insert(path.to_string());
+        self
+    }
+
+    pub fn with_fail_commit(mut self) -> Self {
+        self.fail_commit = true;
+        self
+    }
+
+    pub fn committed_worktrees(&self) -> Vec<(String, String)> {
+        self.committed_worktrees.lock().unwrap().clone()
     }
 
     pub fn with_worktree(mut self, path: &str, branch: Option<&str>) -> Self {
@@ -187,6 +207,21 @@ impl GitOps for MockGit {
             bail!("branch delete failed");
         }
         self.deleted_branches.lock().unwrap().push(name.to_string());
+        Ok(())
+    }
+
+    fn has_uncommitted_changes(&self, worktree_path: &str) -> Result<bool> {
+        Ok(self.uncommitted_worktrees.contains(worktree_path))
+    }
+
+    fn commit_all_in_worktree(&self, worktree_path: &str, message: &str) -> Result<()> {
+        if self.fail_commit {
+            bail!("commit failed");
+        }
+        self.committed_worktrees
+            .lock()
+            .unwrap()
+            .push((worktree_path.to_string(), message.to_string()));
         Ok(())
     }
 }

--- a/plugins/github-autopilot/cli/tests/worktree_tests.rs
+++ b/plugins/github-autopilot/cli/tests/worktree_tests.rs
@@ -84,3 +84,74 @@ fn cleanup_propagates_worktree_list_error() {
 
     assert!(result.is_err());
 }
+
+// --- cleanup_stale tests ---
+
+#[test]
+fn cleanup_stale_commits_and_removes_draft_worktrees() {
+    let git = MockGit::new()
+        .with_worktree("/repo/.claude/worktrees/a1", Some("draft/issue-42"))
+        .with_uncommitted_worktree("/repo/.claude/worktrees/a1")
+        .with_worktree("/repo/.claude/worktrees/a2", Some("draft/issue-99"))
+        .with_uncommitted_worktree("/repo/.claude/worktrees/a2");
+
+    let svc = WorktreeService::new(Box::new(git));
+    let results = svc.cleanup_stale().unwrap();
+
+    assert_eq!(results.len(), 2);
+    assert!(results[0].had_uncommitted);
+    assert!(results[0].worktree_removed);
+    assert!(results[1].had_uncommitted);
+    assert!(results[1].worktree_removed);
+}
+
+#[test]
+fn cleanup_stale_skips_worktree_without_uncommitted_changes() {
+    let git = MockGit::new().with_worktree("/repo/.claude/worktrees/a1", Some("draft/issue-42"));
+
+    let svc = WorktreeService::new(Box::new(git));
+    let results = svc.cleanup_stale().unwrap();
+
+    assert_eq!(results.len(), 1);
+    assert!(!results[0].had_uncommitted);
+    assert!(results[0].worktree_removed);
+}
+
+#[test]
+fn cleanup_stale_ignores_non_draft_worktrees() {
+    let git = MockGit::new()
+        .with_worktree("/repo", Some("main"))
+        .with_worktree("/repo/.claude/worktrees/a1", Some("feature/issue-42"))
+        .with_worktree("/repo/.claude/worktrees/a2", Some("draft/issue-99"));
+
+    let svc = WorktreeService::new(Box::new(git));
+    let results = svc.cleanup_stale().unwrap();
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].branch, "draft/issue-99");
+}
+
+#[test]
+fn cleanup_stale_returns_empty_when_no_worktrees() {
+    let git = MockGit::new();
+
+    let svc = WorktreeService::new(Box::new(git));
+    let results = svc.cleanup_stale().unwrap();
+
+    assert!(results.is_empty());
+}
+
+#[test]
+fn cleanup_stale_continues_when_commit_fails() {
+    let git = MockGit::new()
+        .with_worktree("/repo/.claude/worktrees/a1", Some("draft/issue-42"))
+        .with_uncommitted_worktree("/repo/.claude/worktrees/a1")
+        .with_fail_commit();
+
+    let svc = WorktreeService::new(Box::new(git));
+    let results = svc.cleanup_stale().unwrap();
+
+    assert_eq!(results.len(), 1);
+    assert!(!results[0].had_uncommitted); // commit failed, so not marked
+    assert!(results[0].worktree_removed);
+}

--- a/plugins/github-autopilot/skills/branch-sync/SKILL.md
+++ b/plugins/github-autopilot/skills/branch-sync/SKILL.md
@@ -10,6 +10,16 @@ autopilot의 모든 커맨드가 작업 시작 전 수행하는 공통 동기화
 
 ## 절차
 
+### 0. Stale Worktree 정리
+
+```bash
+autopilot worktree cleanup-stale
+```
+
+이전 cycle에서 정리되지 못한 `draft/*` worktree를 정리한다.
+uncommitted changes는 partial commit으로 브랜치에 보존한 뒤 worktree만 제거한다.
+draft 브랜치 자체는 삭제하지 않으므로, 다음 cycle에서 이전 작업을 이어받을 수 있다.
+
 ### 1. 설정 로딩
 
 `github-autopilot.local.md` frontmatter에서 `work_branch`와 `branch_strategy`를 읽는다.


### PR DESCRIPTION
## Summary

- cycle 시작 시 이전에 정리되지 못한 `draft/*` worktree를 자동 정리하는 `autopilot worktree cleanup-stale` CLI 커맨드 추가
- uncommitted changes는 partial commit으로 브랜치에 보존한 뒤 worktree만 제거하여 다음 cycle에서 이전 작업을 이어받을 수 있도록 함
- `branch-sync` Step 0에서 자동 실행, `issue-implementer`에 기존 draft 브랜치 resume 로직 추가

Closes #597

## Test plan

- [x] `cleanup_stale` 테스트 5개 케이스 통과 (uncommitted 커밋/제거, clean 제거, non-draft 무시, 빈 목록, commit 실패 시 계속 진행)
- [x] 기존 worktree cleanup 테스트 7개 회귀 없음
- [x] 전체 119 테스트 통과
- [ ] 실제 autopilot cycle에서 stale worktree 정리 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)