### PR TITLE
feat(github-autopilot): skip idle check on first run and add check reset command

### DIFF
--- a/plugins/github-autopilot/cli/Cargo.lock
+++ b/plugins/github-autopilot/cli/Cargo.lock
@@ -60,7 +60,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "autopilot"
-version = "0.13.3"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/plugins/github-autopilot/cli/src/cmd/check/mod.rs
+++ b/plugins/github-autopilot/cli/src/cmd/check/mod.rs
@@ -12,7 +12,8 @@ use crate::git::GitOps;
 use analysis::{AnalysisContext, DiffAnalysis};
 use stagnation::classify_pattern;
 use state::{
-    append_output_entry, read_state, state_dir, validate_loop_name, write_state, OutputEntry,
+    append_output_entry, read_state, state_dir, state_file_path, validate_loop_name, write_state,
+    OutputEntry, STATE_EXT,
 };
 
 // Exit codes with business semantics
@@ -64,7 +65,7 @@ impl CheckService {
     /// Exit codes: 0=no_changes, 1=spec_changed, 2=code_changed, 3=first_run, 4=stagnation
     pub fn diff(&self, loop_name: &str, spec_paths: &[String]) -> Result<i32> {
         validate_loop_name(loop_name)?;
-        let state_file = state_dir(self.git.as_ref())?.join(format!("{loop_name}.state"));
+        let state_file = state_file_path(&state_dir(self.git.as_ref())?, loop_name);
 
         // Try reading state file; missing file means first run
         let state = match read_state(self.fs.as_ref(), &state_file) {
@@ -155,7 +156,7 @@ impl CheckService {
         status: Option<&crate::cmd::LoopStatus>,
     ) -> Result<i32> {
         validate_loop_name(loop_name)?;
-        let state_file = state_dir(self.git.as_ref())?.join(format!("{loop_name}.state"));
+        let state_file = state_file_path(&state_dir(self.git.as_ref())?, loop_name);
         let hash = self.git.rev_parse_head()?;
         let ts = state::utc_timestamp();
 
@@ -194,7 +195,7 @@ impl CheckService {
     pub fn status(&self) -> Result<i32> {
         let dir = state_dir(self.git.as_ref())?;
 
-        let files = match self.fs.list_files(&dir, "state") {
+        let files = match self.fs.list_files(&dir, STATE_EXT) {
             Ok(f) => f,
             Err(_) => {
                 println!("(no loop states found)");
@@ -230,7 +231,7 @@ impl CheckService {
         use crate::cmd::simhash;
 
         let dir = state_dir(self.git.as_ref())?;
-        let files = match self.fs.list_files(&dir, "state") {
+        let files = match self.fs.list_files(&dir, STATE_EXT) {
             Ok(f) => f,
             Err(_) => {
                 println!(r#"{{"loops":[],"overall":"healthy"}}"#);
@@ -289,6 +290,27 @@ impl CheckService {
         };
         let out = serde_json::json!({ "loops": loops, "overall": overall });
         println!("{out}");
+        Ok(0)
+    }
+
+    /// Reset (delete) state files. If loop_name is given, only that loop; otherwise all.
+    pub fn reset(&self, loop_name: Option<&str>) -> Result<i32> {
+        let dir = state_dir(self.git.as_ref())?;
+
+        if let Some(name) = loop_name {
+            validate_loop_name(name)?;
+            let state_file = state_file_path(&dir, name);
+            self.fs.remove_file(&state_file)?;
+            println!("reset {name}");
+        } else {
+            let files = self.fs.list_files(&dir, STATE_EXT).unwrap_or_default();
+            for file in &files {
+                self.fs.remove_file(file)?;
+            }
+            let count = files.len();
+            println!("reset {count} loop(s)");
+        }
+
         Ok(0)
     }
 }

--- a/plugins/github-autopilot/cli/src/cmd/check/state.rs
+++ b/plugins/github-autopilot/cli/src/cmd/check/state.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
 use crate::fs::FsOps;
@@ -8,6 +8,14 @@ use crate::git::GitOps;
 
 /// Maximum number of output entries to keep in history (sliding window).
 const MAX_OUTPUT_HISTORY: usize = 10;
+
+/// File extension for loop state files.
+pub const STATE_EXT: &str = "state";
+
+/// Build the state file path for a given loop name.
+pub fn state_file_path(dir: &Path, loop_name: &str) -> PathBuf {
+    dir.join(format!("{loop_name}.{STATE_EXT}"))
+}
 
 #[derive(Serialize, Deserialize, Clone, Default)]
 pub struct LoopState {
@@ -53,13 +61,13 @@ pub fn validate_loop_name(name: &str) -> Result<()> {
     Ok(())
 }
 
-pub fn read_state(fs: &dyn FsOps, state_file: &std::path::Path) -> Result<LoopState> {
+pub fn read_state(fs: &dyn FsOps, state_file: &Path) -> Result<LoopState> {
     let content = fs.read_file(state_file)?;
     let state: LoopState = serde_json::from_str(&content)?;
     Ok(state)
 }
 
-pub fn write_state(fs: &dyn FsOps, state_file: &std::path::Path, state: &LoopState) -> Result<()> {
+pub fn write_state(fs: &dyn FsOps, state_file: &Path, state: &LoopState) -> Result<()> {
     fs.write_file(state_file, &serde_json::to_string(state)?)
 }
 

--- a/plugins/github-autopilot/cli/src/cmd/issue_list.rs
+++ b/plugins/github-autopilot/cli/src/cmd/issue_list.rs
@@ -42,7 +42,7 @@ pub fn list(
         .filter(|issue| {
             require_label.is_none_or(|req| labels::has_exact_label(get_labels(issue), req))
         })
-        .map(|issue| slim_issue(issue))
+        .map(slim_issue)
         .collect();
 
     println!("{}", serde_json::to_string(&result)?);
@@ -109,7 +109,7 @@ pub fn filter_by_stage(issues: &[Value], stage: &Stage, label_prefix: &str) -> V
     issues
         .iter()
         .filter(|issue| matches_stage(issue, stage, label_prefix))
-        .map(|issue| slim_issue(issue))
+        .map(slim_issue)
         .collect()
 }
 

--- a/plugins/github-autopilot/cli/src/cmd/mod.rs
+++ b/plugins/github-autopilot/cli/src/cmd/mod.rs
@@ -80,6 +80,11 @@ pub enum CheckCommands {
     Status,
     /// Pipeline health report across all loops
     Health,
+    /// Reset (delete) loop state files
+    Reset {
+        /// Loop name to reset. If omitted, resets all loops.
+        loop_name: Option<String>,
+    },
 }
 
 #[derive(Args)]

--- a/plugins/github-autopilot/cli/src/fs.rs
+++ b/plugins/github-autopilot/cli/src/fs.rs
@@ -14,6 +14,9 @@ pub trait FsOps: Send + Sync {
 
     /// List files in a directory (non-recursive) that match the given extension.
     fn list_files(&self, dir: &Path, extension: &str) -> Result<Vec<PathBuf>>;
+
+    /// Remove a file. Returns Ok(()) even if the file does not exist.
+    fn remove_file(&self, path: &Path) -> Result<()>;
 }
 
 /// Real implementation using `std::fs`.
@@ -53,6 +56,14 @@ impl FsOps for RealFs {
         }
         files.sort();
         Ok(files)
+    }
+
+    fn remove_file(&self, path: &Path) -> Result<()> {
+        match std::fs::remove_file(path) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(anyhow::anyhow!("failed to remove {}: {e}", path.display())),
+        }
     }
 }
 

--- a/plugins/github-autopilot/cli/src/main.rs
+++ b/plugins/github-autopilot/cli/src/main.rs
@@ -96,6 +96,7 @@ fn main() {
                 } => svc.mark(&loop_name, output_hash.as_deref(), status.as_ref()),
                 CheckCommands::Status => svc.status(),
                 CheckCommands::Health => svc.health(),
+                CheckCommands::Reset { loop_name } => svc.reset(loop_name.as_deref()),
             }
         }
         Commands::Watch(args) => {

--- a/plugins/github-autopilot/cli/tests/check_tests.rs
+++ b/plugins/github-autopilot/cli/tests/check_tests.rs
@@ -150,7 +150,11 @@ fn mark_status_idle_increments_count() {
     let fs = MockFs::new();
 
     make_svc(git, fs.clone())
-        .mark("build-issues", None, Some(&autopilot::cmd::LoopStatus::Idle))
+        .mark(
+            "build-issues",
+            None,
+            Some(&autopilot::cmd::LoopStatus::Idle),
+        )
         .unwrap();
     let written = fs.written_files();
     let state: serde_json::Value = serde_json::from_str(&written[0].1).unwrap();
@@ -166,7 +170,11 @@ fn mark_status_active_resets_count() {
     );
 
     make_svc(git, fs.clone())
-        .mark("build-issues", None, Some(&autopilot::cmd::LoopStatus::Active))
+        .mark(
+            "build-issues",
+            None,
+            Some(&autopilot::cmd::LoopStatus::Active),
+        )
         .unwrap();
     let written = fs.written_files();
     let state: serde_json::Value = serde_json::from_str(&written[0].1).unwrap();
@@ -243,4 +251,58 @@ fn diff_backward_compat_with_old_state_format() {
         .diff("gap-watch", &["spec/".to_string()])
         .unwrap();
     assert_eq!(code, 2);
+}
+
+#[test]
+fn reset_single_loop_removes_state_file() {
+    let git = MockGit::new();
+    let fs = MockFs::new().with_file(
+        "/tmp/autopilot-repo/state/gap-watch.state",
+        r#"{"hash":"aaa1111","timestamp":"2026-01-01T00:00:00Z"}"#,
+    );
+
+    let code = make_svc(git, fs.clone()).reset(Some("gap-watch")).unwrap();
+    assert_eq!(code, 0);
+
+    let removed = fs.removed_files();
+    assert_eq!(removed.len(), 1);
+    assert!(removed[0].to_str().unwrap().contains("gap-watch.state"));
+}
+
+#[test]
+fn reset_all_loops_removes_all_state_files() {
+    let git = MockGit::new();
+    let fs = MockFs::new()
+        .with_file(
+            "/tmp/autopilot-repo/state/gap-watch.state",
+            r#"{"hash":"aaa1111","timestamp":"2026-01-01T00:00:00Z"}"#,
+        )
+        .with_file(
+            "/tmp/autopilot-repo/state/build-issues.state",
+            r#"{"hash":"bbb2222","timestamp":"2026-01-02T00:00:00Z"}"#,
+        );
+
+    let code = make_svc(git, fs.clone()).reset(None).unwrap();
+    assert_eq!(code, 0);
+
+    let removed = fs.removed_files();
+    assert_eq!(removed.len(), 2);
+}
+
+#[test]
+fn reset_nonexistent_loop_succeeds() {
+    let git = MockGit::new();
+    let fs = MockFs::new();
+
+    let code = make_svc(git, fs.clone()).reset(Some("gap-watch")).unwrap();
+    assert_eq!(code, 0);
+}
+
+#[test]
+fn reset_rejects_invalid_loop_name() {
+    let git = MockGit::new();
+    let fs = MockFs::new();
+
+    let result = make_svc(git, fs).reset(Some("../etc/passwd"));
+    assert!(result.is_err());
 }

--- a/plugins/github-autopilot/cli/tests/check_tests.rs
+++ b/plugins/github-autopilot/cli/tests/check_tests.rs
@@ -1,10 +1,20 @@
 mod mock_fs;
 mod mock_git;
 
+use std::path::{Path, PathBuf};
+
 use autopilot::cmd::check::spec_code::SpecCodeAnalysis;
-use autopilot::cmd::check::CheckService;
+use autopilot::cmd::check::state::state_file_path;
+use autopilot::cmd::check::{
+    CheckService, EXIT_CODE_CHANGED, EXIT_FIRST_RUN, EXIT_NO_CHANGES, EXIT_SPEC_CHANGED,
+};
 use mock_fs::MockFs;
 use mock_git::MockGit;
+
+// --- Test helpers ---
+
+const GAP_WATCH_STATE: &str = "/tmp/autopilot-repo/state/gap-watch.state";
+const BUILD_ISSUES_STATE: &str = "/tmp/autopilot-repo/state/build-issues.state";
 
 fn make_svc(git: MockGit, fs: MockFs) -> CheckService {
     CheckService::new(
@@ -14,79 +24,86 @@ fn make_svc(git: MockGit, fs: MockFs) -> CheckService {
     )
 }
 
+fn state_json(hash: &str) -> String {
+    format!(r#"{{"hash":"{hash}","timestamp":"2026-01-01T00:00:00Z"}}"#)
+}
+
+fn state_json_with_idle(hash: &str, idle_count: u32) -> String {
+    format!(r#"{{"hash":"{hash}","timestamp":"2026-01-01T00:00:00Z","idle_count":{idle_count}}}"#)
+}
+
+fn spec_paths() -> Vec<String> {
+    vec!["spec/".to_string()]
+}
+
+// --- diff tests ---
+
 #[test]
-fn diff_returns_3_on_first_run() {
+fn diff_returns_first_run_on_missing_state() {
     let git = MockGit::new().with_head("aaa1111");
-    let fs = MockFs::new(); // no state file
+    let fs = MockFs::new();
 
-    let code = make_svc(git, fs)
-        .diff("gap-watch", &["spec/".to_string()])
-        .unwrap();
-    assert_eq!(code, 3);
+    let code = make_svc(git, fs).diff("gap-watch", &spec_paths()).unwrap();
+    assert_eq!(code, EXIT_FIRST_RUN);
 }
 
 #[test]
-fn diff_returns_0_when_same_hash() {
+fn diff_returns_no_changes_when_same_hash() {
     let git = MockGit::new().with_head("aaa1111").with_commit("aaa1111");
-    let fs = MockFs::new().with_file(
-        "/tmp/autopilot-repo/state/gap-watch.state",
-        r#"{"hash":"aaa1111","timestamp":"2026-01-01T00:00:00Z"}"#,
-    );
+    let fs = MockFs::new().with_file(GAP_WATCH_STATE, &state_json("aaa1111"));
 
-    let code = make_svc(git, fs)
-        .diff("gap-watch", &["spec/".to_string()])
-        .unwrap();
-    assert_eq!(code, 0);
+    let code = make_svc(git, fs).diff("gap-watch", &spec_paths()).unwrap();
+    assert_eq!(code, EXIT_NO_CHANGES);
 }
 
 #[test]
-fn diff_returns_1_when_spec_changed() {
+fn diff_returns_spec_changed_when_spec_files_modified() {
     let git = MockGit::new()
         .with_head("bbb2222")
         .with_commit("aaa1111")
         .with_diff("aaa1111", "bbb2222", vec!["spec/auth.md", "src/lib.rs"]);
-    let fs = MockFs::new().with_file(
-        "/tmp/autopilot-repo/state/gap-watch.state",
-        r#"{"hash":"aaa1111","timestamp":"2026-01-01T00:00:00Z"}"#,
-    );
+    let fs = MockFs::new().with_file(GAP_WATCH_STATE, &state_json("aaa1111"));
 
-    let code = make_svc(git, fs)
-        .diff("gap-watch", &["spec/".to_string()])
-        .unwrap();
-    assert_eq!(code, 1);
+    let code = make_svc(git, fs).diff("gap-watch", &spec_paths()).unwrap();
+    assert_eq!(code, EXIT_SPEC_CHANGED);
 }
 
 #[test]
-fn diff_returns_2_when_only_code_changed() {
+fn diff_returns_code_changed_when_only_code_modified() {
     let git = MockGit::new()
         .with_head("bbb2222")
         .with_commit("aaa1111")
         .with_diff("aaa1111", "bbb2222", vec!["src/lib.rs", "src/main.rs"]);
-    let fs = MockFs::new().with_file(
-        "/tmp/autopilot-repo/state/gap-watch.state",
-        r#"{"hash":"aaa1111","timestamp":"2026-01-01T00:00:00Z"}"#,
-    );
+    let fs = MockFs::new().with_file(GAP_WATCH_STATE, &state_json("aaa1111"));
 
-    let code = make_svc(git, fs)
-        .diff("gap-watch", &["spec/".to_string()])
-        .unwrap();
-    assert_eq!(code, 2);
+    let code = make_svc(git, fs).diff("gap-watch", &spec_paths()).unwrap();
+    assert_eq!(code, EXIT_CODE_CHANGED);
 }
 
 #[test]
-fn diff_returns_3_when_stale_hash() {
+fn diff_returns_first_run_when_stale_hash() {
     let git = MockGit::new().with_head("bbb2222");
     // aaa1111 NOT added to existing_commits
-    let fs = MockFs::new().with_file(
-        "/tmp/autopilot-repo/state/gap-watch.state",
-        r#"{"hash":"aaa1111","timestamp":"2026-01-01T00:00:00Z"}"#,
-    );
+    let fs = MockFs::new().with_file(GAP_WATCH_STATE, &state_json("aaa1111"));
 
-    let code = make_svc(git, fs)
-        .diff("gap-watch", &["spec/".to_string()])
-        .unwrap();
-    assert_eq!(code, 3);
+    let code = make_svc(git, fs).diff("gap-watch", &spec_paths()).unwrap();
+    assert_eq!(code, EXIT_FIRST_RUN);
 }
+
+#[test]
+fn diff_backward_compat_with_old_state_format() {
+    // Old state files without output_history should still work
+    let git = MockGit::new()
+        .with_head("bbb2222")
+        .with_commit("aaa1111")
+        .with_diff("aaa1111", "bbb2222", vec!["src/lib.rs"]);
+    let fs = MockFs::new().with_file(GAP_WATCH_STATE, &state_json("aaa1111"));
+
+    let code = make_svc(git, fs).diff("gap-watch", &spec_paths()).unwrap();
+    assert_eq!(code, EXIT_CODE_CHANGED);
+}
+
+// --- mark tests ---
 
 #[test]
 fn mark_writes_state_file() {
@@ -128,23 +145,6 @@ fn mark_with_output_hash_appends_history() {
 }
 
 #[test]
-fn status_shows_loops() {
-    let git = MockGit::new();
-    let fs = MockFs::new()
-        .with_file(
-            "/tmp/autopilot-repo/state/gap-watch.state",
-            r#"{"hash":"aaa1111","timestamp":"2026-01-01T00:00:00Z"}"#,
-        )
-        .with_file(
-            "/tmp/autopilot-repo/state/build-issues.state",
-            r#"{"hash":"bbb2222","timestamp":"2026-01-02T00:00:00Z"}"#,
-        );
-
-    let code = make_svc(git, fs).status().unwrap();
-    assert_eq!(code, 0);
-}
-
-#[test]
 fn mark_status_idle_increments_count() {
     let git = MockGit::new().with_head("ccc3333");
     let fs = MockFs::new();
@@ -164,10 +164,7 @@ fn mark_status_idle_increments_count() {
 #[test]
 fn mark_status_active_resets_count() {
     let git = MockGit::new().with_head("ccc3333");
-    let fs = MockFs::new().with_file(
-        "/tmp/autopilot-repo/state/build-issues.state",
-        r#"{"hash":"bbb2222","timestamp":"2026-01-01T00:00:00Z","idle_count":4}"#,
-    );
+    let fs = MockFs::new().with_file(BUILD_ISSUES_STATE, &state_json_with_idle("bbb2222", 4));
 
     make_svc(git, fs.clone())
         .mark(
@@ -184,11 +181,7 @@ fn mark_status_active_resets_count() {
 #[test]
 fn mark_idle_accumulates_across_calls() {
     let git = MockGit::new().with_head("ccc3333");
-    // Start with idle_count=3
-    let fs = MockFs::new().with_file(
-        "/tmp/autopilot-repo/state/build-issues.state",
-        r#"{"hash":"bbb2222","timestamp":"2026-01-01T00:00:00Z","idle_count":3}"#,
-    );
+    let fs = MockFs::new().with_file(BUILD_ISSUES_STATE, &state_json_with_idle("bbb2222", 3));
 
     make_svc(git, fs.clone())
         .mark(
@@ -205,27 +198,21 @@ fn mark_idle_accumulates_across_calls() {
 #[test]
 fn mark_without_status_preserves_idle_count() {
     let git = MockGit::new().with_head("ccc3333");
-    let fs = MockFs::new().with_file(
-        "/tmp/autopilot-repo/state/build-issues.state",
-        r#"{"hash":"bbb2222","timestamp":"2026-01-01T00:00:00Z","idle_count":5}"#,
-    );
+    let fs = MockFs::new().with_file(BUILD_ISSUES_STATE, &state_json_with_idle("bbb2222", 5));
 
     make_svc(git, fs.clone())
         .mark("build-issues", None, None)
         .unwrap();
     let written = fs.written_files();
     let state: serde_json::Value = serde_json::from_str(&written[0].1).unwrap();
-    assert_eq!(state["idle_count"], 5); // unchanged
+    assert_eq!(state["idle_count"], 5);
 }
 
 #[test]
 fn mark_backward_compat_without_idle_count() {
     // Old state files without idle_count should default to 0
     let git = MockGit::new().with_head("ccc3333");
-    let fs = MockFs::new().with_file(
-        "/tmp/autopilot-repo/state/gap-watch.state",
-        r#"{"hash":"aaa1111","timestamp":"2026-01-01T00:00:00Z"}"#,
-    );
+    let fs = MockFs::new().with_file(GAP_WATCH_STATE, &state_json("aaa1111"));
 
     make_svc(git, fs.clone())
         .mark("gap-watch", None, Some(&autopilot::cmd::LoopStatus::Idle))
@@ -235,31 +222,25 @@ fn mark_backward_compat_without_idle_count() {
     assert_eq!(state["idle_count"], 1);
 }
 
-#[test]
-fn diff_backward_compat_with_old_state_format() {
-    // Old state files without output_history should still work
-    let git = MockGit::new()
-        .with_head("bbb2222")
-        .with_commit("aaa1111")
-        .with_diff("aaa1111", "bbb2222", vec!["src/lib.rs"]);
-    let fs = MockFs::new().with_file(
-        "/tmp/autopilot-repo/state/gap-watch.state",
-        r#"{"hash":"aaa1111","timestamp":"2026-01-01T00:00:00Z"}"#,
-    );
+// --- status tests ---
 
-    let code = make_svc(git, fs)
-        .diff("gap-watch", &["spec/".to_string()])
-        .unwrap();
-    assert_eq!(code, 2);
+#[test]
+fn status_shows_loops() {
+    let git = MockGit::new();
+    let fs = MockFs::new()
+        .with_file(GAP_WATCH_STATE, &state_json("aaa1111"))
+        .with_file(BUILD_ISSUES_STATE, &state_json("bbb2222"));
+
+    let code = make_svc(git, fs).status().unwrap();
+    assert_eq!(code, 0);
 }
+
+// --- reset tests ---
 
 #[test]
 fn reset_single_loop_removes_state_file() {
     let git = MockGit::new();
-    let fs = MockFs::new().with_file(
-        "/tmp/autopilot-repo/state/gap-watch.state",
-        r#"{"hash":"aaa1111","timestamp":"2026-01-01T00:00:00Z"}"#,
-    );
+    let fs = MockFs::new().with_file(GAP_WATCH_STATE, &state_json("aaa1111"));
 
     let code = make_svc(git, fs.clone()).reset(Some("gap-watch")).unwrap();
     assert_eq!(code, 0);
@@ -273,14 +254,8 @@ fn reset_single_loop_removes_state_file() {
 fn reset_all_loops_removes_all_state_files() {
     let git = MockGit::new();
     let fs = MockFs::new()
-        .with_file(
-            "/tmp/autopilot-repo/state/gap-watch.state",
-            r#"{"hash":"aaa1111","timestamp":"2026-01-01T00:00:00Z"}"#,
-        )
-        .with_file(
-            "/tmp/autopilot-repo/state/build-issues.state",
-            r#"{"hash":"bbb2222","timestamp":"2026-01-02T00:00:00Z"}"#,
-        );
+        .with_file(GAP_WATCH_STATE, &state_json("aaa1111"))
+        .with_file(BUILD_ISSUES_STATE, &state_json("bbb2222"));
 
     let code = make_svc(git, fs.clone()).reset(None).unwrap();
     assert_eq!(code, 0);
@@ -305,4 +280,131 @@ fn reset_rejects_invalid_loop_name() {
 
     let result = make_svc(git, fs).reset(Some("../etc/passwd"));
     assert!(result.is_err());
+}
+
+#[test]
+fn reset_all_with_no_state_directory_succeeds() {
+    let git = MockGit::new();
+    let fs = MockFs::new();
+
+    let code = make_svc(git, fs).reset(None).unwrap();
+    assert_eq!(code, 0);
+}
+
+// --- reset → diff integration: the core scenario this feature solves ---
+
+#[test]
+fn reset_then_diff_returns_first_run() {
+    let git = MockGit::new().with_head("aaa1111").with_commit("aaa1111");
+    let fs = MockFs::new().with_file(GAP_WATCH_STATE, &state_json("aaa1111"));
+
+    let svc = make_svc(git, fs.clone());
+
+    // Before reset: diff sees existing state → no_changes
+    assert_eq!(
+        svc.diff("gap-watch", &spec_paths()).unwrap(),
+        EXIT_NO_CHANGES
+    );
+
+    // Reset removes the state
+    assert_eq!(svc.reset(Some("gap-watch")).unwrap(), 0);
+
+    // After reset: diff sees no state → first_run
+    assert_eq!(
+        svc.diff("gap-watch", &spec_paths()).unwrap(),
+        EXIT_FIRST_RUN
+    );
+}
+
+#[test]
+fn reset_then_mark_then_diff_full_cycle() {
+    let git = MockGit::new().with_head("aaa1111").with_commit("aaa1111");
+    let fs = MockFs::new().with_file(GAP_WATCH_STATE, &state_json("aaa1111"));
+
+    let svc = make_svc(git, fs);
+
+    assert_eq!(svc.reset(Some("gap-watch")).unwrap(), 0);
+    assert_eq!(
+        svc.diff("gap-watch", &spec_paths()).unwrap(),
+        EXIT_FIRST_RUN
+    );
+    assert_eq!(svc.mark("gap-watch", None, None).unwrap(), 0);
+    assert_eq!(
+        svc.diff("gap-watch", &spec_paths()).unwrap(),
+        EXIT_NO_CHANGES
+    );
+}
+
+#[test]
+fn reset_all_then_diff_returns_first_run_for_each() {
+    let git = MockGit::new().with_head("aaa1111").with_commit("aaa1111");
+    let fs = MockFs::new()
+        .with_file(GAP_WATCH_STATE, &state_json("aaa1111"))
+        .with_file(BUILD_ISSUES_STATE, &state_json("aaa1111"));
+
+    let svc = make_svc(git, fs);
+
+    // Both loops have state → no_changes
+    assert_eq!(
+        svc.diff("gap-watch", &spec_paths()).unwrap(),
+        EXIT_NO_CHANGES
+    );
+    assert_eq!(
+        svc.diff("build-issues", &spec_paths()).unwrap(),
+        EXIT_NO_CHANGES
+    );
+
+    assert_eq!(svc.reset(None).unwrap(), 0);
+
+    // Both loops now return first_run
+    assert_eq!(
+        svc.diff("gap-watch", &spec_paths()).unwrap(),
+        EXIT_FIRST_RUN
+    );
+    assert_eq!(
+        svc.diff("build-issues", &spec_paths()).unwrap(),
+        EXIT_FIRST_RUN
+    );
+}
+
+#[test]
+fn reset_only_affects_target_loop() {
+    let git = MockGit::new().with_head("aaa1111").with_commit("aaa1111");
+    let fs = MockFs::new()
+        .with_file(GAP_WATCH_STATE, &state_json("aaa1111"))
+        .with_file(BUILD_ISSUES_STATE, &state_json("aaa1111"));
+
+    let svc = make_svc(git, fs);
+
+    svc.reset(Some("gap-watch")).unwrap();
+
+    assert_eq!(
+        svc.diff("gap-watch", &spec_paths()).unwrap(),
+        EXIT_FIRST_RUN
+    );
+    assert_eq!(
+        svc.diff("build-issues", &spec_paths()).unwrap(),
+        EXIT_NO_CHANGES
+    );
+}
+
+// --- state_file_path unit tests ---
+
+#[test]
+fn state_file_path_constructs_correct_paths() {
+    let dir = Path::new("/tmp/autopilot-repo/state");
+    assert_eq!(
+        state_file_path(dir, "gap-watch"),
+        PathBuf::from("/tmp/autopilot-repo/state/gap-watch.state")
+    );
+    assert_eq!(
+        state_file_path(dir, "build-issues"),
+        PathBuf::from("/tmp/autopilot-repo/state/build-issues.state")
+    );
+
+    let other_dir = Path::new("/tmp/autopilot-myrepo/state");
+    assert_eq!(
+        state_file_path(other_dir, "ci-watch"),
+        PathBuf::from("/tmp/autopilot-myrepo/state/ci-watch.state")
+    );
 }

--- a/plugins/github-autopilot/cli/tests/mock_fs.rs
+++ b/plugins/github-autopilot/cli/tests/mock_fs.rs
@@ -10,6 +10,7 @@ use std::sync::{Arc, Mutex};
 pub struct MockFs {
     files: HashMap<PathBuf, String>,
     pub written: Arc<Mutex<Vec<(PathBuf, String)>>>,
+    pub removed: Arc<Mutex<Vec<PathBuf>>>,
 }
 
 impl Clone for MockFs {
@@ -17,6 +18,7 @@ impl Clone for MockFs {
         Self {
             files: self.files.clone(),
             written: Arc::clone(&self.written),
+            removed: Arc::clone(&self.removed),
         }
     }
 }
@@ -26,6 +28,7 @@ impl MockFs {
         Self {
             files: HashMap::new(),
             written: Arc::new(Mutex::new(Vec::new())),
+            removed: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -37,6 +40,11 @@ impl MockFs {
     /// Return all files written during the test.
     pub fn written_files(&self) -> Vec<(PathBuf, String)> {
         self.written.lock().unwrap().clone()
+    }
+
+    /// Return all files removed during the test.
+    pub fn removed_files(&self) -> Vec<PathBuf> {
+        self.removed.lock().unwrap().clone()
     }
 }
 
@@ -69,5 +77,10 @@ impl FsOps for MockFs {
             .collect();
         files.sort();
         Ok(files)
+    }
+
+    fn remove_file(&self, path: &Path) -> Result<()> {
+        self.removed.lock().unwrap().push(path.to_path_buf());
+        Ok(())
     }
 }

--- a/plugins/github-autopilot/cli/tests/mock_fs.rs
+++ b/plugins/github-autopilot/cli/tests/mock_fs.rs
@@ -6,70 +6,76 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
-/// A mock FsOps backed by an in-memory file map.
-pub struct MockFs {
+/// Shared mutable state for MockFs, enabling stateful multi-step tests.
+#[derive(Clone, Default)]
+struct Inner {
     files: HashMap<PathBuf, String>,
-    pub written: Arc<Mutex<Vec<(PathBuf, String)>>>,
-    pub removed: Arc<Mutex<Vec<PathBuf>>>,
+    written: Vec<(PathBuf, String)>,
+    removed: Vec<PathBuf>,
 }
 
-impl Clone for MockFs {
-    fn clone(&self) -> Self {
-        Self {
-            files: self.files.clone(),
-            written: Arc::clone(&self.written),
-            removed: Arc::clone(&self.removed),
-        }
-    }
+/// A mock FsOps backed by an in-memory file map.
+/// Writes and removes mutate the internal file map so that subsequent
+/// reads, list_files, and file_exists calls reflect the changes.
+#[derive(Clone)]
+pub struct MockFs {
+    inner: Arc<Mutex<Inner>>,
 }
 
 impl MockFs {
     pub fn new() -> Self {
         Self {
-            files: HashMap::new(),
-            written: Arc::new(Mutex::new(Vec::new())),
-            removed: Arc::new(Mutex::new(Vec::new())),
+            inner: Arc::new(Mutex::new(Inner::default())),
         }
     }
 
-    pub fn with_file(mut self, path: &str, content: &str) -> Self {
-        self.files.insert(PathBuf::from(path), content.to_string());
+    pub fn with_file(self, path: &str, content: &str) -> Self {
+        self.inner
+            .lock()
+            .unwrap()
+            .files
+            .insert(PathBuf::from(path), content.to_string());
         self
     }
 
     /// Return all files written during the test.
     pub fn written_files(&self) -> Vec<(PathBuf, String)> {
-        self.written.lock().unwrap().clone()
+        self.inner.lock().unwrap().written.clone()
     }
 
     /// Return all files removed during the test.
     pub fn removed_files(&self) -> Vec<PathBuf> {
-        self.removed.lock().unwrap().clone()
+        self.inner.lock().unwrap().removed.clone()
     }
 }
 
 impl FsOps for MockFs {
     fn read_file(&self, path: &Path) -> Result<String> {
-        self.files
+        self.inner
+            .lock()
+            .unwrap()
+            .files
             .get(path)
             .cloned()
             .ok_or_else(|| anyhow::anyhow!("file not found: {}", path.display()))
     }
 
     fn write_file(&self, path: &Path, content: &str) -> Result<()> {
-        self.written
-            .lock()
-            .unwrap()
-            .push((path.to_path_buf(), content.to_string()));
+        let mut inner = self.inner.lock().unwrap();
+        let path = path.to_path_buf();
+        let content = content.to_string();
+        inner.files.insert(path.clone(), content.clone());
+        inner.written.push((path, content));
         Ok(())
     }
 
     fn file_exists(&self, path: &Path) -> bool {
-        self.files.contains_key(path)
+        self.inner.lock().unwrap().files.contains_key(path)
     }
 
     fn list_files(&self, dir: &Path, extension: &str) -> Result<Vec<PathBuf>> {
-        let mut files: Vec<PathBuf> = self
+        let inner = self.inner.lock().unwrap();
+        let mut files: Vec<PathBuf> = inner
             .files
             .keys()
             .filter(|p| p.parent() == Some(dir) && p.extension().map_or(false, |e| e == extension))
@@ -80,7 +86,9 @@ impl FsOps for MockFs {
     }
 
     fn remove_file(&self, path: &Path) -> Result<()> {
-        self.removed.lock().unwrap().push(path.to_path_buf());
+        let mut inner = self.inner.lock().unwrap();
+        inner.files.remove(path);
+        inner.removed.push(path.to_path_buf());
         Ok(())
     }
 }

--- a/plugins/github-autopilot/commands/gap-watch.md
+++ b/plugins/github-autopilot/commands/gap-watch.md
@@ -29,6 +29,16 @@ allowed-tools: ["Bash", "Glob", "Read", "Agent", "AskUserQuestion"]
 
 ### Step 1.5: Pipeline Idle Check
 
+먼저 gap-watch의 분석 이력이 존재하는지 확인합니다:
+
+```bash
+REPO=$(basename "$(git rev-parse --show-toplevel)")
+[ -f "/tmp/autopilot-${REPO}/state/gap-watch.state" ]
+```
+
+- **파일 없음 (exit 1)**: 분석 이력이 없습니다. idle check를 건너뛰고 **Step 2로 바로 진행**합니다.
+- **파일 있음 (exit 0)**: 분석 이력이 존재합니다. 아래 pipeline idle check를 수행합니다.
+
 ```bash
 autopilot pipeline idle --label-prefix "{label_prefix}"
 ```

--- a/plugins/github-autopilot/commands/setup.md
+++ b/plugins/github-autopilot/commands/setup.md
@@ -153,6 +153,16 @@ bash ${CLAUDE_PLUGIN_ROOT}/scripts/ensure-binary.sh
 > export PATH="$HOME/.local/bin:$PATH"
 > ```
 
+### Step 4.5: 분석 이력 초기화
+
+기존 loop state를 리셋하여 첫 cycle에서 gap 분석이 반드시 실행되도록 합니다:
+
+```bash
+autopilot check reset
+```
+
+> 이전 설정의 state가 남아있으면 gap-watch가 idle로 판정하여 분석을 건너뛸 수 있습니다.
+
 ### Step 5: GitHub 라벨 생성
 
 autopilot이 사용하는 라벨을 레포에 일괄 생성합니다.


### PR DESCRIPTION
## Summary

- **gap-watch 초기 실행 문제 해결**: 이슈/PR이 없을 때 idle로 판정하여 gap 분석을 건너뛰는 닭과 달걀 문제를 수정. 분석 이력이 없으면 idle check를 스킵하여 첫 cycle에서 반드시 gap 분석이 실행됨
- **`autopilot check reset` 서브커맨드 추가**: loop state 파일을 삭제하는 CLI 명령어. 특정 루프 또는 전체 리셋 지원
- **setup 시 state 초기화**: `/github-autopilot:setup` 실행 시 기존 state를 리셋하여 깨끗한 상태에서 시작
- **코드 품질 개선**: `STATE_EXT` 상수 및 `state_file_path` 헬퍼 추출, clippy 경고 수정

## Test plan

- [x] `reset_single_loop_removes_state_file` — 단일 루프 리셋 검증
- [x] `reset_all_loops_removes_all_state_files` — 전체 리셋 검증
- [x] `reset_nonexistent_loop_succeeds` — 존재하지 않는 루프 리셋 시 에러 없음
- [x] `reset_rejects_invalid_loop_name` — path traversal 방어
- [x] 기존 177개 테스트 전체 통과
- [x] `cargo fmt --check` + `cargo clippy -- -D warnings` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)