### PR TITLE
feat(github-autopilot): harden gap pipeline, add lifecycle CLI, and improve autopilot efficiency

### DIFF
--- a/plugins/github-autopilot/agents/gap-detector.md
+++ b/plugins/github-autopilot/agents/gap-detector.md
@@ -66,6 +66,26 @@ skip된 파일은 리포트의 맨 앞에 다음 형식으로 기록합니다:
    - 이벤트 리스너: `on_event`, `subscribe`
 4. **LSP 확인**: rust-analyzer, gopls, typescript-language-server 존재 여부
 
+#### Test Scope 제외
+
+Grep으로 entry point를 수집할 때, 다음 영역에서 발견된 매치는 **test scope**로 분류하여 갭 분석 대상에서 제외합니다:
+
+| 언어 | Test Scope 판별 기준 |
+|------|---------------------|
+| Rust | 매치 라인 상위에 `#[cfg(test)]` 또는 `mod tests {`가 있고, 해당 블록 내부에 위치 |
+| JS/TS | `describe(`, `it(`, `test(` 블록 내부 |
+| Go | `func Test*` 또는 `func Benchmark*` 함수 내부 |
+| Python | `class Test*` 또는 `def test_*` 내부 |
+
+**판별 방법**: Grep 매치의 전후 컨텍스트를 확인하여 test scope 경계를 탐지합니다. 컨텍스트 범위는 파일 구조에 맞게 조정합니다 (Rust의 `#[cfg(test)]`는 보통 파일 하단에 위치하므로 매치 이전 전체를 확인, JS/Go/Python은 함수/클래스 단위로 판별). 확실하지 않은 경우 production code로 간주합니다 (false negative 허용, false positive 방지).
+
+제외된 entry point는 리포트의 `Filtered Entries` 섹션에 기록합니다:
+```
+## Filtered Entries (Test Scope)
+- Filtered: src/cron.rs:125 `make_active_spec` (inside #[cfg(test)])
+- Filtered: src/pipeline.rs:300 `spec_fixture` (inside mod tests)
+```
+
 ### Phase 3: 갭 분석
 
 각 요구사항에 대해 entry point에서 call chain을 추적합니다:
@@ -80,6 +100,19 @@ skip된 파일은 리포트의 맨 앞에 다음 형식으로 기록합니다:
 | ✅ Implemented | call chain에서 요구사항의 핵심 로직이 확인됨 |
 | ⚠️ Partial | 일부 수용 기준만 충족, 나머지 미구현 |
 | ❌ Missing | entry point나 관련 코드가 전혀 없음 |
+| ⚠️ WARNING (spec-not-found) | spec_paths에 실제 파일이 없음 — Cross-validation 참조 |
+
+#### Spec ID Cross-validation
+
+갭으로 판정된 항목(❌ Missing, ⚠️ Partial)에 대해 **spec_paths 실존 검증**을 수행합니다: 갭의 스펙 경로가 설정의 `spec_paths` 디렉토리 내 실제 파일인지 확인합니다. 파일이 없으면 `⚠️ WARNING (spec-not-found)`로 재분류합니다.
+
+> Test-scope 필터링은 이미 Phase 2에서 수행되므로 여기서 중복 검사하지 않습니다.
+
+WARNING 항목은 리포트의 별도 섹션에 기록하며, gap-issue-creator는 이 항목에 대해 이슈를 생성하지 않습니다:
+```markdown
+## Warnings (이슈 생성 제외)
+- ⚠️ WARNING (spec-not-found): R-008 `spec-pipeline-create` — spec_paths에 파일 없음
+```
 
 ## 출력
 

--- a/plugins/github-autopilot/agents/gap-issue-creator.md
+++ b/plugins/github-autopilot/agents/gap-issue-creator.md
@@ -22,6 +22,10 @@ skills: ["issue-label", "resilience"]
 
 갭 리포트에서 ❌ Missing 또는 ⚠️ Partial 항목을 추출하여, autopilot CLI로 이슈를 생성합니다. CLI가 fingerprint 중복 확인과 이슈 생성을 한 번에 처리합니다.
 
+#### WARNING 항목 제외
+
+`⚠️ WARNING (spec-not-found)` 항목은 이슈를 생성하지 않습니다. `skipped_warnings` 목록에 추가하고 결과 보고에 포함합니다.
+
 #### 스펙 파일 실존 검증
 
 각 갭 항목의 스펙 경로가 실제 파일로 존재하는지 확인합니다:
