### PR TITLE
feat(github-autopilot): add comment filtering and failure resilience for implementer agents

### DIFF
--- a/plugins/github-autopilot/agents/issue-implementer.md
+++ b/plugins/github-autopilot/agents/issue-implementer.md
@@ -15,7 +15,8 @@ skills: ["draft-branch"]
 - issue_number: 이슈 번호
 - issue_title: 이슈 제목
 - issue_body: 이슈 본문 (요구사항, 영향 범위, 구현 가이드)
-- issue_comments: 이슈 코멘트 (analyze-issue의 분석 결과 포함 — 영향 범위, 구현 가이드 참조)
+- issue_comments: 필터링된 이슈 코멘트 (analyze-issue의 분석 결과 포함 — 영향 범위, 구현 가이드 참조)
+- recommended_persona: (optional) 반복 실패 시 추천되는 접근 전환 persona. 아래 Persona 가이드 참조
 - draft_branch: 작업할 draft 브랜치명
 - base_branch: draft 브랜치를 분기할 base 브랜치 (work_branch 또는 branch_strategy에서 결정된 값)
 - quality_gate_command: (optional) 커스텀 quality gate 명령어. 비어있으면 자동 감지
@@ -103,6 +104,20 @@ Closes #${ISSUE_NUMBER}"
   "partial_work": true
 }
 ```
+
+## Persona 가이드 (반복 실패 시)
+
+`recommended_persona`가 전달되면, 이전과 같은 접근이 반복 실패했다는 뜻이다. 해당 persona의 관점으로 접근 방식을 전환한다:
+
+| Persona | 핵심 질문 | 접근 |
+|---------|----------|------|
+| **hacker** | 제약을 우회할 수 있는가? | 당연시하는 가정을 의심하고 다른 경로로 해결 |
+| **researcher** | 정보가 부족한가? | 에러 메시지를 다시 읽고 공식 문서에서 정확한 케이스 확인 |
+| **simplifier** | 복잡성이 문제인가? | 동작하는 가장 단순한 것을 찾고 불필요한 것 제거 |
+| **architect** | 구조가 잘못되었나? | 현재 구조의 근본적 불일치를 찾고 최소한의 구조 변경 제안 |
+| **contrarian** | 올바른 문제를 풀고 있나? | 모든 가정의 반대를 고려하고 문제 자체를 의심 |
+
+persona가 없으면 일반적인 구현 프로세스를 따른다.
 
 ## 주의사항
 

--- a/plugins/github-autopilot/cli/Cargo.lock
+++ b/plugins/github-autopilot/cli/Cargo.lock
@@ -60,7 +60,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "autopilot"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/plugins/github-autopilot/cli/src/cmd/issue.rs
+++ b/plugins/github-autopilot/cli/src/cmd/issue.rs
@@ -351,6 +351,234 @@ pub fn compute_overlaps(issues: &[Value], threshold: u32) -> Value {
     })
 }
 
+/// Persona rotation order for repeated build failures (matches resilience skill).
+const PERSONAS: &[&str] = &[
+    "hacker",
+    "researcher",
+    "simplifier",
+    "architect",
+    "contrarian",
+];
+
+/// Filter issue comments for implementer agents and analyze failure patterns.
+/// Reads comments from stdin as JSON array: `[{"body":"..."}]`
+/// Outputs filtered comments + failure analysis with optional persona recommendation.
+pub fn filter_comments() -> Result<i32> {
+    let mut input = String::new();
+    std::io::stdin()
+        .read_to_string(&mut input)
+        .context("failed to read stdin")?;
+
+    let comments: Vec<Value> =
+        serde_json::from_str(&input).context("failed to parse stdin JSON")?;
+
+    let result = compute_filtered_comments(&comments);
+    println!("{result}");
+    Ok(0)
+}
+
+/// Pure function for testability: filter comments and analyze failure patterns.
+pub fn compute_filtered_comments(comments: &[Value]) -> Value {
+    let mut analysis_comments = Vec::new();
+    let mut failure_comments: Vec<(usize, Value)> = Vec::new(); // (attempt, comment)
+    let mut rework_comments: Vec<(usize, Value)> = Vec::new(); // (index, comment)
+    let mut other_comments = Vec::new();
+
+    for (i, comment) in comments.iter().enumerate() {
+        let body = comment["body"].as_str().unwrap_or("");
+        let category = classify_comment(body);
+
+        match category {
+            CommentCategory::InternalMarker | CommentCategory::PrLink => {
+                // excluded
+            }
+            CommentCategory::Analysis => {
+                analysis_comments.push(comment.clone());
+            }
+            CommentCategory::FailureMarker => {
+                let attempt = extract_failure_attempt(body).unwrap_or(0);
+                failure_comments.push((attempt, comment.clone()));
+            }
+            CommentCategory::ReworkRequest => {
+                rework_comments.push((i, comment.clone()));
+            }
+            CommentCategory::Other => {
+                other_comments.push(comment.clone());
+            }
+        }
+    }
+
+    // Keep only latest failure and rework
+    let latest_failure = failure_comments.iter().max_by_key(|(attempt, _)| *attempt);
+    let latest_rework = rework_comments.last();
+
+    let mut filtered = Vec::new();
+    filtered.extend(analysis_comments);
+    filtered.extend(other_comments);
+    if let Some((_, comment)) = latest_rework {
+        filtered.push(comment.clone());
+    }
+    if let Some((_, comment)) = latest_failure {
+        filtered.push(comment.clone());
+    }
+
+    // Failure analysis
+    let failure_analysis = analyze_failures(&failure_comments);
+
+    serde_json::json!({
+        "comments": filtered,
+        "failure_analysis": failure_analysis,
+    })
+}
+
+#[derive(Debug, PartialEq)]
+enum CommentCategory {
+    Analysis,
+    FailureMarker,
+    ReworkRequest,
+    InternalMarker,
+    PrLink,
+    Other,
+}
+
+fn classify_comment(body: &str) -> CommentCategory {
+    let trimmed = body.trim();
+
+    // Internal markers (body is mostly just the marker)
+    if trimmed == "<!-- notified -->"
+        || trimmed == "<!-- autopilot:rework-detected -->"
+        || trimmed.contains("<!-- autopilot:escalated -->")
+    {
+        return CommentCategory::InternalMarker;
+    }
+
+    // Marker-only comments or comments containing rework-detected/notified markers
+    // (these are internal tracking, even when wrapped with descriptive text)
+    if trimmed.contains("<!-- autopilot:rework-detected -->")
+        || is_marker_only(trimmed, "<!-- notified -->")
+    {
+        return CommentCategory::InternalMarker;
+    }
+
+    // PR link
+    if trimmed.contains("PR created by autopilot") {
+        return CommentCategory::PrLink;
+    }
+
+    // Failure marker
+    if trimmed.contains("<!-- autopilot:failure:") {
+        return CommentCategory::FailureMarker;
+    }
+
+    // Analysis comment
+    if trimmed.contains("Autopilot 분석 결과") {
+        return CommentCategory::Analysis;
+    }
+
+    // Rework request
+    if has_rework_keyword(trimmed) {
+        return CommentCategory::ReworkRequest;
+    }
+
+    CommentCategory::Other
+}
+
+fn is_marker_only(body: &str, marker: &str) -> bool {
+    let without_marker = body.replace(marker, "");
+    without_marker.trim().is_empty()
+}
+
+fn has_rework_keyword(body: &str) -> bool {
+    const KEYWORDS: &[&str] = &[
+        "재구현 필요",
+        "재작업",
+        "rework",
+        "다시 구현",
+        "re-implement",
+    ];
+    KEYWORDS.iter().any(|kw| body.contains(kw))
+}
+
+fn extract_failure_attempt(body: &str) -> Option<usize> {
+    // Match <!-- autopilot:failure:N -->
+    let marker = "<!-- autopilot:failure:";
+    if let Some(start) = body.find(marker) {
+        let rest = &body[start + marker.len()..];
+        if let Some(end) = rest.find(" -->") {
+            return rest[..end].parse().ok();
+        }
+    }
+    None
+}
+
+fn extract_failure_category(body: &str) -> Option<String> {
+    // Match **Category**: value or Category: value
+    for line in body.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("**Category**:") {
+            return Some(rest.trim().to_string());
+        }
+        if let Some(rest) = trimmed.strip_prefix("Category:") {
+            return Some(rest.trim().to_string());
+        }
+    }
+    None
+}
+
+fn analyze_failures(failure_comments: &[(usize, Value)]) -> Value {
+    if failure_comments.is_empty() {
+        return serde_json::json!({
+            "total_failures": 0,
+            "repeated_category": false,
+            "recommended_persona": null,
+        });
+    }
+
+    let mut sorted: Vec<_> = failure_comments.to_vec();
+    sorted.sort_by_key(|(attempt, _)| *attempt);
+
+    let categories: Vec<Option<String>> = sorted
+        .iter()
+        .map(|(_, comment)| {
+            let body = comment["body"].as_str().unwrap_or("");
+            extract_failure_category(body)
+        })
+        .collect();
+
+    let latest = sorted.last().unwrap();
+    let latest_attempt = latest.0;
+    let latest_category = categories.last().cloned().flatten();
+
+    // Check if the same category is repeated consecutively
+    let repeated = if categories.len() >= 2 {
+        let last = categories.last().unwrap();
+        let second_last = &categories[categories.len() - 2];
+        last.is_some() && last == second_last
+    } else {
+        false
+    };
+
+    let persona = if repeated {
+        // Count consecutive same-category failures from the end
+        let target = categories.last().unwrap();
+        let consecutive = categories.iter().rev().take_while(|c| c == &target).count();
+        // Pick persona: 2 consecutive → index 0 (hacker), 3 → index 1, etc.
+        let idx = (consecutive - 2).min(PERSONAS.len() - 1);
+        Some(PERSONAS[idx])
+    } else {
+        None
+    };
+
+    serde_json::json!({
+        "total_failures": sorted.len(),
+        "latest_attempt": latest_attempt,
+        "latest_category": latest_category,
+        "categories": categories,
+        "repeated_category": repeated,
+        "recommended_persona": persona,
+    })
+}
+
 /// Extract branch name from CI failure issue title.
 /// Expected format: "fix: CI failure in {workflow} on {branch}"
 pub fn extract_branch_from_ci_title(title: &str) -> String {
@@ -521,5 +749,340 @@ mod tests {
             "feat/add-auth"
         );
         assert_eq!(extract_branch_from_ci_title("some other title"), "");
+    }
+
+    // --- filter_comments tests ---
+
+    #[test]
+    fn filter_excludes_internal_markers() {
+        let comments = vec![
+            serde_json::json!({"body": "<!-- notified -->"}),
+            serde_json::json!({"body": "<!-- autopilot:rework-detected -->"}),
+            serde_json::json!({"body": "## Autopilot Escalation Report\n\n<!-- autopilot:escalated -->"}),
+            serde_json::json!({"body": "Autopilot 분석 결과: 영향 범위는 auth 모듈"}),
+        ];
+        let result = compute_filtered_comments(&comments);
+        let filtered = result["comments"].as_array().unwrap();
+        assert_eq!(filtered.len(), 1);
+        assert!(filtered[0]["body"].as_str().unwrap().contains("분석 결과"));
+    }
+
+    #[test]
+    fn filter_excludes_pr_links() {
+        let comments = vec![
+            serde_json::json!({"body": "PR created by autopilot: #50"}),
+            serde_json::json!({"body": "사용자 코멘트: 이 부분 수정해주세요"}),
+        ];
+        let result = compute_filtered_comments(&comments);
+        let filtered = result["comments"].as_array().unwrap();
+        assert_eq!(filtered.len(), 1);
+        assert!(filtered[0]["body"]
+            .as_str()
+            .unwrap()
+            .contains("수정해주세요"));
+    }
+
+    #[test]
+    fn filter_keeps_only_latest_failure() {
+        let comments = vec![
+            serde_json::json!({"body": "Autopilot 구현 실패 (attempt 1/3)\n\n**Category**: lint_failure\n**Reason**: clippy\n\n<!-- autopilot:failure:1 -->"}),
+            serde_json::json!({"body": "Autopilot 구현 실패 (attempt 2/3)\n\n**Category**: test_failure\n**Reason**: assertion\n\n<!-- autopilot:failure:2 -->"}),
+        ];
+        let result = compute_filtered_comments(&comments);
+        let filtered = result["comments"].as_array().unwrap();
+        assert_eq!(filtered.len(), 1);
+        assert!(filtered[0]["body"].as_str().unwrap().contains("failure:2"));
+    }
+
+    #[test]
+    fn filter_keeps_only_latest_rework() {
+        let comments = vec![
+            serde_json::json!({"body": "재구현 필요 — API 스펙 변경됨"}),
+            serde_json::json!({"body": "재작업 — 새로운 요구사항 추가"}),
+        ];
+        let result = compute_filtered_comments(&comments);
+        let filtered = result["comments"].as_array().unwrap();
+        assert_eq!(filtered.len(), 1);
+        assert!(filtered[0]["body"]
+            .as_str()
+            .unwrap()
+            .contains("새로운 요구사항"));
+    }
+
+    #[test]
+    fn filter_preserves_all_analysis_and_user_comments() {
+        let comments = vec![
+            serde_json::json!({"body": "Autopilot 분석 결과: 첫 번째 분석"}),
+            serde_json::json!({"body": "Autopilot 분석 결과: 두 번째 분석"}),
+            serde_json::json!({"body": "사용자: 이건 중요한 코멘트"}),
+        ];
+        let result = compute_filtered_comments(&comments);
+        let filtered = result["comments"].as_array().unwrap();
+        assert_eq!(filtered.len(), 3);
+    }
+
+    #[test]
+    fn filter_empty_comments() {
+        let result = compute_filtered_comments(&[]);
+        let filtered = result["comments"].as_array().unwrap();
+        assert!(filtered.is_empty());
+        assert_eq!(result["failure_analysis"]["total_failures"], 0);
+    }
+
+    #[test]
+    fn failure_analysis_no_failures() {
+        let comments = vec![serde_json::json!({"body": "Autopilot 분석 결과: 분석 내용"})];
+        let result = compute_filtered_comments(&comments);
+        let analysis = &result["failure_analysis"];
+        assert_eq!(analysis["total_failures"], 0);
+        assert_eq!(analysis["repeated_category"], false);
+        assert!(analysis["recommended_persona"].is_null());
+    }
+
+    #[test]
+    fn failure_analysis_detects_repeated_category() {
+        let comments = vec![
+            serde_json::json!({"body": "실패\n\n**Category**: lint_failure\n\n<!-- autopilot:failure:1 -->"}),
+            serde_json::json!({"body": "실패\n\n**Category**: lint_failure\n\n<!-- autopilot:failure:2 -->"}),
+        ];
+        let result = compute_filtered_comments(&comments);
+        let analysis = &result["failure_analysis"];
+        assert_eq!(analysis["total_failures"], 2);
+        assert_eq!(analysis["repeated_category"], true);
+        assert_eq!(analysis["recommended_persona"], "hacker");
+    }
+
+    #[test]
+    fn failure_analysis_no_persona_for_different_categories() {
+        let comments = vec![
+            serde_json::json!({"body": "실패\n\n**Category**: lint_failure\n\n<!-- autopilot:failure:1 -->"}),
+            serde_json::json!({"body": "실패\n\n**Category**: test_failure\n\n<!-- autopilot:failure:2 -->"}),
+        ];
+        let result = compute_filtered_comments(&comments);
+        let analysis = &result["failure_analysis"];
+        assert_eq!(analysis["total_failures"], 2);
+        assert_eq!(analysis["repeated_category"], false);
+        assert!(analysis["recommended_persona"].is_null());
+    }
+
+    #[test]
+    fn failure_analysis_persona_rotates_with_consecutive_failures() {
+        let comments = vec![
+            serde_json::json!({"body": "실패\n\n**Category**: test_failure\n\n<!-- autopilot:failure:1 -->"}),
+            serde_json::json!({"body": "실패\n\n**Category**: test_failure\n\n<!-- autopilot:failure:2 -->"}),
+            serde_json::json!({"body": "실패\n\n**Category**: test_failure\n\n<!-- autopilot:failure:3 -->"}),
+        ];
+        let result = compute_filtered_comments(&comments);
+        let analysis = &result["failure_analysis"];
+        assert_eq!(analysis["total_failures"], 3);
+        // 3 consecutive same category → persona index 1 → "researcher"
+        assert_eq!(analysis["recommended_persona"], "researcher");
+    }
+
+    #[test]
+    fn classify_comment_categories() {
+        assert_eq!(
+            classify_comment("<!-- notified -->"),
+            CommentCategory::InternalMarker
+        );
+        assert_eq!(
+            classify_comment("<!-- autopilot:rework-detected -->"),
+            CommentCategory::InternalMarker
+        );
+        assert_eq!(
+            classify_comment("Report\n<!-- autopilot:escalated -->"),
+            CommentCategory::InternalMarker
+        );
+        assert_eq!(
+            classify_comment("PR created by autopilot: #50"),
+            CommentCategory::PrLink
+        );
+        assert_eq!(
+            classify_comment("실패\n<!-- autopilot:failure:1 -->"),
+            CommentCategory::FailureMarker
+        );
+        assert_eq!(
+            classify_comment("Autopilot 분석 결과: 영향 범위"),
+            CommentCategory::Analysis
+        );
+        assert_eq!(
+            classify_comment("재구현 필요"),
+            CommentCategory::ReworkRequest
+        );
+        assert_eq!(
+            classify_comment("일반 사용자 코멘트"),
+            CommentCategory::Other
+        );
+    }
+
+    #[test]
+    fn extract_failure_attempt_parses_correctly() {
+        assert_eq!(
+            extract_failure_attempt("text <!-- autopilot:failure:3 --> more"),
+            Some(3)
+        );
+        assert_eq!(extract_failure_attempt("no marker"), None);
+        assert_eq!(
+            extract_failure_attempt("<!-- autopilot:failure:12 -->"),
+            Some(12)
+        );
+    }
+
+    #[test]
+    fn extract_failure_category_parses_both_formats() {
+        assert_eq!(
+            extract_failure_category("**Category**: lint_failure"),
+            Some("lint_failure".to_string())
+        );
+        assert_eq!(
+            extract_failure_category("Category: test_failure"),
+            Some("test_failure".to_string())
+        );
+        assert_eq!(extract_failure_category("no category"), None);
+    }
+
+    #[test]
+    fn filter_realistic_cycle_scenario() {
+        // Simulates a real issue with 3 failed cycles + rework + analysis
+        let comments = vec![
+            serde_json::json!({"body": "Autopilot 분석 결과: auth 모듈에 refresh token 로직 추가 필요\n\n## 영향 범위\n- src/auth/mod.rs\n- src/auth/token.rs"}),
+            serde_json::json!({"body": "Autopilot 구현 실패 (attempt 1/3)\n\n**Category**: lint_failure\n**Reason**: cargo clippy warnings\n\n<!-- autopilot:failure:1 -->"}),
+            serde_json::json!({"body": "<!-- notified -->"}),
+            serde_json::json!({"body": "PR created by autopilot: #50"}),
+            serde_json::json!({"body": "재구현 필요 — API 스펙이 변경됨"}),
+            serde_json::json!({"body": "Autopilot: 코멘트에서 재작업 요청 감지 — ready 라벨 재부여\n\n<!-- autopilot:rework-detected -->"}),
+            serde_json::json!({"body": "Autopilot 구현 실패 (attempt 2/3)\n\n**Category**: lint_failure\n**Reason**: cargo clippy warnings\n\n<!-- autopilot:failure:2 -->"}),
+            serde_json::json!({"body": "사용자: 이 함수의 리턴 타입을 Result로 바꿔주세요"}),
+        ];
+        let result = compute_filtered_comments(&comments);
+        let filtered = result["comments"].as_array().unwrap();
+
+        // Should keep: analysis(1) + user comment(1) + latest rework(1) + latest failure(1) = 4
+        assert_eq!(filtered.len(), 4);
+
+        // Verify excluded: notified, PR link, rework-detected marker, failure:1
+        let all_bodies: Vec<&str> = filtered
+            .iter()
+            .map(|c| c["body"].as_str().unwrap())
+            .collect();
+        assert!(all_bodies.iter().any(|b| b.contains("분석 결과")));
+        assert!(all_bodies.iter().any(|b| b.contains("리턴 타입")));
+        assert!(all_bodies.iter().any(|b| b.contains("재구현 필요")));
+        assert!(all_bodies.iter().any(|b| b.contains("failure:2")));
+        assert!(!all_bodies.iter().any(|b| b.contains("failure:1")));
+        assert!(!all_bodies.iter().any(|b| b.contains("notified")));
+        assert!(!all_bodies.iter().any(|b| b.contains("PR created")));
+
+        // Failure analysis: 2 consecutive lint_failure → hacker
+        let analysis = &result["failure_analysis"];
+        assert_eq!(analysis["total_failures"], 2);
+        assert_eq!(analysis["repeated_category"], true);
+        assert_eq!(analysis["recommended_persona"], "hacker");
+    }
+
+    #[test]
+    fn persona_rotates_through_all_five() {
+        let comments: Vec<Value> = (1..=6)
+            .map(|i| {
+                serde_json::json!({"body": format!(
+                    "실패\n\n**Category**: test_failure\n\n<!-- autopilot:failure:{i} -->"
+                )})
+            })
+            .collect();
+        let result = compute_filtered_comments(&comments);
+        let analysis = &result["failure_analysis"];
+
+        // 6 consecutive → persona index min(6-2, 4) = 4 → "contrarian"
+        assert_eq!(analysis["recommended_persona"], "contrarian");
+    }
+
+    #[test]
+    fn persona_caps_at_contrarian_beyond_five() {
+        let comments: Vec<Value> = (1..=10)
+            .map(|i| {
+                serde_json::json!({"body": format!(
+                    "실패\n\n**Category**: lint_failure\n\n<!-- autopilot:failure:{i} -->"
+                )})
+            })
+            .collect();
+        let result = compute_filtered_comments(&comments);
+        let analysis = &result["failure_analysis"];
+
+        // 10 consecutive → capped at index 4 → "contrarian"
+        assert_eq!(analysis["recommended_persona"], "contrarian");
+    }
+
+    #[test]
+    fn category_break_resets_persona() {
+        // A, A, B, B → last two are B, repeated=true, consecutive B=2 → hacker
+        let comments = vec![
+            serde_json::json!({"body": "실패\n\n**Category**: lint_failure\n\n<!-- autopilot:failure:1 -->"}),
+            serde_json::json!({"body": "실패\n\n**Category**: lint_failure\n\n<!-- autopilot:failure:2 -->"}),
+            serde_json::json!({"body": "실패\n\n**Category**: test_failure\n\n<!-- autopilot:failure:3 -->"}),
+            serde_json::json!({"body": "실패\n\n**Category**: test_failure\n\n<!-- autopilot:failure:4 -->"}),
+        ];
+        let result = compute_filtered_comments(&comments);
+        let analysis = &result["failure_analysis"];
+        assert_eq!(analysis["repeated_category"], true);
+        // Consecutive test_failure = 2 → index 0 → "hacker" (reset, not continuing from lint)
+        assert_eq!(analysis["recommended_persona"], "hacker");
+    }
+
+    #[test]
+    fn failure_markers_sorted_by_attempt_not_order() {
+        // Comments arrive out of order (attempt 2 before attempt 1)
+        let comments = vec![
+            serde_json::json!({"body": "실패\n\n**Category**: lint_failure\n\n<!-- autopilot:failure:2 -->"}),
+            serde_json::json!({"body": "실패\n\n**Category**: lint_failure\n\n<!-- autopilot:failure:1 -->"}),
+        ];
+        let result = compute_filtered_comments(&comments);
+        let filtered = result["comments"].as_array().unwrap();
+
+        // Latest by attempt number (2), not by array position
+        assert_eq!(filtered.len(), 1);
+        assert!(filtered[0]["body"].as_str().unwrap().contains("failure:2"));
+
+        let analysis = &result["failure_analysis"];
+        assert_eq!(analysis["latest_attempt"], 2);
+        assert_eq!(analysis["repeated_category"], true);
+    }
+
+    #[test]
+    fn single_failure_no_persona() {
+        let comments = vec![
+            serde_json::json!({"body": "실패\n\n**Category**: lint_failure\n\n<!-- autopilot:failure:1 -->"}),
+        ];
+        let result = compute_filtered_comments(&comments);
+        let analysis = &result["failure_analysis"];
+        assert_eq!(analysis["total_failures"], 1);
+        assert_eq!(analysis["repeated_category"], false);
+        assert!(analysis["recommended_persona"].is_null());
+    }
+
+    #[test]
+    fn empty_or_null_body_handled_without_panic() {
+        let comments = vec![
+            serde_json::json!({"body": ""}),
+            serde_json::json!({"body": null}),
+            serde_json::json!({"other_field": "no body"}),
+            serde_json::json!({"body": "실제 사용자 코멘트"}),
+        ];
+        let result = compute_filtered_comments(&comments);
+        // Should not panic; user comment is preserved
+        let filtered = result["comments"].as_array().unwrap();
+        assert!(filtered
+            .iter()
+            .any(|c| c["body"].as_str().unwrap_or("") == "실제 사용자 코멘트"));
+    }
+
+    #[test]
+    fn rework_detected_with_meaningful_text_excluded() {
+        // The marker comment has text before the marker — still excluded
+        let comments = vec![
+            serde_json::json!({"body": "Autopilot: 코멘트에서 재작업 요청 감지 — ready 라벨 재부여\n\n<!-- autopilot:rework-detected -->"}),
+        ];
+        let result = compute_filtered_comments(&comments);
+        let filtered = result["comments"].as_array().unwrap();
+        assert!(filtered.is_empty());
     }
 }

--- a/plugins/github-autopilot/cli/src/cmd/issue.rs
+++ b/plugins/github-autopilot/cli/src/cmd/issue.rs
@@ -444,17 +444,9 @@ enum CommentCategory {
 fn classify_comment(body: &str) -> CommentCategory {
     let trimmed = body.trim();
 
-    // Internal markers (body is mostly just the marker)
-    if trimmed == "<!-- notified -->"
-        || trimmed == "<!-- autopilot:rework-detected -->"
-        || trimmed.contains("<!-- autopilot:escalated -->")
-    {
-        return CommentCategory::InternalMarker;
-    }
-
-    // Marker-only comments or comments containing rework-detected/notified markers
-    // (these are internal tracking, even when wrapped with descriptive text)
+    // Internal markers: autopilot tracking comments not useful for implementer
     if trimmed.contains("<!-- autopilot:rework-detected -->")
+        || trimmed.contains("<!-- autopilot:escalated -->")
         || is_marker_only(trimmed, "<!-- notified -->")
     {
         return CommentCategory::InternalMarker;
@@ -534,18 +526,18 @@ fn analyze_failures(failure_comments: &[(usize, Value)]) -> Value {
         });
     }
 
-    let mut sorted: Vec<_> = failure_comments.to_vec();
-    sorted.sort_by_key(|(attempt, _)| *attempt);
+    let mut indices: Vec<usize> = (0..failure_comments.len()).collect();
+    indices.sort_by_key(|&i| failure_comments[i].0);
 
-    let categories: Vec<Option<String>> = sorted
+    let categories: Vec<Option<String>> = indices
         .iter()
-        .map(|(_, comment)| {
-            let body = comment["body"].as_str().unwrap_or("");
+        .map(|&i| {
+            let body = failure_comments[i].1["body"].as_str().unwrap_or("");
             extract_failure_category(body)
         })
         .collect();
 
-    let latest = sorted.last().unwrap();
+    let latest = &failure_comments[*indices.last().unwrap()];
     let latest_attempt = latest.0;
     let latest_category = categories.last().cloned().flatten();
 
@@ -570,7 +562,7 @@ fn analyze_failures(failure_comments: &[(usize, Value)]) -> Value {
     };
 
     serde_json::json!({
-        "total_failures": sorted.len(),
+        "total_failures": failure_comments.len(),
         "latest_attempt": latest_attempt,
         "latest_category": latest_category,
         "categories": categories,

--- a/plugins/github-autopilot/cli/src/cmd/mod.rs
+++ b/plugins/github-autopilot/cli/src/cmd/mod.rs
@@ -102,6 +102,8 @@ pub enum IssueCommands {
     SearchSimilar(issue::SearchSimilarArgs),
     /// Detect overlapping issues by text similarity (stdin JSON)
     DetectOverlap(issue::DetectOverlapArgs),
+    /// Filter issue comments for implementer agents (stdin JSON)
+    FilterComments,
 }
 
 #[derive(Subcommand)]

--- a/plugins/github-autopilot/cli/src/main.rs
+++ b/plugins/github-autopilot/cli/src/main.rs
@@ -27,6 +27,7 @@ fn main() {
                 let client = gh::real();
                 cmd::issue::search_similar(client.as_ref(), &args)
             }
+            IssueCommands::FilterComments => cmd::issue::filter_comments(),
         },
         Commands::Pipeline { command } => {
             let client = gh::real();

--- a/plugins/github-autopilot/commands/build-issues.md
+++ b/plugins/github-autopilot/commands/build-issues.md
@@ -194,11 +194,20 @@ gh issue edit ${ISSUE_NUMBER} --add-label "{label_prefix}wip"
 - `isolation: "worktree"` 로 독립 작업 공간 확보
 - `run_in_background: true` 로 병렬 실행
 
+각 이슈의 comments를 필터링합니다:
+
+```bash
+echo '${COMMENTS_JSON}' | autopilot issue filter-comments
+```
+
+출력의 `comments`가 필터링된 코멘트, `failure_analysis`가 실패 패턴 분석 결과입니다.
+
 전달 정보 (**모든 항목 필수 — 생략 금지**):
 - issue_number
 - issue_title
 - issue_body (요구사항, 영향 범위, 구현 가이드)
-- **issue_comments**: Step 5에서 가져온 comments 배열 **전체**를 반드시 포함한다. 분석 코멘트, 재작업 요청, 추가 컨텍스트가 포함되어 있으므로 절대 생략하지 않는다
+- **issue_comments**: `filter-comments` 출력의 `comments` 배열. 불필요한 내부 마커와 중복 실패 코멘트가 제거되어 있다
+- **recommended_persona**: `filter-comments` 출력의 `failure_analysis.recommended_persona` (null이면 생략). 같은 카테고리의 실패가 반복되면 persona가 추천된다
 - draft_branch: `draft/issue-{number}`
 - base_branch: Step 1에서 결정한 base 브랜치
 - quality_gate_command: 설정에서 읽은 값 (비어있으면 자동 감지)


### PR DESCRIPTION
## Summary

- `autopilot issue filter-comments` CLI 커맨드 추가 — 불필요한 내부 마커/PR 링크를 제거하고 최신 failure/rework 코멘트만 유지하여 implementer agent의 context 소비를 최적화
- 반복 실패 패턴 감지 — 같은 category의 연속 실패 시 resilience persona(hacker → researcher → simplifier → architect → contrarian) 추천
- build-issues Step 8에서 필터링 파이프라인 적용, issue-implementer에 persona 기반 접근 전환 가이드 추가

Closes #598

## Test plan

- [x] 코멘트 필터링 테스트 (내부 마커 제외, PR 링크 제외, 최신 failure만 유지, 최신 rework만 유지)
- [x] 실패 패턴 분석 테스트 (반복 카테고리 감지, persona 로테이션, 카테고리 변경 시 리셋)
- [x] 실제 cycle 시나리오 통합 테스트
- [x] Edge cases (빈 입력, null body, 순서 무관, 단일 실패, persona 상한)
- [x] 테스트에서 발견한 rework-detected 분류 버그 수정
- [x] 전체 141개 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)