@@ -132,6 +136,9 @@ EOF
   ],
   "skipped_missing": [
     {"spec_path": "spec-pipeline-create", "requirement": "Pipeline Issue Creation", "reason": "spec file not found"}
+  ],
+  "skipped_warnings": [
+    {"requirement_id": "R-008", "keyword": "spec-gap", "reason": "spec-not-found in spec_paths"}
   ]
 }
 ```

--- a/plugins/github-autopilot/cli/src/cmd/check/mod.rs
+++ b/plugins/github-autopilot/cli/src/cmd/check/mod.rs
@@ -152,7 +152,7 @@ impl CheckService {
         &self,
         loop_name: &str,
         output_hash: Option<&str>,
-        status: Option<&str>,
+        status: Option<&crate::cmd::LoopStatus>,
     ) -> Result<i32> {
         validate_loop_name(loop_name)?;
         let state_file = state_dir(self.git.as_ref())?.join(format!("{loop_name}.state"));
@@ -165,14 +165,12 @@ impl CheckService {
         loop_state.hash = hash.clone();
         loop_state.timestamp = ts.clone();
 
-        // Update idle count based on status
         match status {
-            Some("idle") => loop_state.idle_count += 1,
-            Some("active") => loop_state.idle_count = 0,
-            _ => {}
+            Some(crate::cmd::LoopStatus::Idle) => loop_state.idle_count += 1,
+            Some(crate::cmd::LoopStatus::Active) => loop_state.idle_count = 0,
+            None => {}
         }
 
-        // Append output hash if provided
         if let Some(simhash) = output_hash {
             append_output_entry(
                 &mut loop_state,

--- a/plugins/github-autopilot/cli/src/cmd/check/mod.rs
+++ b/plugins/github-autopilot/cli/src/cmd/check/mod.rs
@@ -148,7 +148,12 @@ impl CheckService {
     }
 
     /// Record current HEAD as the last analyzed commit.
-    pub fn mark(&self, loop_name: &str, output_hash: Option<&str>) -> Result<i32> {
+    pub fn mark(
+        &self,
+        loop_name: &str,
+        output_hash: Option<&str>,
+        status: Option<&str>,
+    ) -> Result<i32> {
         validate_loop_name(loop_name)?;
         let state_file = state_dir(self.git.as_ref())?.join(format!("{loop_name}.state"));
         let hash = self.git.rev_parse_head()?;
@@ -159,6 +164,13 @@ impl CheckService {
 
         loop_state.hash = hash.clone();
         loop_state.timestamp = ts.clone();
+
+        // Update idle count based on status
+        match status {
+            Some("idle") => loop_state.idle_count += 1,
+            Some("active") => loop_state.idle_count = 0,
+            _ => {}
+        }
 
         // Append output hash if provided
         if let Some(simhash) = output_hash {
@@ -173,7 +185,10 @@ impl CheckService {
         }
 
         write_state(self.fs.as_ref(), &state_file, &loop_state)?;
-        println!("marked {loop_name}: {hash} at {ts}");
+        println!(
+            "marked {loop_name}: {hash} at {ts} (idle_count: {})",
+            loop_state.idle_count
+        );
         Ok(0)
     }
 

--- a/plugins/github-autopilot/cli/src/cmd/check/stagnation.rs
+++ b/plugins/github-autopilot/cli/src/cmd/check/stagnation.rs
@@ -202,6 +202,7 @@ mod tests {
             hash: "abc1234".to_string(),
             timestamp: "2026-01-01T00:00:00Z".to_string(),
             output_history: history,
+            ..Default::default()
         };
         (vec!["src/lib.rs".to_string()], state)
     }

--- a/plugins/github-autopilot/cli/src/cmd/check/state.rs
+++ b/plugins/github-autopilot/cli/src/cmd/check/state.rs
@@ -15,6 +15,8 @@ pub struct LoopState {
     pub timestamp: String,
     #[serde(default)]
     pub output_history: Vec<OutputEntry>,
+    #[serde(default)]
+    pub idle_count: u32,
 }
 
 #[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
@@ -184,6 +186,7 @@ mod tests {
             hash: "abc".to_string(),
             timestamp: "2026-01-01T00:00:00Z".to_string(),
             output_history: Vec::new(),
+            ..Default::default()
         };
         for i in 0..15 {
             append_output_entry(

--- a/plugins/github-autopilot/cli/src/cmd/issue.rs
+++ b/plugins/github-autopilot/cli/src/cmd/issue.rs
@@ -480,12 +480,7 @@ fn is_marker_only(body: &str, marker: &str) -> bool {
     without_marker.trim().is_empty()
 }
 
-/// Public wrapper for issue_list module.
-pub fn has_rework_keyword_pub(body: &str) -> bool {
-    has_rework_keyword(body)
-}
-
-fn has_rework_keyword(body: &str) -> bool {
+pub(crate) fn has_rework_keyword(body: &str) -> bool {
     const KEYWORDS: &[&str] = &[
         "재구현 필요",
         "재작업",

--- a/plugins/github-autopilot/cli/src/cmd/issue.rs
+++ b/plugins/github-autopilot/cli/src/cmd/issue.rs
@@ -480,6 +480,11 @@ fn is_marker_only(body: &str, marker: &str) -> bool {
     without_marker.trim().is_empty()
 }
 
+/// Public wrapper for issue_list module.
+pub fn has_rework_keyword_pub(body: &str) -> bool {
+    has_rework_keyword(body)
+}
+
 fn has_rework_keyword(body: &str) -> bool {
     const KEYWORDS: &[&str] = &[
         "재구현 필요",

--- a/plugins/github-autopilot/cli/src/cmd/issue_list.rs
+++ b/plugins/github-autopilot/cli/src/cmd/issue_list.rs
@@ -6,6 +6,12 @@ use crate::gh::GhOps;
 
 use super::labels;
 
+// HTML comment markers used across the autopilot pipeline
+const MARKER_ANALYSIS: &str = "Autopilot 분석 결과";
+const MARKER_FALSE_POSITIVE: &str = "<!-- autopilot:false-positive -->";
+const MARKER_ESCALATED: &str = "<!-- autopilot:escalated -->";
+const MARKER_REWORK_RESOLVED: &str = "<!-- autopilot:rework-resolved -->";
+
 #[derive(Clone, ValueEnum)]
 pub enum Stage {
     /// No autopilot label, no analysis comment
@@ -29,22 +35,14 @@ pub fn list(
     limit: usize,
 ) -> Result<i32> {
     let issues = fetch_issues(gh, stage, label_prefix, limit)?;
-    let filtered = filter_by_stage(&issues, stage, label_prefix);
 
-    let result: Vec<Value> = filtered
-        .into_iter()
+    let result: Vec<Value> = issues
+        .iter()
+        .filter(|issue| matches_stage(issue, stage, label_prefix))
         .filter(|issue| {
-            if let Some(req) = require_label {
-                let issue_labels = issue["labels"]
-                    .as_array()
-                    .map(|a| a.as_slice())
-                    .unwrap_or(&[]);
-                labels::has_exact_label(issue_labels, req)
-            } else {
-                true
-            }
+            require_label.is_none_or(|req| labels::has_exact_label(get_labels(issue), req))
         })
-        .map(|issue| slim_issue(&issue))
+        .map(|issue| slim_issue(issue))
         .collect();
 
     println!("{}", serde_json::to_string(&result)?);
@@ -60,28 +58,17 @@ fn fetch_issues(
     let limit_str = limit.to_string();
 
     match stage {
-        Stage::Ready => {
-            let ready_label = labels::with_prefix(label_prefix, labels::READY);
+        Stage::Ready | Stage::Wip => {
+            let suffix = match stage {
+                Stage::Ready => labels::READY,
+                _ => labels::WIP,
+            };
+            let label = labels::with_prefix(label_prefix, suffix);
             gh.list_json(&[
                 "issue",
                 "list",
                 "--label",
-                &ready_label,
-                "--state",
-                "open",
-                "--json",
-                "number,title,labels",
-                "--limit",
-                &limit_str,
-            ])
-        }
-        Stage::Wip => {
-            let wip_label = labels::with_prefix(label_prefix, labels::WIP);
-            gh.list_json(&[
-                "issue",
-                "list",
-                "--label",
-                &wip_label,
+                &label,
                 "--state",
                 "open",
                 "--json",
@@ -103,30 +90,38 @@ fn fetch_issues(
     }
 }
 
+fn get_labels(issue: &Value) -> &[Value] {
+    issue["labels"]
+        .as_array()
+        .map(|a| a.as_slice())
+        .unwrap_or(&[])
+}
+
+fn get_comments(issue: &Value) -> &[Value] {
+    issue["comments"]
+        .as_array()
+        .map(|a| a.as_slice())
+        .unwrap_or(&[])
+}
+
 /// Pure filtering logic — testable without gh calls.
 pub fn filter_by_stage(issues: &[Value], stage: &Stage, label_prefix: &str) -> Vec<Value> {
     issues
         .iter()
         .filter(|issue| matches_stage(issue, stage, label_prefix))
-        .cloned()
+        .map(|issue| slim_issue(issue))
         .collect()
 }
 
 fn matches_stage(issue: &Value, stage: &Stage, prefix: &str) -> bool {
-    let issue_labels = issue["labels"]
-        .as_array()
-        .map(|a| a.as_slice())
-        .unwrap_or(&[]);
-    let comments = issue["comments"]
-        .as_array()
-        .map(|a| a.as_slice())
-        .unwrap_or(&[]);
+    let issue_labels = get_labels(issue);
+    let comments = get_comments(issue);
 
     match stage {
         Stage::Unanalyzed => {
             !labels::has_prefixed_label(issue_labels, prefix)
-                && !has_comment_containing(comments, "Autopilot 분석 결과")
-                && !has_comment_containing(comments, "<!-- autopilot:false-positive -->")
+                && !has_comment_containing(comments, MARKER_ANALYSIS)
+                && !has_comment_containing(comments, MARKER_FALSE_POSITIVE)
         }
         Stage::Ready => {
             labels::has_label(issue_labels, prefix, labels::READY)
@@ -138,7 +133,7 @@ fn matches_stage(issue: &Value, stage: &Stage, prefix: &str) -> bool {
                 && has_rework_request(comments)
         }
         Stage::Wip => labels::has_label(issue_labels, prefix, labels::WIP),
-        Stage::Escalated => has_comment_containing(comments, "<!-- autopilot:escalated -->"),
+        Stage::Escalated => has_comment_containing(comments, MARKER_ESCALATED),
     }
 }
 
@@ -150,19 +145,18 @@ fn has_comment_containing(comments: &[Value], needle: &str) -> bool {
 
 fn has_rework_request(comments: &[Value]) -> bool {
     let mut has_keyword = false;
-    let mut resolved = false;
 
     for comment in comments {
         let body = comment["body"].as_str().unwrap_or("");
-        if super::issue::has_rework_keyword(body) {
-            has_keyword = true;
+        if body.contains(MARKER_REWORK_RESOLVED) {
+            return false;
         }
-        if body.contains("<!-- autopilot:rework-resolved -->") {
-            resolved = true;
+        if !has_keyword && super::issue::has_rework_keyword(body) {
+            has_keyword = true;
         }
     }
 
-    has_keyword && !resolved
+    has_keyword
 }
 
 fn slim_issue(issue: &Value) -> Value {
@@ -195,8 +189,6 @@ pub fn extract_fingerprint(body: &str, check_path: Option<&dyn Fn(&str) -> bool>
 fn extract_gap_fingerprint(body: &str) -> Option<(String, String, String)> {
     for line in body.lines() {
         let trimmed = line.trim();
-        // <!-- gap-fingerprint: gap:spec/auth.md:token-refresh -->
-        // <!-- fingerprint: gap:spec/auth.md:token-refresh -->
         for prefix in &["<!-- gap-fingerprint:", "<!-- fingerprint:"] {
             if let Some(rest) = trimmed.strip_prefix(prefix) {
                 if let Some(content) = rest.strip_suffix("-->") {
@@ -249,7 +241,7 @@ mod tests {
     fn extract_fingerprint_non_gap() {
         let body = "<!-- fingerprint: ci-failure:workflow:main -->";
         let result = extract_fingerprint(body, None);
-        assert_eq!(result["found"], false); // not a gap: prefix
+        assert_eq!(result["found"], false);
     }
 
     #[test]
@@ -321,6 +313,27 @@ mod tests {
     }
 
     #[test]
+    fn filter_ready_with_missing_labels_field() {
+        let issues = vec![serde_json::json!({
+            "number": 1, "title": "No labels field", "body": "",
+            "comments": []
+        })];
+        let result = filter_by_stage(&issues, &Stage::Ready, "autopilot:");
+        assert_eq!(result.len(), 0);
+    }
+
+    #[test]
+    fn filter_with_malformed_label_object() {
+        let issues = vec![serde_json::json!({
+            "number": 1, "title": "Bad label", "body": "",
+            "labels": [{"id": 123}],
+            "comments": []
+        })];
+        let result = filter_by_stage(&issues, &Stage::Unanalyzed, "autopilot:");
+        assert_eq!(result.len(), 1);
+    }
+
+    #[test]
     fn filter_rework_detects_keyword() {
         let issues = vec![serde_json::json!({
             "number": 1, "title": "Fix", "body": "",
@@ -346,31 +359,7 @@ mod tests {
     }
 
     #[test]
-    fn filter_ready_with_missing_labels_field() {
-        // Issue JSON without a "labels" array — should not crash
-        let issues = vec![serde_json::json!({
-            "number": 1, "title": "No labels field", "body": "",
-            "comments": []
-        })];
-        let result = filter_by_stage(&issues, &Stage::Ready, "autopilot:");
-        assert_eq!(result.len(), 0);
-    }
-
-    #[test]
-    fn filter_with_malformed_label_object() {
-        // Label without "name" field
-        let issues = vec![serde_json::json!({
-            "number": 1, "title": "Bad label", "body": "",
-            "labels": [{"id": 123}],
-            "comments": []
-        })];
-        let result = filter_by_stage(&issues, &Stage::Unanalyzed, "autopilot:");
-        assert_eq!(result.len(), 1); // no prefixed label found → unanalyzed
-    }
-
-    #[test]
     fn filter_rework_excludes_ready_labeled() {
-        // Issue with rework keyword BUT also has :ready — should NOT match rework stage
         let issues = vec![serde_json::json!({
             "number": 1, "title": "Fix", "body": "",
             "labels": [{"name": "autopilot:ready"}],

--- a/plugins/github-autopilot/cli/src/cmd/issue_list.rs
+++ b/plugins/github-autopilot/cli/src/cmd/issue_list.rs
@@ -346,6 +346,60 @@ mod tests {
     }
 
     #[test]
+    fn filter_ready_with_missing_labels_field() {
+        // Issue JSON without a "labels" array — should not crash
+        let issues = vec![serde_json::json!({
+            "number": 1, "title": "No labels field", "body": "",
+            "comments": []
+        })];
+        let result = filter_by_stage(&issues, &Stage::Ready, "autopilot:");
+        assert_eq!(result.len(), 0);
+    }
+
+    #[test]
+    fn filter_with_malformed_label_object() {
+        // Label without "name" field
+        let issues = vec![serde_json::json!({
+            "number": 1, "title": "Bad label", "body": "",
+            "labels": [{"id": 123}],
+            "comments": []
+        })];
+        let result = filter_by_stage(&issues, &Stage::Unanalyzed, "autopilot:");
+        assert_eq!(result.len(), 1); // no prefixed label found → unanalyzed
+    }
+
+    #[test]
+    fn filter_rework_excludes_ready_labeled() {
+        // Issue with rework keyword BUT also has :ready — should NOT match rework stage
+        let issues = vec![serde_json::json!({
+            "number": 1, "title": "Fix", "body": "",
+            "labels": [{"name": "autopilot:ready"}],
+            "comments": [{"body": "rework 필요"}]
+        })];
+        let result = filter_by_stage(&issues, &Stage::Rework, "autopilot:");
+        assert_eq!(result.len(), 0);
+    }
+
+    #[test]
+    fn filter_wip() {
+        let issues = vec![
+            serde_json::json!({
+                "number": 1, "title": "In progress", "body": "",
+                "labels": [{"name": "autopilot:wip"}],
+                "comments": []
+            }),
+            serde_json::json!({
+                "number": 2, "title": "Not wip", "body": "",
+                "labels": [{"name": "autopilot:ready"}],
+                "comments": []
+            }),
+        ];
+        let result = filter_by_stage(&issues, &Stage::Wip, "autopilot:");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0]["number"], 1);
+    }
+
+    #[test]
     fn filter_escalated() {
         let issues = vec![
             serde_json::json!({

--- a/plugins/github-autopilot/cli/src/cmd/issue_list.rs
+++ b/plugins/github-autopilot/cli/src/cmd/issue_list.rs
@@ -70,7 +70,7 @@ fn fetch_issues(
                 "--state",
                 "open",
                 "--json",
-                "number,title,body,labels,comments",
+                "number,title,labels",
                 "--limit",
                 &limit_str,
             ])
@@ -85,7 +85,7 @@ fn fetch_issues(
                 "--state",
                 "open",
                 "--json",
-                "number,title,body,labels,comments",
+                "number,title,labels",
                 "--limit",
                 &limit_str,
             ])
@@ -154,7 +154,7 @@ fn has_rework_request(comments: &[Value]) -> bool {
 
     for comment in comments {
         let body = comment["body"].as_str().unwrap_or("");
-        if super::issue::has_rework_keyword_pub(body) {
+        if super::issue::has_rework_keyword(body) {
             has_keyword = true;
         }
         if body.contains("<!-- autopilot:rework-resolved -->") {
@@ -179,7 +179,7 @@ pub fn extract_fingerprint(body: &str, check_path: Option<&dyn Fn(&str) -> bool>
 
     match fingerprint {
         Some((full, spec_path, keyword)) => {
-            let spec_exists = check_path.map_or(true, |f| f(&spec_path));
+            let spec_exists = check_path.is_none_or(|f| f(&spec_path));
             serde_json::json!({
                 "found": true,
                 "fingerprint": full,

--- a/plugins/github-autopilot/cli/src/cmd/issue_list.rs
+++ b/plugins/github-autopilot/cli/src/cmd/issue_list.rs
@@ -1,0 +1,366 @@
+use anyhow::Result;
+use clap::ValueEnum;
+use serde_json::Value;
+
+use crate::gh::GhOps;
+
+use super::labels;
+
+#[derive(Clone, ValueEnum)]
+pub enum Stage {
+    /// No autopilot label, no analysis comment
+    Unanalyzed,
+    /// Has :ready, not :wip
+    Ready,
+    /// No :ready/:wip but has rework keyword in comments
+    Rework,
+    /// Has :wip
+    Wip,
+    /// Has escalation marker in comments
+    Escalated,
+}
+
+/// List issues filtered by lifecycle stage.
+pub fn list(
+    gh: &dyn GhOps,
+    stage: &Stage,
+    label_prefix: &str,
+    require_label: Option<&str>,
+    limit: usize,
+) -> Result<i32> {
+    let issues = fetch_issues(gh, stage, label_prefix, limit)?;
+    let filtered = filter_by_stage(&issues, stage, label_prefix);
+
+    let result: Vec<Value> = filtered
+        .into_iter()
+        .filter(|issue| {
+            if let Some(req) = require_label {
+                let issue_labels = issue["labels"]
+                    .as_array()
+                    .map(|a| a.as_slice())
+                    .unwrap_or(&[]);
+                labels::has_exact_label(issue_labels, req)
+            } else {
+                true
+            }
+        })
+        .map(|issue| slim_issue(&issue))
+        .collect();
+
+    println!("{}", serde_json::to_string(&result)?);
+    Ok(0)
+}
+
+fn fetch_issues(
+    gh: &dyn GhOps,
+    stage: &Stage,
+    label_prefix: &str,
+    limit: usize,
+) -> Result<Vec<Value>> {
+    let limit_str = limit.to_string();
+
+    match stage {
+        Stage::Ready => {
+            let ready_label = labels::with_prefix(label_prefix, labels::READY);
+            gh.list_json(&[
+                "issue",
+                "list",
+                "--label",
+                &ready_label,
+                "--state",
+                "open",
+                "--json",
+                "number,title,body,labels,comments",
+                "--limit",
+                &limit_str,
+            ])
+        }
+        Stage::Wip => {
+            let wip_label = labels::with_prefix(label_prefix, labels::WIP);
+            gh.list_json(&[
+                "issue",
+                "list",
+                "--label",
+                &wip_label,
+                "--state",
+                "open",
+                "--json",
+                "number,title,body,labels,comments",
+                "--limit",
+                &limit_str,
+            ])
+        }
+        _ => gh.list_json(&[
+            "issue",
+            "list",
+            "--state",
+            "open",
+            "--json",
+            "number,title,body,labels,comments",
+            "--limit",
+            &limit_str,
+        ]),
+    }
+}
+
+/// Pure filtering logic — testable without gh calls.
+pub fn filter_by_stage(issues: &[Value], stage: &Stage, label_prefix: &str) -> Vec<Value> {
+    issues
+        .iter()
+        .filter(|issue| matches_stage(issue, stage, label_prefix))
+        .cloned()
+        .collect()
+}
+
+fn matches_stage(issue: &Value, stage: &Stage, prefix: &str) -> bool {
+    let issue_labels = issue["labels"]
+        .as_array()
+        .map(|a| a.as_slice())
+        .unwrap_or(&[]);
+    let comments = issue["comments"]
+        .as_array()
+        .map(|a| a.as_slice())
+        .unwrap_or(&[]);
+
+    match stage {
+        Stage::Unanalyzed => {
+            !labels::has_prefixed_label(issue_labels, prefix)
+                && !has_comment_containing(comments, "Autopilot 분석 결과")
+                && !has_comment_containing(comments, "<!-- autopilot:false-positive -->")
+        }
+        Stage::Ready => {
+            labels::has_label(issue_labels, prefix, labels::READY)
+                && !labels::has_label(issue_labels, prefix, labels::WIP)
+        }
+        Stage::Rework => {
+            !labels::has_label(issue_labels, prefix, labels::READY)
+                && !labels::has_label(issue_labels, prefix, labels::WIP)
+                && has_rework_request(comments)
+        }
+        Stage::Wip => labels::has_label(issue_labels, prefix, labels::WIP),
+        Stage::Escalated => has_comment_containing(comments, "<!-- autopilot:escalated -->"),
+    }
+}
+
+fn has_comment_containing(comments: &[Value], needle: &str) -> bool {
+    comments
+        .iter()
+        .any(|c| c["body"].as_str().is_some_and(|b| b.contains(needle)))
+}
+
+fn has_rework_request(comments: &[Value]) -> bool {
+    let mut has_keyword = false;
+    let mut resolved = false;
+
+    for comment in comments {
+        let body = comment["body"].as_str().unwrap_or("");
+        if super::issue::has_rework_keyword_pub(body) {
+            has_keyword = true;
+        }
+        if body.contains("<!-- autopilot:rework-resolved -->") {
+            resolved = true;
+        }
+    }
+
+    has_keyword && !resolved
+}
+
+fn slim_issue(issue: &Value) -> Value {
+    serde_json::json!({
+        "number": issue["number"],
+        "title": issue["title"],
+    })
+}
+
+/// Extract gap-fingerprint from issue body.
+/// Returns JSON with fingerprint components + spec existence info.
+pub fn extract_fingerprint(body: &str, check_path: Option<&dyn Fn(&str) -> bool>) -> Value {
+    let fingerprint = extract_gap_fingerprint(body);
+
+    match fingerprint {
+        Some((full, spec_path, keyword)) => {
+            let spec_exists = check_path.map_or(true, |f| f(&spec_path));
+            serde_json::json!({
+                "found": true,
+                "fingerprint": full,
+                "spec_path": spec_path,
+                "keyword": keyword,
+                "spec_exists": spec_exists,
+            })
+        }
+        None => serde_json::json!({"found": false}),
+    }
+}
+
+fn extract_gap_fingerprint(body: &str) -> Option<(String, String, String)> {
+    for line in body.lines() {
+        let trimmed = line.trim();
+        // <!-- gap-fingerprint: gap:spec/auth.md:token-refresh -->
+        // <!-- fingerprint: gap:spec/auth.md:token-refresh -->
+        for prefix in &["<!-- gap-fingerprint:", "<!-- fingerprint:"] {
+            if let Some(rest) = trimmed.strip_prefix(prefix) {
+                if let Some(content) = rest.strip_suffix("-->") {
+                    let fp = content.trim();
+                    if let Some(gap_content) = fp.strip_prefix("gap:") {
+                        if let Some(colon) = gap_content.rfind(':') {
+                            let spec_path = gap_content[..colon].to_string();
+                            let keyword = gap_content[colon + 1..].to_string();
+                            return Some((fp.to_string(), spec_path, keyword));
+                        }
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_fingerprint_gap_format() {
+        let body = "Some text\n\n<!-- gap-fingerprint: gap:spec/auth.md:token-refresh -->\n<!-- simhash: 0x123 -->";
+        let result = extract_fingerprint(body, None);
+        assert_eq!(result["found"], true);
+        assert_eq!(result["fingerprint"], "gap:spec/auth.md:token-refresh");
+        assert_eq!(result["spec_path"], "spec/auth.md");
+        assert_eq!(result["keyword"], "token-refresh");
+    }
+
+    #[test]
+    fn extract_fingerprint_standard_format() {
+        let body = "`fingerprint: gap:spec/api.md:rate-limiting`\n<!-- fingerprint: gap:spec/api.md:rate-limiting -->";
+        let result = extract_fingerprint(body, None);
+        assert_eq!(result["found"], true);
+        assert_eq!(result["spec_path"], "spec/api.md");
+        assert_eq!(result["keyword"], "rate-limiting");
+    }
+
+    #[test]
+    fn extract_fingerprint_not_found() {
+        let body = "Just a regular issue body without fingerprint";
+        let result = extract_fingerprint(body, None);
+        assert_eq!(result["found"], false);
+    }
+
+    #[test]
+    fn extract_fingerprint_non_gap() {
+        let body = "<!-- fingerprint: ci-failure:workflow:main -->";
+        let result = extract_fingerprint(body, None);
+        assert_eq!(result["found"], false); // not a gap: prefix
+    }
+
+    #[test]
+    fn extract_fingerprint_with_spec_check() {
+        let body = "<!-- gap-fingerprint: gap:spec/missing.md:feature -->";
+        let result = extract_fingerprint(body, Some(&|_path: &str| false));
+        assert_eq!(result["found"], true);
+        assert_eq!(result["spec_exists"], false);
+    }
+
+    #[test]
+    fn filter_unanalyzed_excludes_labeled() {
+        let issues = vec![
+            serde_json::json!({
+                "number": 1, "title": "Bug", "body": "",
+                "labels": [{"name": "autopilot:ready"}],
+                "comments": []
+            }),
+            serde_json::json!({
+                "number": 2, "title": "Feature", "body": "",
+                "labels": [],
+                "comments": []
+            }),
+        ];
+        let result = filter_by_stage(&issues, &Stage::Unanalyzed, "autopilot:");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0]["number"], 2);
+    }
+
+    #[test]
+    fn filter_unanalyzed_excludes_analyzed() {
+        let issues = vec![serde_json::json!({
+            "number": 1, "title": "Bug", "body": "",
+            "labels": [],
+            "comments": [{"body": "Autopilot 분석 결과: skip"}]
+        })];
+        let result = filter_by_stage(&issues, &Stage::Unanalyzed, "autopilot:");
+        assert_eq!(result.len(), 0);
+    }
+
+    #[test]
+    fn filter_unanalyzed_excludes_false_positive() {
+        let issues = vec![serde_json::json!({
+            "number": 1, "title": "Bug", "body": "",
+            "labels": [],
+            "comments": [{"body": "<!-- autopilot:false-positive -->"}]
+        })];
+        let result = filter_by_stage(&issues, &Stage::Unanalyzed, "autopilot:");
+        assert_eq!(result.len(), 0);
+    }
+
+    #[test]
+    fn filter_ready_excludes_wip() {
+        let issues = vec![
+            serde_json::json!({
+                "number": 1, "title": "Ready", "body": "",
+                "labels": [{"name": "autopilot:ready"}],
+                "comments": []
+            }),
+            serde_json::json!({
+                "number": 2, "title": "WIP", "body": "",
+                "labels": [{"name": "autopilot:ready"}, {"name": "autopilot:wip"}],
+                "comments": []
+            }),
+        ];
+        let result = filter_by_stage(&issues, &Stage::Ready, "autopilot:");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0]["number"], 1);
+    }
+
+    #[test]
+    fn filter_rework_detects_keyword() {
+        let issues = vec![serde_json::json!({
+            "number": 1, "title": "Fix", "body": "",
+            "labels": [],
+            "comments": [{"body": "이 부분 재작업 필요합니다"}]
+        })];
+        let result = filter_by_stage(&issues, &Stage::Rework, "autopilot:");
+        assert_eq!(result.len(), 1);
+    }
+
+    #[test]
+    fn filter_rework_skips_resolved() {
+        let issues = vec![serde_json::json!({
+            "number": 1, "title": "Fix", "body": "",
+            "labels": [],
+            "comments": [
+                {"body": "재작업 필요"},
+                {"body": "<!-- autopilot:rework-resolved -->"}
+            ]
+        })];
+        let result = filter_by_stage(&issues, &Stage::Rework, "autopilot:");
+        assert_eq!(result.len(), 0);
+    }
+
+    #[test]
+    fn filter_escalated() {
+        let issues = vec![
+            serde_json::json!({
+                "number": 1, "title": "Escalated", "body": "",
+                "labels": [],
+                "comments": [{"body": "## Autopilot Escalation Report\n\n<!-- autopilot:escalated -->"}]
+            }),
+            serde_json::json!({
+                "number": 2, "title": "Normal", "body": "",
+                "labels": [],
+                "comments": []
+            }),
+        ];
+        let result = filter_by_stage(&issues, &Stage::Escalated, "autopilot:");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0]["number"], 1);
+    }
+}

--- a/plugins/github-autopilot/cli/src/cmd/labels.rs
+++ b/plugins/github-autopilot/cli/src/cmd/labels.rs
@@ -6,3 +6,27 @@ pub const AUTO: &str = "auto";
 pub fn with_prefix(prefix: &str, suffix: &str) -> String {
     format!("{prefix}{suffix}")
 }
+
+/// Check if any label starts with the given prefix.
+pub fn has_prefixed_label(labels: &[serde_json::Value], prefix: &str) -> bool {
+    labels.iter().any(|l| {
+        l["name"]
+            .as_str()
+            .is_some_and(|name| name.starts_with(prefix))
+    })
+}
+
+/// Check if a specific prefixed label exists.
+pub fn has_label(labels: &[serde_json::Value], prefix: &str, suffix: &str) -> bool {
+    let target = with_prefix(prefix, suffix);
+    labels
+        .iter()
+        .any(|l| l["name"].as_str().is_some_and(|name| name == target))
+}
+
+/// Check if a specific label (exact match) exists.
+pub fn has_exact_label(labels: &[serde_json::Value], label: &str) -> bool {
+    labels
+        .iter()
+        .any(|l| l["name"].as_str().is_some_and(|name| name == label))
+}

--- a/plugins/github-autopilot/cli/src/cmd/mod.rs
+++ b/plugins/github-autopilot/cli/src/cmd/mod.rs
@@ -1,5 +1,6 @@
 pub mod check;
 pub mod issue;
+pub mod issue_list;
 pub mod labels;
 pub mod pipeline;
 pub mod preflight;
@@ -113,6 +114,26 @@ pub enum IssueCommands {
     DetectOverlap(issue::DetectOverlapArgs),
     /// Filter issue comments for implementer agents (stdin JSON)
     FilterComments,
+    /// List issues filtered by lifecycle stage
+    List(ListArgs),
+    /// Extract gap-fingerprint from issue body (stdin)
+    ExtractFingerprint,
+}
+
+#[derive(Args)]
+pub struct ListArgs {
+    /// Lifecycle stage to filter by
+    #[arg(long)]
+    pub stage: issue_list::Stage,
+    /// Label prefix (default: "autopilot:")
+    #[arg(long, default_value = "autopilot:")]
+    pub label_prefix: String,
+    /// Only include issues with this exact label
+    #[arg(long)]
+    pub require_label: Option<String>,
+    /// Maximum number of issues to fetch
+    #[arg(long, default_value_t = 50)]
+    pub limit: usize,
 }
 
 #[derive(Subcommand)]

--- a/plugins/github-autopilot/cli/src/cmd/mod.rs
+++ b/plugins/github-autopilot/cli/src/cmd/mod.rs
@@ -4,6 +4,7 @@ pub mod labels;
 pub mod pipeline;
 pub mod preflight;
 pub mod simhash;
+pub mod stats;
 pub mod watch;
 pub mod worktree;
 
@@ -46,6 +47,11 @@ pub enum Commands {
         #[command(subcommand)]
         command: WorktreeCommands,
     },
+    /// Session statistics management
+    Stats {
+        #[command(subcommand)]
+        command: StatsCommands,
+    },
 }
 
 #[derive(Subcommand)]
@@ -65,6 +71,9 @@ pub enum CheckCommands {
         /// Optional simhash of analysis output (for stagnation tracking)
         #[arg(long)]
         output_hash: Option<String>,
+        /// Loop status: "idle" increments idle counter, "active" resets it
+        #[arg(long)]
+        status: Option<String>,
     },
     /// Show state of all loops
     Status,
@@ -125,5 +134,35 @@ pub enum PipelineCommands {
         /// Label prefix (default: "autopilot:")
         #[arg(long, default_value = "autopilot:")]
         label_prefix: String,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum StatsCommands {
+    /// Initialize (or reset) session statistics
+    Init,
+    /// Update statistics for a command
+    Update {
+        /// Command name (e.g. "build-issues")
+        #[arg(long)]
+        command: String,
+        /// Number of issues processed this cycle
+        #[arg(long, default_value_t = 0)]
+        processed: u32,
+        /// Number of successful implementations
+        #[arg(long, default_value_t = 0)]
+        success: u32,
+        /// Number of failed implementations
+        #[arg(long, default_value_t = 0)]
+        failed: u32,
+        /// Number of false positives closed
+        #[arg(long, default_value_t = 0)]
+        false_positive: u32,
+    },
+    /// Show session statistics
+    Show {
+        /// Filter by command name (omit for all)
+        #[arg(long)]
+        command: Option<String>,
     },
 }

--- a/plugins/github-autopilot/cli/src/cmd/mod.rs
+++ b/plugins/github-autopilot/cli/src/cmd/mod.rs
@@ -9,7 +9,7 @@ pub mod stats;
 pub mod watch;
 pub mod worktree;
 
-use clap::{Args, Parser, Subcommand};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 
 #[derive(Parser)]
 #[command(
@@ -74,7 +74,7 @@ pub enum CheckCommands {
         output_hash: Option<String>,
         /// Loop status: "idle" increments idle counter, "active" resets it
         #[arg(long)]
-        status: Option<String>,
+        status: Option<LoopStatus>,
     },
     /// Show state of all loops
     Status,
@@ -146,6 +146,12 @@ pub enum WorktreeCommands {
     },
     /// Remove stale draft/* worktrees, preserving branches with partial commits
     CleanupStale,
+}
+
+#[derive(Clone, ValueEnum)]
+pub enum LoopStatus {
+    Idle,
+    Active,
 }
 
 #[derive(Subcommand)]

--- a/plugins/github-autopilot/cli/src/cmd/stats.rs
+++ b/plugins/github-autopilot/cli/src/cmd/stats.rs
@@ -1,0 +1,116 @@
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+use crate::cmd::check::state::{state_dir, utc_timestamp};
+use crate::fs::FsOps;
+use crate::git::GitOps;
+
+const STATS_FILE: &str = "session-stats.json";
+
+#[derive(Serialize, Deserialize, Default)]
+pub struct SessionStats {
+    pub started_at: String,
+    pub commands: HashMap<String, CommandStats>,
+}
+
+#[derive(Serialize, Deserialize, Default, Clone)]
+pub struct CommandStats {
+    pub total_cycles: u32,
+    pub processed: u32,
+    pub success: u32,
+    pub failed: u32,
+    pub false_positive: u32,
+    pub idle_cycles: u32,
+    pub consecutive_idle: u32,
+    pub agent_calls: u32,
+}
+
+pub struct StatsService {
+    git: Box<dyn GitOps>,
+    fs: Box<dyn FsOps>,
+}
+
+impl StatsService {
+    pub fn new(git: Box<dyn GitOps>, fs: Box<dyn FsOps>) -> Self {
+        Self { git, fs }
+    }
+
+    /// Initialize (or reset) session statistics.
+    pub fn init(&self) -> Result<i32> {
+        let path = state_dir(self.git.as_ref())?.join(STATS_FILE);
+        let stats = SessionStats {
+            started_at: utc_timestamp(),
+            commands: HashMap::new(),
+        };
+        self.fs.write_file(&path, &serde_json::to_string(&stats)?)?;
+        println!("session stats initialized at {}", stats.started_at);
+        Ok(0)
+    }
+
+    /// Update statistics for a command.
+    pub fn update(
+        &self,
+        command: &str,
+        processed: u32,
+        success: u32,
+        failed: u32,
+        false_positive: u32,
+    ) -> Result<i32> {
+        let path = state_dir(self.git.as_ref())?.join(STATS_FILE);
+        let mut stats = self.read_or_init(&path)?;
+
+        {
+            let entry = stats.commands.entry(command.to_string()).or_default();
+            entry.total_cycles += 1;
+            entry.processed += processed;
+            entry.success += success;
+            entry.failed += failed;
+            entry.false_positive += false_positive;
+
+            if processed == 0 {
+                entry.idle_cycles += 1;
+                entry.consecutive_idle += 1;
+            } else {
+                entry.consecutive_idle = 0;
+                entry.agent_calls += processed;
+            }
+        }
+
+        self.fs.write_file(&path, &serde_json::to_string(&stats)?)?;
+        let entry = &stats.commands[command];
+        println!("{}", serde_json::to_string(entry)?);
+        Ok(0)
+    }
+
+    /// Show session statistics.
+    pub fn show(&self, command: Option<&str>) -> Result<i32> {
+        let path = state_dir(self.git.as_ref())?.join(STATS_FILE);
+        let stats = match self.fs.read_file(&path) {
+            Ok(content) => serde_json::from_str::<SessionStats>(&content)?,
+            Err(_) => {
+                println!("(no session stats found)");
+                return Ok(0);
+            }
+        };
+
+        match command {
+            Some(cmd) => match stats.commands.get(cmd) {
+                Some(entry) => println!("{}", serde_json::to_string_pretty(entry)?),
+                None => println!("(no stats for command: {cmd})"),
+            },
+            None => println!("{}", serde_json::to_string_pretty(&stats)?),
+        }
+        Ok(0)
+    }
+
+    fn read_or_init(&self, path: &std::path::Path) -> Result<SessionStats> {
+        match self.fs.read_file(path) {
+            Ok(content) => Ok(serde_json::from_str(&content)?),
+            Err(_) => Ok(SessionStats {
+                started_at: utc_timestamp(),
+                commands: HashMap::new(),
+            }),
+        }
+    }
+}

--- a/plugins/github-autopilot/cli/src/main.rs
+++ b/plugins/github-autopilot/cli/src/main.rs
@@ -93,7 +93,7 @@ fn main() {
                     loop_name,
                     output_hash,
                     status,
-                } => svc.mark(&loop_name, output_hash.as_deref(), status.as_deref()),
+                } => svc.mark(&loop_name, output_hash.as_deref(), status.as_ref()),
                 CheckCommands::Status => svc.status(),
                 CheckCommands::Health => svc.health(),
             }

--- a/plugins/github-autopilot/cli/src/main.rs
+++ b/plugins/github-autopilot/cli/src/main.rs
@@ -1,5 +1,6 @@
 use autopilot::cmd::{
-    CheckCommands, Cli, Commands, IssueCommands, PipelineCommands, PreflightArgs, WorktreeCommands,
+    CheckCommands, Cli, Commands, IssueCommands, PipelineCommands, PreflightArgs, StatsCommands,
+    WorktreeCommands,
 };
 use autopilot::{cmd, fs, gh, git, github};
 use clap::Parser;
@@ -58,7 +59,8 @@ fn main() {
                 CheckCommands::Mark {
                     loop_name,
                     output_hash,
-                } => svc.mark(&loop_name, output_hash.as_deref()),
+                    status,
+                } => svc.mark(&loop_name, output_hash.as_deref(), status.as_deref()),
                 CheckCommands::Status => svc.status(),
                 CheckCommands::Health => svc.health(),
             }
@@ -81,6 +83,22 @@ fn main() {
             match command {
                 WorktreeCommands::Cleanup { branch } => svc.cleanup(&branch),
                 WorktreeCommands::CleanupStale => svc.cleanup_stale_cmd(),
+            }
+        }
+        Commands::Stats { command } => {
+            let git_client = git::real();
+            let fs_client = fs::real();
+            let svc = cmd::stats::StatsService::new(git_client, fs_client);
+            match command {
+                StatsCommands::Init => svc.init(),
+                StatsCommands::Update {
+                    command,
+                    processed,
+                    success,
+                    failed,
+                    false_positive,
+                } => svc.update(&command, processed, success, failed, false_positive),
+                StatsCommands::Show { command } => svc.show(command.as_deref()),
             }
         }
         Commands::Preflight(PreflightArgs { config, repo_root }) => {

--- a/plugins/github-autopilot/cli/src/main.rs
+++ b/plugins/github-autopilot/cli/src/main.rs
@@ -1,6 +1,6 @@
 use autopilot::cmd::{
-    CheckCommands, Cli, Commands, IssueCommands, PipelineCommands, PreflightArgs, StatsCommands,
-    WorktreeCommands,
+    CheckCommands, Cli, Commands, IssueCommands, ListArgs, PipelineCommands, PreflightArgs,
+    StatsCommands, WorktreeCommands,
 };
 use autopilot::{cmd, fs, gh, git, github};
 use clap::Parser;
@@ -29,6 +29,39 @@ fn main() {
                 cmd::issue::search_similar(client.as_ref(), &args)
             }
             IssueCommands::FilterComments => cmd::issue::filter_comments(),
+            IssueCommands::List(ListArgs {
+                stage,
+                label_prefix,
+                require_label,
+                limit,
+            }) => {
+                let client = gh::real();
+                cmd::issue_list::list(
+                    client.as_ref(),
+                    &stage,
+                    &label_prefix,
+                    require_label.as_deref(),
+                    limit,
+                )
+            }
+            IssueCommands::ExtractFingerprint => {
+                use std::io::Read as _;
+                let mut input = String::new();
+                std::io::stdin()
+                    .read_to_string(&mut input)
+                    .expect("failed to read stdin");
+                let result = cmd::issue_list::extract_fingerprint(
+                    &input,
+                    Some(&|path: &str| std::path::Path::new(path).exists()),
+                );
+                let exit = if result["found"].as_bool() == Some(true) {
+                    0
+                } else {
+                    1
+                };
+                println!("{result}");
+                Ok(exit)
+            }
         },
         Commands::Pipeline { command } => {
             let client = gh::real();

--- a/plugins/github-autopilot/cli/tests/check_tests.rs
+++ b/plugins/github-autopilot/cli/tests/check_tests.rs
@@ -94,7 +94,7 @@ fn mark_writes_state_file() {
     let fs = MockFs::new();
 
     let code = make_svc(git, fs.clone())
-        .mark("build-issues", None)
+        .mark("build-issues", None, None)
         .unwrap();
     assert_eq!(code, 0);
 
@@ -117,7 +117,7 @@ fn mark_with_output_hash_appends_history() {
     let fs = MockFs::new();
 
     let code = make_svc(git, fs.clone())
-        .mark("gap-watch", Some("0xA3F2B81C4D5E6F1B"))
+        .mark("gap-watch", Some("0xA3F2B81C4D5E6F1B"), None)
         .unwrap();
     assert_eq!(code, 0);
 
@@ -142,6 +142,52 @@ fn status_shows_loops() {
 
     let code = make_svc(git, fs).status().unwrap();
     assert_eq!(code, 0);
+}
+
+#[test]
+fn mark_status_idle_increments_count() {
+    let git = MockGit::new().with_head("ccc3333");
+    let fs = MockFs::new();
+
+    make_svc(git, fs.clone())
+        .mark("build-issues", None, Some("idle"))
+        .unwrap();
+    let written = fs.written_files();
+    let state: serde_json::Value = serde_json::from_str(&written[0].1).unwrap();
+    assert_eq!(state["idle_count"], 1);
+}
+
+#[test]
+fn mark_status_active_resets_count() {
+    let git = MockGit::new().with_head("ccc3333");
+    let fs = MockFs::new().with_file(
+        "/tmp/autopilot-repo/state/build-issues.state",
+        r#"{"hash":"bbb2222","timestamp":"2026-01-01T00:00:00Z","idle_count":4}"#,
+    );
+
+    make_svc(git, fs.clone())
+        .mark("build-issues", None, Some("active"))
+        .unwrap();
+    let written = fs.written_files();
+    let state: serde_json::Value = serde_json::from_str(&written[0].1).unwrap();
+    assert_eq!(state["idle_count"], 0);
+}
+
+#[test]
+fn mark_backward_compat_without_idle_count() {
+    // Old state files without idle_count should default to 0
+    let git = MockGit::new().with_head("ccc3333");
+    let fs = MockFs::new().with_file(
+        "/tmp/autopilot-repo/state/gap-watch.state",
+        r#"{"hash":"aaa1111","timestamp":"2026-01-01T00:00:00Z"}"#,
+    );
+
+    make_svc(git, fs.clone())
+        .mark("gap-watch", None, Some("idle"))
+        .unwrap();
+    let written = fs.written_files();
+    let state: serde_json::Value = serde_json::from_str(&written[0].1).unwrap();
+    assert_eq!(state["idle_count"], 1);
 }
 
 #[test]

--- a/plugins/github-autopilot/cli/tests/check_tests.rs
+++ b/plugins/github-autopilot/cli/tests/check_tests.rs
@@ -174,6 +174,43 @@ fn mark_status_active_resets_count() {
 }
 
 #[test]
+fn mark_idle_accumulates_across_calls() {
+    let git = MockGit::new().with_head("ccc3333");
+    // Start with idle_count=3
+    let fs = MockFs::new().with_file(
+        "/tmp/autopilot-repo/state/build-issues.state",
+        r#"{"hash":"bbb2222","timestamp":"2026-01-01T00:00:00Z","idle_count":3}"#,
+    );
+
+    make_svc(git, fs.clone())
+        .mark(
+            "build-issues",
+            None,
+            Some(&autopilot::cmd::LoopStatus::Idle),
+        )
+        .unwrap();
+    let written = fs.written_files();
+    let state: serde_json::Value = serde_json::from_str(&written[0].1).unwrap();
+    assert_eq!(state["idle_count"], 4);
+}
+
+#[test]
+fn mark_without_status_preserves_idle_count() {
+    let git = MockGit::new().with_head("ccc3333");
+    let fs = MockFs::new().with_file(
+        "/tmp/autopilot-repo/state/build-issues.state",
+        r#"{"hash":"bbb2222","timestamp":"2026-01-01T00:00:00Z","idle_count":5}"#,
+    );
+
+    make_svc(git, fs.clone())
+        .mark("build-issues", None, None)
+        .unwrap();
+    let written = fs.written_files();
+    let state: serde_json::Value = serde_json::from_str(&written[0].1).unwrap();
+    assert_eq!(state["idle_count"], 5); // unchanged
+}
+
+#[test]
 fn mark_backward_compat_without_idle_count() {
     // Old state files without idle_count should default to 0
     let git = MockGit::new().with_head("ccc3333");

--- a/plugins/github-autopilot/cli/tests/check_tests.rs
+++ b/plugins/github-autopilot/cli/tests/check_tests.rs
@@ -150,7 +150,7 @@ fn mark_status_idle_increments_count() {
     let fs = MockFs::new();
 
     make_svc(git, fs.clone())
-        .mark("build-issues", None, Some("idle"))
+        .mark("build-issues", None, Some(&autopilot::cmd::LoopStatus::Idle))
         .unwrap();
     let written = fs.written_files();
     let state: serde_json::Value = serde_json::from_str(&written[0].1).unwrap();
@@ -166,7 +166,7 @@ fn mark_status_active_resets_count() {
     );
 
     make_svc(git, fs.clone())
-        .mark("build-issues", None, Some("active"))
+        .mark("build-issues", None, Some(&autopilot::cmd::LoopStatus::Active))
         .unwrap();
     let written = fs.written_files();
     let state: serde_json::Value = serde_json::from_str(&written[0].1).unwrap();
@@ -183,7 +183,7 @@ fn mark_backward_compat_without_idle_count() {
     );
 
     make_svc(git, fs.clone())
-        .mark("gap-watch", None, Some("idle"))
+        .mark("gap-watch", None, Some(&autopilot::cmd::LoopStatus::Idle))
         .unwrap();
     let written = fs.written_files();
     let state: serde_json::Value = serde_json::from_str(&written[0].1).unwrap();

--- a/plugins/github-autopilot/cli/tests/issue_list_tests.rs
+++ b/plugins/github-autopilot/cli/tests/issue_list_tests.rs
@@ -48,8 +48,7 @@ fn list_ready_with_require_label() {
         ],
     );
 
-    let code =
-        issue_list::list(&gh, &Stage::Ready, "autopilot:", Some("bug"), 50).unwrap();
+    let code = issue_list::list(&gh, &Stage::Ready, "autopilot:", Some("bug"), 50).unwrap();
     assert_eq!(code, 0);
     // Only issue #1 has "bug" label — output is captured via println
 }

--- a/plugins/github-autopilot/cli/tests/issue_list_tests.rs
+++ b/plugins/github-autopilot/cli/tests/issue_list_tests.rs
@@ -1,0 +1,77 @@
+mod mock_gh;
+
+use autopilot::cmd::issue_list::{self, Stage};
+use mock_gh::MockGh;
+
+#[test]
+fn list_unanalyzed_filters_via_gh() {
+    let gh = MockGh::new().on_list_containing(
+        "issue",
+        vec![
+            serde_json::json!({
+                "number": 1, "title": "Has label", "body": "",
+                "labels": [{"name": "autopilot:ready"}],
+                "comments": []
+            }),
+            serde_json::json!({
+                "number": 2, "title": "Fresh issue", "body": "",
+                "labels": [],
+                "comments": []
+            }),
+            serde_json::json!({
+                "number": 3, "title": "Already analyzed", "body": "",
+                "labels": [],
+                "comments": [{"body": "Autopilot 분석 결과: ready"}]
+            }),
+        ],
+    );
+
+    let code = issue_list::list(&gh, &Stage::Unanalyzed, "autopilot:", None, 50).unwrap();
+    assert_eq!(code, 0);
+}
+
+#[test]
+fn list_ready_with_require_label() {
+    let gh = MockGh::new().on_list_containing(
+        "issue",
+        vec![
+            serde_json::json!({
+                "number": 1, "title": "Ready+bug", "body": "",
+                "labels": [{"name": "autopilot:ready"}, {"name": "bug"}],
+                "comments": []
+            }),
+            serde_json::json!({
+                "number": 2, "title": "Ready only", "body": "",
+                "labels": [{"name": "autopilot:ready"}],
+                "comments": []
+            }),
+        ],
+    );
+
+    let code =
+        issue_list::list(&gh, &Stage::Ready, "autopilot:", Some("bug"), 50).unwrap();
+    assert_eq!(code, 0);
+    // Only issue #1 has "bug" label — output is captured via println
+}
+
+#[test]
+fn list_rework_via_gh() {
+    let gh = MockGh::new().on_list_containing(
+        "issue",
+        vec![
+            serde_json::json!({
+                "number": 10, "title": "Needs rework", "body": "",
+                "labels": [],
+                "comments": [{"body": "이 부분 rework 해주세요"}]
+            }),
+            serde_json::json!({
+                "number": 11, "title": "Normal", "body": "",
+                "labels": [],
+                "comments": [{"body": "LGTM"}]
+            }),
+        ],
+    );
+
+    let code = issue_list::list(&gh, &Stage::Rework, "autopilot:", None, 50).unwrap();
+    assert_eq!(code, 0);
+}

--- a/plugins/github-autopilot/cli/tests/stats_tests.rs
+++ b/plugins/github-autopilot/cli/tests/stats_tests.rs
@@ -1,0 +1,121 @@
+mod mock_fs;
+mod mock_git;
+
+use autopilot::cmd::stats::StatsService;
+use mock_fs::MockFs;
+use mock_git::MockGit;
+
+fn make_svc(git: MockGit, fs: MockFs) -> StatsService {
+    StatsService::new(Box::new(git), Box::new(fs))
+}
+
+#[test]
+fn init_creates_stats_file() {
+    let git = MockGit::new();
+    let fs = MockFs::new();
+
+    let code = make_svc(git, fs.clone()).init().unwrap();
+    assert_eq!(code, 0);
+
+    let written = fs.written_files();
+    assert_eq!(written.len(), 1);
+    assert!(written[0]
+        .0
+        .to_str()
+        .unwrap()
+        .contains("session-stats.json"));
+
+    let stats: serde_json::Value = serde_json::from_str(&written[0].1).unwrap();
+    assert!(stats["started_at"].is_string());
+    assert_eq!(stats["commands"], serde_json::json!({}));
+}
+
+#[test]
+fn update_accumulates_stats() {
+    let git = MockGit::new();
+    let fs = MockFs::new();
+    let svc = make_svc(git, fs.clone());
+
+    // First update (no existing file — auto-init)
+    let code = svc.update("build-issues", 3, 2, 1, 0).unwrap();
+    assert_eq!(code, 0);
+
+    // Simulate second update by providing the written state
+    let written = fs.written_files();
+    let git2 = MockGit::new();
+    let fs2 = MockFs::new().with_file(
+        "/tmp/autopilot-repo/state/session-stats.json",
+        &written[0].1,
+    );
+    let svc2 = make_svc(git2, fs2.clone());
+
+    let code = svc2.update("build-issues", 1, 1, 0, 0).unwrap();
+    assert_eq!(code, 0);
+
+    let written2 = fs2.written_files();
+    let stats: serde_json::Value = serde_json::from_str(&written2[0].1).unwrap();
+    let cmd = &stats["commands"]["build-issues"];
+    assert_eq!(cmd["total_cycles"], 2);
+    assert_eq!(cmd["processed"], 4);
+    assert_eq!(cmd["success"], 3);
+    assert_eq!(cmd["failed"], 1);
+}
+
+#[test]
+fn update_idle_cycle_increments_consecutive() {
+    let git = MockGit::new();
+    let fs = MockFs::new();
+    let svc = make_svc(git, fs.clone());
+
+    // processed=0 means idle
+    let code = svc.update("build-issues", 0, 0, 0, 0).unwrap();
+    assert_eq!(code, 0);
+
+    let written = fs.written_files();
+    let stats: serde_json::Value = serde_json::from_str(&written[0].1).unwrap();
+    let cmd = &stats["commands"]["build-issues"];
+    assert_eq!(cmd["idle_cycles"], 1);
+    assert_eq!(cmd["consecutive_idle"], 1);
+}
+
+#[test]
+fn update_active_cycle_resets_consecutive_idle() {
+    let git = MockGit::new();
+    // Pre-seed with 3 consecutive idle cycles
+    let fs = MockFs::new().with_file(
+        "/tmp/autopilot-repo/state/session-stats.json",
+        r#"{"started_at":"2026-04-13T00:00:00Z","commands":{"build-issues":{"total_cycles":3,"processed":0,"success":0,"failed":0,"false_positive":0,"idle_cycles":3,"consecutive_idle":3,"agent_calls":0}}}"#,
+    );
+    let svc = make_svc(git, fs.clone());
+
+    let code = svc.update("build-issues", 2, 2, 0, 0).unwrap();
+    assert_eq!(code, 0);
+
+    let written = fs.written_files();
+    let stats: serde_json::Value = serde_json::from_str(&written[0].1).unwrap();
+    let cmd = &stats["commands"]["build-issues"];
+    assert_eq!(cmd["consecutive_idle"], 0);
+    assert_eq!(cmd["idle_cycles"], 3); // idle_cycles doesn't reset
+    assert_eq!(cmd["total_cycles"], 4);
+}
+
+#[test]
+fn show_returns_0_when_no_stats() {
+    let git = MockGit::new();
+    let fs = MockFs::new();
+
+    let code = make_svc(git, fs).show(None).unwrap();
+    assert_eq!(code, 0);
+}
+
+#[test]
+fn show_with_command_filter() {
+    let git = MockGit::new();
+    let fs = MockFs::new().with_file(
+        "/tmp/autopilot-repo/state/session-stats.json",
+        r#"{"started_at":"2026-04-13T00:00:00Z","commands":{"build-issues":{"total_cycles":5,"processed":3,"success":2,"failed":1,"false_positive":0,"idle_cycles":2,"consecutive_idle":0,"agent_calls":3}}}"#,
+    );
+
+    let code = make_svc(git, fs).show(Some("build-issues")).unwrap();
+    assert_eq!(code, 0);
+}

--- a/plugins/github-autopilot/cli/tests/stats_tests.rs
+++ b/plugins/github-autopilot/cli/tests/stats_tests.rs
@@ -100,6 +100,51 @@ fn update_active_cycle_resets_consecutive_idle() {
 }
 
 #[test]
+fn update_active_cycle_accumulates_agent_calls() {
+    let git = MockGit::new();
+    let fs = MockFs::new().with_file(
+        "/tmp/autopilot-repo/state/session-stats.json",
+        r#"{"started_at":"2026-04-13T00:00:00Z","commands":{"build-issues":{"total_cycles":1,"processed":3,"success":2,"failed":1,"false_positive":0,"idle_cycles":0,"consecutive_idle":0,"agent_calls":3}}}"#,
+    );
+    let svc = make_svc(git, fs.clone());
+
+    let code = svc.update("build-issues", 2, 2, 0, 0).unwrap();
+    assert_eq!(code, 0);
+
+    let written = fs.written_files();
+    let stats: serde_json::Value = serde_json::from_str(&written[0].1).unwrap();
+    let cmd = &stats["commands"]["build-issues"];
+    assert_eq!(cmd["agent_calls"], 5); // 3 + 2
+    assert_eq!(cmd["processed"], 5); // 3 + 2
+    assert_eq!(cmd["consecutive_idle"], 0);
+}
+
+#[test]
+fn update_multiple_commands_independent() {
+    let git = MockGit::new();
+    let fs = MockFs::new();
+    let svc = make_svc(git, fs.clone());
+
+    svc.update("build-issues", 1, 1, 0, 0).unwrap();
+
+    let written = fs.written_files();
+    let git2 = MockGit::new();
+    let fs2 = MockFs::new().with_file(
+        "/tmp/autopilot-repo/state/session-stats.json",
+        &written[0].1,
+    );
+    let svc2 = make_svc(git2, fs2.clone());
+
+    svc2.update("gap-watch", 0, 0, 0, 0).unwrap();
+
+    let written2 = fs2.written_files();
+    let stats: serde_json::Value = serde_json::from_str(&written2[0].1).unwrap();
+    assert_eq!(stats["commands"]["build-issues"]["total_cycles"], 1);
+    assert_eq!(stats["commands"]["gap-watch"]["total_cycles"], 1);
+    assert_eq!(stats["commands"]["gap-watch"]["idle_cycles"], 1);
+}
+
+#[test]
 fn show_returns_0_when_no_stats() {
     let git = MockGit::new();
     let fs = MockFs::new();

--- a/plugins/github-autopilot/commands/autopilot.md
+++ b/plugins/github-autopilot/commands/autopilot.md
@@ -119,14 +119,6 @@ autopilot 시작 시 기존 갭과 미분석 이슈를 감지합니다.
 
 > hybrid/cron 모드 모두 동일하게 적용됩니다.
 
-#### 1.7c: 세션 통계 초기화
-
-```bash
-autopilot stats init
-```
-
-> `/tmp/autopilot-{repo}/session-stats.json`을 초기화합니다. 기존 파일이 있으면 덮어씁니다.
-
 ### Step 2: 모드 분기
 
 `event_mode` 설정에 따라 분기합니다:

--- a/plugins/github-autopilot/commands/autopilot.md
+++ b/plugins/github-autopilot/commands/autopilot.md
@@ -104,15 +104,11 @@ autopilot 시작 시 기존 갭과 미분석 이슈를 감지합니다.
 
 세션 시작 전 생성된 이슈 중 autopilot 분석이 아직 되지 않은 이슈를 처리합니다.
 
-1. 열린 이슈를 조회합니다:
+1. CLI로 미분석 이슈를 조회합니다:
    ```bash
-   gh issue list --state open --json number,title,labels,comments --limit 20
+   autopilot issue list --stage unanalyzed --label-prefix "{label_prefix}" --limit 20
    ```
-2. 다음 조건을 모두 만족하는 이슈를 필터링합니다:
-   - `{label_prefix}`로 시작하는 라벨이 **없음** (autopilot 미처리)
-   - 코멘트에 `Autopilot 분석 결과`가 **없음** (분석 미완료)
-   - 코멘트에 `<!-- autopilot:false-positive -->`가 **없음** (이전에 false positive로 close된 이슈 제외)
-3. 해당 이슈들에 대해 `/github-autopilot:analyze-issue {number}`를 병렬 실행합니다 (`max_parallel_agents` 단위로 분할)
+2. 반환된 이슈들에 대해 `/github-autopilot:analyze-issue {number}`를 병렬 실행합니다 (`max_parallel_agents` 단위로 분할)
 4. 결과 로그:
    - 처리됨: "초기 이슈 분석 완료 — {N}건 분석 ({M}건 ready 라벨 부여)"
    - 대상 없음: "초기 이슈 분석 완료 — 미분석 이슈 없음"

--- a/plugins/github-autopilot/commands/autopilot.md
+++ b/plugins/github-autopilot/commands/autopilot.md
@@ -119,6 +119,14 @@ autopilot 시작 시 기존 갭과 미분석 이슈를 감지합니다.
 
 > hybrid/cron 모드 모두 동일하게 적용됩니다.
 
+#### 1.7c: 세션 통계 초기화
+
+```bash
+autopilot stats init
+```
+
+> `/tmp/autopilot-{repo}/state/session-stats.json`을 초기화합니다. 기존 파일이 있으면 덮어씁니다.
+
 ### Step 2: 모드 분기
 
 `event_mode` 설정에 따라 분기합니다:

--- a/plugins/github-autopilot/commands/autopilot.md
+++ b/plugins/github-autopilot/commands/autopilot.md
@@ -84,11 +84,13 @@ autopilot preflight --config github-autopilot.local.md --repo-root .
 
 > `spec_paths`에 파일이 없으면 이 단계를 skip합니다 (preflight에서 이미 확인).
 
-### Step 1.7: 초기 Gap 분석
+### Step 1.7: 초기 스캔 (Initial Scan)
 
-autopilot 시작 시 기존 갭을 감지하기 위해 `/github-autopilot:gap-watch`를 1회 실행합니다.
+autopilot 시작 시 기존 갭과 미분석 이슈를 감지합니다.
 
-> 이벤트 드리븐 모드에서는 `MAIN_UPDATED` 이벤트가 발생해야 gap-watch가 트리거되므로, 시작 시점에 이미 존재하는 갭은 이 단계에서 감지합니다.
+> 이벤트 드리븐 모드에서는 이벤트가 발생해야 각 커맨드가 트리거되므로, 시작 시점에 이미 존재하는 갭과 미분석 이슈는 이 단계에서 처리합니다.
+
+#### 1.7a: 초기 Gap 분석
 
 1. `spec_paths`에 스펙 파일이 있으면 `/github-autopilot:gap-watch`를 실행합니다
 2. 발견된 갭이 이슈로 등록됩니다
@@ -97,7 +99,33 @@ autopilot 시작 시 기존 갭을 감지하기 위해 `/github-autopilot:gap-wa
    - 갭 없음: "초기 갭 분석 완료 — 갭 없음"
 
 > `spec_paths`에 파일이 없으면 이 단계를 skip합니다 (Step 1.6과 동일 조건).
+
+#### 1.7b: 미분석 이슈 처리
+
+세션 시작 전 생성된 이슈 중 autopilot 분석이 아직 되지 않은 이슈를 처리합니다.
+
+1. 열린 이슈를 조회합니다:
+   ```bash
+   gh issue list --state open --json number,title,labels,comments --limit 20
+   ```
+2. 다음 조건을 모두 만족하는 이슈를 필터링합니다:
+   - `{label_prefix}`로 시작하는 라벨이 **없음** (autopilot 미처리)
+   - 코멘트에 `Autopilot 분석 결과`가 **없음** (분석 미완료)
+   - 코멘트에 `<!-- autopilot:false-positive -->`가 **없음** (이전에 false positive로 close된 이슈 제외)
+3. 해당 이슈들에 대해 `/github-autopilot:analyze-issue {number}`를 병렬 실행합니다 (`max_parallel_agents` 단위로 분할)
+4. 결과 로그:
+   - 처리됨: "초기 이슈 분석 완료 — {N}건 분석 ({M}건 ready 라벨 부여)"
+   - 대상 없음: "초기 이슈 분석 완료 — 미분석 이슈 없음"
+
 > hybrid/cron 모드 모두 동일하게 적용됩니다.
+
+#### 1.7c: 세션 통계 초기화
+
+```bash
+autopilot stats init
+```
+
+> `/tmp/autopilot-{repo}/session-stats.json`을 초기화합니다. 기존 파일이 있으면 덮어씁니다.
 
 ### Step 2: 모드 분기
 

--- a/plugins/github-autopilot/commands/build-issues.md
+++ b/plugins/github-autopilot/commands/build-issues.md
@@ -104,36 +104,17 @@ gh issue comment ${ISSUE_NUMBER} --body "<!-- notified -->"
 
 ### Step 5: Ready 이슈 조회
 
-설정에서 label_prefix를 확인합니다 (기본값: `autopilot:`).
-
 ```bash
-gh issue list \
-  --label "{label_prefix}ready" \
-  --state open \
-  --json number,title,body,labels,comments \
-  --limit 20
+autopilot issue list --stage ready --label-prefix "{label_prefix}" --limit 20
 ```
-
-이미 `{label_prefix}wip` 라벨이 붙은 이슈는 제외합니다 (진행 중인 작업).
 
 이슈가 없으면 `autopilot check mark build-issues --status idle` 후 "구현 대상 이슈 없음" 출력 후 종료.
 
 ### Step 5.5: 코멘트 기반 재작업 감지
 
-Step 5에서 제외된 이슈(ready 라벨 없음) 중, 코멘트에 재작업 요청이 포함된 이슈를 탐색합니다.
-
 ```bash
-gh issue list \
-  --state open \
-  --json number,title,body,labels,comments \
-  --limit 50
+autopilot issue list --stage rework --label-prefix "{label_prefix}"
 ```
-
-필터 조건:
-- `{label_prefix}ready` 라벨이 **없음**
-- `{label_prefix}wip` 라벨이 **없음**
-- 코멘트에 재작업 키워드 포함: `재구현 필요`, `재작업`, `rework`, `다시 구현`, `re-implement`, `라우트가.*제거됨`
-- 해당 키워드가 포함된 코멘트 이후에 `<!-- autopilot:rework-resolved -->` 마커가 **없음** (이미 처리된 건 제외)
 
 해당 이슈가 발견되면:
 1. `{label_prefix}ready` 라벨을 재부여합니다:
@@ -185,14 +166,18 @@ gh issue edit ${ISSUE_NUMBER} --add-label "{label_prefix}wip"
 
 ### Step 7.5: Gap 이슈 사전 검증
 
-현재 배치의 이슈 중 gap-fingerprint를 포함한 이슈의 스펙 파일 실존 여부를 확인합니다. gap-detector와 gap-issue-creator에서 이미 검증하지만, 이슈 생성 이후 스펙 파일이 삭제/이동된 경우를 방어합니다.
+현재 배치의 이슈 중 gap-fingerprint를 포함한 이슈의 스펙 파일 실존 여부를 CLI로 확인합니다.
 
-> Test-scope 필터링은 gap-detector Phase 2에서 수행되므로 여기서 중복 검사하지 않습니다.
+각 이슈의 body를 `extract-fingerprint`에 전달합니다:
 
-1. 이슈 body에서 fingerprint 추출: `<!-- gap-fingerprint: gap:{spec_path}:{requirement_keyword} -->`
-2. fingerprint가 없는 이슈는 검증을 건너뛰고 Step 8로 진행
-3. fingerprint가 있는 이슈: `[ -f "${SPEC_PATH}" ]`로 스펙 파일 실존 확인
-4. 스펙 파일이 없는 이슈:
+```bash
+echo "${ISSUE_BODY}" | autopilot issue extract-fingerprint
+# exit 0: {"found": true, "fingerprint": "...", "spec_path": "...", "spec_exists": true/false}
+# exit 1: {"found": false}  — gap 이슈가 아님, Step 8로 진행
+```
+
+- `found: false` 또는 `spec_exists: true` → Step 8로 진행
+- `spec_exists: false` → false positive, 이슈를 close:
    ```bash
    gh issue close ${ISSUE_NUMBER} --comment "$(cat <<'EOF'
    Autopilot: 스펙 파일이 존재하지 않아 false positive로 판정하여 close합니다.

--- a/plugins/github-autopilot/commands/build-issues.md
+++ b/plugins/github-autopilot/commands/build-issues.md
@@ -43,9 +43,7 @@ autopilot pipeline idle --label-prefix "{label_prefix}"
 - **exit 2 (error)**: 스크립트 실행 환경 오류. 에러 메시지를 출력하고 이번 cycle을 skip합니다.
 - **exit 1 (active)**: Step 4부터 정상 진행
 
-### Step 3.5: Idle Count Check + Adaptive Throttling
-
-> gap-watch Step 1.7에도 동일한 throttling 패턴이 적용됩니다. 로직 변경 시 양쪽을 함께 수정하세요.
+### Step 3.5: Idle Count Check
 
 이전 Step의 결과가 "대상 없음"(idle)이면, 연속 idle 횟수를 기록합니다.
 
@@ -55,20 +53,13 @@ autopilot check mark build-issues --status idle
 
 설정에서 `idle_shutdown.max_idle` 값을 읽습니다 (기본값: 5).
 
-연속 idle 횟수에 따라 동적으로 간격을 조정합니다:
+연속 idle 횟수가 `max_idle` 이상이면:
+1. `autopilot cron self-delete --name "build-issues"` 로 cron을 자동 해제합니다.
+2. "연속 {N}회 idle — cron 자동 해제" 메시지를 출력하고 종료합니다.
 
-| 연속 idle 횟수 | 동작 |
-|---------------|------|
-| 1~3회 | 현재 간격 유지 |
-| 4~`max_idle`-1회 | 간격 2배로 확대: `autopilot cron update --name "build-issues" --multiply 2` |
-| `max_idle`회 이상 | `autopilot cron self-delete --name "build-issues"` 로 자동 해제. "연속 {N}회 idle — cron 자동 해제" 출력 후 종료 |
-
-> 간격 확대는 한 번만 적용됩니다 (4회째에 2배로 변경 후, 5~max_idle-1회까지 유지).
-
-실제 작업을 수행하면 idle count를 리셋하고 간격을 원래 값으로 복원합니다:
+실제 작업을 수행하면 idle count를 리셋합니다:
 ```bash
 autopilot check mark build-issues --status active
-autopilot cron update --name "build-issues" --reset
 ```
 
 ### Step 4: Skip 이슈 알림
@@ -335,8 +326,6 @@ gh issue view ${ISSUE_NUMBER} --json comments --jq '.comments[].body' | grep -o 
 
 ### Step 12: 결과 보고
 
-#### 12a: Cycle 결과
-
 ```
 ## Build Issues 결과
 
@@ -362,36 +351,6 @@ gh issue view ${ISSUE_NUMBER} --json comments --jq '.comments[].body' | grep -o 
 - #43 → PR #51 (feature/issue-43)
 - #44 → PR #52 (feature/issue-44)
 ```
-
-#### 12b: 세션 누적 통계
-
-매 cycle 종료 시 세션 통계를 업데이트하고 출력합니다:
-
-```bash
-autopilot stats update \
-  --command build-issues \
-  --processed ${PROCESSED} \
-  --success ${SUCCESS} \
-  --failed ${FAILED} \
-  --false-positive ${FALSE_POSITIVE}
-
-autopilot stats show --command build-issues
-```
-
-출력 형식:
-```
-### 세션 누적 통계
-- 총 cycles: 15
-- 처리 이슈: 11건
-  - 성공 (PR 생성): 3건
-  - false positive (close): 6건
-  - 실패 (재시도/에스컬레이션): 2건
-- idle cycles: 8회 (현재 연속 2회)
-- 총 agent 호출: 9회
-```
-
-> 통계는 `/tmp/autopilot-{repo}/session-stats.json`에 세션 동안 누적됩니다.
-> 세션 시작 시(autopilot.md Step 1) 자동 초기화됩니다.
 
 ## 주의사항
 

--- a/plugins/github-autopilot/commands/build-issues.md
+++ b/plugins/github-autopilot/commands/build-issues.md
@@ -43,7 +43,9 @@ autopilot pipeline idle --label-prefix "{label_prefix}"
 - **exit 2 (error)**: 스크립트 실행 환경 오류. 에러 메시지를 출력하고 이번 cycle을 skip합니다.
 - **exit 1 (active)**: Step 4부터 정상 진행
 
-### Step 3.5: Idle Count Check
+### Step 3.5: Idle Count Check + Adaptive Throttling
+
+> gap-watch Step 1.7에도 동일한 throttling 패턴이 적용됩니다. 로직 변경 시 양쪽을 함께 수정하세요.
 
 이전 Step의 결과가 "대상 없음"(idle)이면, 연속 idle 횟수를 기록합니다.
 
@@ -53,13 +55,20 @@ autopilot check mark build-issues --status idle
 
 설정에서 `idle_shutdown.max_idle` 값을 읽습니다 (기본값: 5).
 
-연속 idle 횟수가 `max_idle` 이상이면:
-1. `autopilot cron self-delete --name "build-issues"` 로 cron을 자동 해제합니다.
-2. "연속 {N}회 idle — cron 자동 해제" 메시지를 출력하고 종료합니다.
+연속 idle 횟수에 따라 동적으로 간격을 조정합니다:
 
-실제 작업을 수행하면 idle count를 리셋합니다:
+| 연속 idle 횟수 | 동작 |
+|---------------|------|
+| 1~3회 | 현재 간격 유지 |
+| 4~`max_idle`-1회 | 간격 2배로 확대: `autopilot cron update --name "build-issues" --multiply 2` |
+| `max_idle`회 이상 | `autopilot cron self-delete --name "build-issues"` 로 자동 해제. "연속 {N}회 idle — cron 자동 해제" 출력 후 종료 |
+
+> 간격 확대는 한 번만 적용됩니다 (4회째에 2배로 변경 후, 5~max_idle-1회까지 유지).
+
+실제 작업을 수행하면 idle count를 리셋하고 간격을 원래 값으로 복원합니다:
 ```bash
 autopilot check mark build-issues --status active
+autopilot cron update --name "build-issues" --reset
 ```
 
 ### Step 4: Skip 이슈 알림
@@ -172,6 +181,31 @@ echo '${BATCH_ISSUES_JSON}' | autopilot issue detect-overlap --threshold 15
 ```bash
 gh issue edit ${ISSUE_NUMBER} --add-label "{label_prefix}wip"
 ```
+
+### Step 7.5: Gap 이슈 사전 검증
+
+현재 배치의 이슈 중 gap-fingerprint를 포함한 이슈의 스펙 파일 실존 여부를 확인합니다. gap-detector와 gap-issue-creator에서 이미 검증하지만, 이슈 생성 이후 스펙 파일이 삭제/이동된 경우를 방어합니다.
+
+> Test-scope 필터링은 gap-detector Phase 2에서 수행되므로 여기서 중복 검사하지 않습니다.
+
+1. 이슈 body에서 fingerprint 추출: `<!-- gap-fingerprint: gap:{spec_path}:{requirement_keyword} -->`
+2. fingerprint가 없는 이슈는 검증을 건너뛰고 Step 8로 진행
+3. fingerprint가 있는 이슈: `[ -f "${SPEC_PATH}" ]`로 스펙 파일 실존 확인
+4. 스펙 파일이 없는 이슈:
+   ```bash
+   gh issue close ${ISSUE_NUMBER} --comment "$(cat <<'EOF'
+   Autopilot: 스펙 파일이 존재하지 않아 false positive로 판정하여 close합니다.
+
+   - spec path: 실제 스펙 파일 미존재
+
+   <!-- autopilot:false-positive -->
+   EOF
+   )"
+   gh issue edit ${ISSUE_NUMBER} --remove-label "{label_prefix}ready" --remove-label "{label_prefix}wip"
+   ```
+5. close된 이슈는 배치에서 제외하고 결과 보고에 포함
+
+배치에 남은 이슈가 없으면 Step 12로 진행합니다.
 
 ### Step 8: 구현 (Agent Team)
 
@@ -301,11 +335,16 @@ gh issue view ${ISSUE_NUMBER} --json comments --jq '.comments[].body' | grep -o 
 
 ### Step 12: 결과 보고
 
+#### 12a: Cycle 결과
+
 ```
 ## Build Issues 결과
 
 ### Skip 이슈 알림
 - 대기 중: #38 (알림 전송됨 → Slack DM)
+
+### 사전 검증 (Step 7.5)
+- false positive close: #55, #56 (test fixture spec)
 
 ### 구현 대상
 - 대상 이슈: 5개
@@ -323,6 +362,36 @@ gh issue view ${ISSUE_NUMBER} --json comments --jq '.comments[].body' | grep -o 
 - #43 → PR #51 (feature/issue-43)
 - #44 → PR #52 (feature/issue-44)
 ```
+
+#### 12b: 세션 누적 통계
+
+매 cycle 종료 시 세션 통계를 업데이트하고 출력합니다:
+
+```bash
+autopilot stats update \
+  --command build-issues \
+  --processed ${PROCESSED} \
+  --success ${SUCCESS} \
+  --failed ${FAILED} \
+  --false-positive ${FALSE_POSITIVE}
+
+autopilot stats show --command build-issues
+```
+
+출력 형식:
+```
+### 세션 누적 통계
+- 총 cycles: 15
+- 처리 이슈: 11건
+  - 성공 (PR 생성): 3건
+  - false positive (close): 6건
+  - 실패 (재시도/에스컬레이션): 2건
+- idle cycles: 8회 (현재 연속 2회)
+- 총 agent 호출: 9회
+```
+
+> 통계는 `/tmp/autopilot-{repo}/session-stats.json`에 세션 동안 누적됩니다.
+> 세션 시작 시(autopilot.md Step 1) 자동 초기화됩니다.
 
 ## 주의사항
 

--- a/plugins/github-autopilot/commands/build-issues.md
+++ b/plugins/github-autopilot/commands/build-issues.md
@@ -43,23 +43,33 @@ autopilot pipeline idle --label-prefix "{label_prefix}"
 - **exit 2 (error)**: 스크립트 실행 환경 오류. 에러 메시지를 출력하고 이번 cycle을 skip합니다.
 - **exit 1 (active)**: Step 4부터 정상 진행
 
-### Step 3.5: Idle Count Check
+### Step 3.5: Idle Count Check + Adaptive Throttling
 
-이전 Step의 결과가 "대상 없음"(idle)이면, 연속 idle 횟수를 기록합니다.
+> gap-watch Step 1.7에도 동일한 throttling 패턴이 적용됩니다. 로직 변경 시 양쪽을 함께 수정하세요.
+
+이전 Step의 결과가 "대상 없음"(idle)이면, CLI로 idle 횟수를 기록하고 출력에서 `idle_count`를 읽습니다.
 
 ```bash
 autopilot check mark build-issues --status idle
+# 출력: marked build-issues: abc1234 at 2026-04-13T10:00:00Z (idle_count: 4)
 ```
 
 설정에서 `idle_shutdown.max_idle` 값을 읽습니다 (기본값: 5).
 
-연속 idle 횟수가 `max_idle` 이상이면:
-1. `autopilot cron self-delete --name "build-issues"` 로 cron을 자동 해제합니다.
-2. "연속 {N}회 idle — cron 자동 해제" 메시지를 출력하고 종료합니다.
+출력의 `idle_count`에 따라 동적으로 간격을 조정합니다:
 
-실제 작업을 수행하면 idle count를 리셋합니다:
+| idle_count | 동작 |
+|------------|------|
+| 1~3 | 현재 간격 유지 |
+| 4~`max_idle`-1 | CronList로 현재 cron을 찾아 CronDelete 후, 간격 2배로 CronCreate 재등록 |
+| `max_idle` 이상 | CronList로 현재 cron을 찾아 CronDelete. "연속 {N}회 idle — cron 자동 해제" 출력 후 종료 |
+
+> 간격 확대는 한 번만 적용됩니다 (4회째에 2배로 변경 후, 5~max_idle-1까지 유지).
+
+실제 작업을 수행하면 idle count를 리셋하고, 간격이 변경되었으면 원래 간격으로 CronDelete → CronCreate합니다:
 ```bash
 autopilot check mark build-issues --status active
+# idle_count가 0으로 리셋됨 → 간격 복원 필요 시 CronDelete + CronCreate
 ```
 
 ### Step 4: Skip 이슈 알림
@@ -351,6 +361,24 @@ gh issue view ${ISSUE_NUMBER} --json comments --jq '.comments[].body' | grep -o 
 - #43 → PR #51 (feature/issue-43)
 - #44 → PR #52 (feature/issue-44)
 ```
+
+#### 12b: 세션 누적 통계
+
+매 cycle 종료 시 CLI로 세션 통계를 업데이트하고 출력합니다:
+
+```bash
+autopilot stats update \
+  --command build-issues \
+  --processed ${PROCESSED} \
+  --success ${SUCCESS} \
+  --failed ${FAILED} \
+  --false-positive ${FALSE_POSITIVE}
+
+autopilot stats show --command build-issues
+```
+
+> 통계는 `/tmp/autopilot-{repo}/state/session-stats.json`에 CLI가 누적 관리합니다.
+> 세션 시작 시(autopilot.md Step 1.7c) `autopilot stats init`으로 초기화됩니다.
 
 ## 주의사항
 

--- a/plugins/github-autopilot/commands/gap-watch.md
+++ b/plugins/github-autopilot/commands/gap-watch.md
@@ -37,9 +37,7 @@ autopilot pipeline idle --label-prefix "{label_prefix}"
 - **exit 2 (error)**: 스크립트 실행 환경 오류. 에러 메시지를 출력하고 이번 cycle을 skip합니다.
 - **exit 1 (active)**: Step 2부터 정상 진행.
 
-### Step 1.7: Idle Count Check + Adaptive Throttling
-
-> build-issues Step 3.5에도 동일한 throttling 패턴이 적용됩니다. 로직 변경 시 양쪽을 함께 수정하세요.
+### Step 1.7: Idle Count Check
 
 이전 Step의 결과가 "대상 없음"(idle)이면, 연속 idle 횟수를 기록합니다.
 
@@ -49,20 +47,13 @@ autopilot check mark gap-watch --status idle
 
 설정에서 `idle_shutdown.max_idle` 값을 읽습니다 (기본값: 5).
 
-연속 idle 횟수에 따라 동적으로 간격을 조정합니다:
+연속 idle 횟수가 `max_idle` 이상이면:
+1. `autopilot cron self-delete --name "gap-watch"` 로 cron을 자동 해제합니다.
+2. "연속 {N}회 idle — cron 자동 해제" 메시지를 출력하고 종료합니다.
 
-| 연속 idle 횟수 | 동작 |
-|---------------|------|
-| 1~3회 | 현재 간격 유지 |
-| 4~`max_idle`-1회 | 간격 2배로 확대: `autopilot cron update --name "gap-watch" --multiply 2` |
-| `max_idle`회 이상 | `autopilot cron self-delete --name "gap-watch"` 로 자동 해제. "연속 {N}회 idle — cron 자동 해제" 출력 후 종료 |
-
-> 간격 확대는 한 번만 적용됩니다 (4회째에 2배로 변경 후, 5~max_idle-1회까지 유지).
-
-실제 작업을 수행하면 idle count를 리셋하고 간격을 원래 값으로 복원합니다:
+실제 작업을 수행하면 idle count를 리셋합니다:
 ```bash
 autopilot check mark gap-watch --status active
-autopilot cron update --name "gap-watch" --reset
 ```
 
 ### Step 2: 설정 로딩

--- a/plugins/github-autopilot/commands/gap-watch.md
+++ b/plugins/github-autopilot/commands/gap-watch.md
@@ -37,7 +37,9 @@ autopilot pipeline idle --label-prefix "{label_prefix}"
 - **exit 2 (error)**: 스크립트 실행 환경 오류. 에러 메시지를 출력하고 이번 cycle을 skip합니다.
 - **exit 1 (active)**: Step 2부터 정상 진행.
 
-### Step 1.7: Idle Count Check
+### Step 1.7: Idle Count Check + Adaptive Throttling
+
+> build-issues Step 3.5에도 동일한 throttling 패턴이 적용됩니다. 로직 변경 시 양쪽을 함께 수정하세요.
 
 이전 Step의 결과가 "대상 없음"(idle)이면, 연속 idle 횟수를 기록합니다.
 
@@ -47,13 +49,20 @@ autopilot check mark gap-watch --status idle
 
 설정에서 `idle_shutdown.max_idle` 값을 읽습니다 (기본값: 5).
 
-연속 idle 횟수가 `max_idle` 이상이면:
-1. `autopilot cron self-delete --name "gap-watch"` 로 cron을 자동 해제합니다.
-2. "연속 {N}회 idle — cron 자동 해제" 메시지를 출력하고 종료합니다.
+연속 idle 횟수에 따라 동적으로 간격을 조정합니다:
 
-실제 작업을 수행하면 idle count를 리셋합니다:
+| 연속 idle 횟수 | 동작 |
+|---------------|------|
+| 1~3회 | 현재 간격 유지 |
+| 4~`max_idle`-1회 | 간격 2배로 확대: `autopilot cron update --name "gap-watch" --multiply 2` |
+| `max_idle`회 이상 | `autopilot cron self-delete --name "gap-watch"` 로 자동 해제. "연속 {N}회 idle — cron 자동 해제" 출력 후 종료 |
+
+> 간격 확대는 한 번만 적용됩니다 (4회째에 2배로 변경 후, 5~max_idle-1회까지 유지).
+
+실제 작업을 수행하면 idle count를 리셋하고 간격을 원래 값으로 복원합니다:
 ```bash
 autopilot check mark gap-watch --status active
+autopilot cron update --name "gap-watch" --reset
 ```
 
 ### Step 2: 설정 로딩

--- a/plugins/github-autopilot/commands/gap-watch.md
+++ b/plugins/github-autopilot/commands/gap-watch.md
@@ -37,23 +37,33 @@ autopilot pipeline idle --label-prefix "{label_prefix}"
 - **exit 2 (error)**: 스크립트 실행 환경 오류. 에러 메시지를 출력하고 이번 cycle을 skip합니다.
 - **exit 1 (active)**: Step 2부터 정상 진행.
 
-### Step 1.7: Idle Count Check
+### Step 1.7: Idle Count Check + Adaptive Throttling
 
-이전 Step의 결과가 "대상 없음"(idle)이면, 연속 idle 횟수를 기록합니다.
+> build-issues Step 3.5에도 동일한 throttling 패턴이 적용됩니다. 로직 변경 시 양쪽을 함께 수정하세요.
+
+이전 Step의 결과가 "대상 없음"(idle)이면, CLI로 idle 횟수를 기록하고 출력에서 `idle_count`를 읽습니다.
 
 ```bash
 autopilot check mark gap-watch --status idle
+# 출력: marked gap-watch: abc1234 at 2026-04-13T10:00:00Z (idle_count: 4)
 ```
 
 설정에서 `idle_shutdown.max_idle` 값을 읽습니다 (기본값: 5).
 
-연속 idle 횟수가 `max_idle` 이상이면:
-1. `autopilot cron self-delete --name "gap-watch"` 로 cron을 자동 해제합니다.
-2. "연속 {N}회 idle — cron 자동 해제" 메시지를 출력하고 종료합니다.
+출력의 `idle_count`에 따라 동적으로 간격을 조정합니다:
 
-실제 작업을 수행하면 idle count를 리셋합니다:
+| idle_count | 동작 |
+|------------|------|
+| 1~3 | 현재 간격 유지 |
+| 4~`max_idle`-1 | CronList로 현재 cron을 찾아 CronDelete 후, 간격 2배로 CronCreate 재등록 |
+| `max_idle` 이상 | CronList로 현재 cron을 찾아 CronDelete. "연속 {N}회 idle — cron 자동 해제" 출력 후 종료 |
+
+> 간격 확대는 한 번만 적용됩니다 (4회째에 2배로 변경 후, 5~max_idle-1까지 유지).
+
+실제 작업을 수행하면 idle count를 리셋하고, 간격이 변경되었으면 원래 간격으로 CronDelete → CronCreate합니다:
 ```bash
 autopilot check mark gap-watch --status active
+# idle_count가 0으로 리셋됨 → 간격 복원 필요 시 CronDelete + CronCreate
 ```
 
 ### Step 2: 설정 로딩


### PR DESCRIPTION
## Summary

### False Positive 방어 (#632, #630)
- gap-detector: Phase 2 test-scope 필터링, Phase 3 spec_paths cross-validation
- gap-issue-creator: WARNING 항목 skip
- build-issues Step 7.5: `autopilot issue extract-fingerprint`로 spec 실존 사전검증

### Cold Start 해결 (#628)
- autopilot Step 1.7b: `autopilot issue list --stage unanalyzed`로 미분석 이슈 초기 스캔

### Adaptive Throttling (#629)
- `check mark --status idle/active`: CLI가 idle_count를 상태 파일로 관리
- LLM이 출력의 idle_count를 읽고 CronList/CronDelete/CronCreate로 간격 조정

### Session Statistics (#631)
- `stats init/update/show`: CLI가 세션 통계를 JSON으로 누적 관리

### Label Lifecycle CLI (신규)
- `issue list --stage unanalyzed|ready|rework|wip|escalated`: 라벨/코멘트 기반 필터링을 CLI로 통합
- `issue extract-fingerprint`: gap-fingerprint HTML 파싱 + spec 실존 확인
- `--require-label` 옵션으로 특정 라벨 필터 지원

Closes #628, #629, #630, #631, #632

## Changed files

### CLI (Rust)
| File | Change |
|------|--------|
| `cli/src/cmd/issue_list.rs` | **신규** — `list --stage` + `extract-fingerprint` |
| `cli/src/cmd/stats.rs` | **신규** — session stats service |
| `cli/src/cmd/labels.rs` | `has_prefixed_label`, `has_label`, `has_exact_label` 헬퍼 |
| `cli/src/cmd/check/state.rs` | `LoopState.idle_count` 필드 |
| `cli/src/cmd/check/mod.rs` | `mark --status` 처리 |
| `cli/src/cmd/mod.rs` | `StatsCommands`, `ListArgs`, `Stage` enum |
| `cli/src/main.rs` | 신규 커맨드 wiring |

### Spec (명세)
| File | Change |
|------|--------|
| `agents/gap-detector.md` | Phase 2 test-scope, Phase 3 cross-validation |
| `agents/gap-issue-creator.md` | WARNING skip |
| `commands/autopilot.md` | Step 1.7b CLI 전환, 1.7c stats init |
| `commands/build-issues.md` | Step 5/5.5/7.5 CLI 전환, throttling, stats |
| `commands/gap-watch.md` | Adaptive throttling |

### Tests
- `tests/issue_list_tests.rs` — 3 integration tests
- `issue_list.rs` 내 12 unit tests (stage 필터링 + fingerprint 파싱)
- `tests/stats_tests.rs` — 6 tests
- `tests/check_tests.rs` — 3 tests (idle/active/backward-compat)

## Design decisions

- **상태(idle_count, stats)는 CLI 책임**: LLM context는 cycle마다 리셋되므로
- **Cron 간격 조정은 LLM 책임**: CronCreate/CronDelete는 Claude Code 내부 도구
- **`issue list --stage`가 label lifecycle 전체를 커버**: 새 stage 추가 시 CLI만 수정
- **slim JSON 출력 (number, title만)**: LLM 토큰 비용 최소화

## Test plan

- [ ] `cargo test` 전체 통과 (164+ tests)
- [ ] `make validate` 통과
- [ ] `autopilot issue list --stage ready --label-prefix "autopilot:"` 동작 확인
- [ ] `echo "body" | autopilot issue extract-fingerprint` 동작 확인
- [ ] `autopilot check mark X --status idle` → idle_count 증가 확인
- [ ] `autopilot stats init && autopilot stats update --command X --processed 3` 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)