### PR TITLE
feat(github-autopilot): add epic task store domain + in-memory adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ plugins/autodev/cli/target/
 # Plugin build outputs
 plugins/git-utils/dist/
 .claude/worktrees/
+
+# github-autopilot local task store cache
+.autopilot/

--- a/plugins/github-autopilot/cli/Cargo.lock
+++ b/plugins/github-autopilot/cli/Cargo.lock
@@ -3,6 +3,27 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,13 +80,77 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "autopilot"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
+ "hex",
+ "rusqlite",
  "serde",
  "serde_json",
+ "sha2",
+ "tempfile",
+ "thiserror",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "cc"
+version = "1.2.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
 ]
 
 [[package]]
@@ -115,10 +200,219 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -133,16 +427,100 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "js-sys"
+version = "0.3.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -161,6 +539,52 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags",
+ "chrono",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -206,6 +630,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,10 +676,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "utf8parse"
@@ -235,10 +757,172 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -247,6 +931,120 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/plugins/github-autopilot/cli/Cargo.toml
+++ b/plugins/github-autopilot/cli/Cargo.toml
@@ -13,9 +13,18 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1"
+chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
+hex = "0.4"
+rusqlite = { version = "0.32", features = ["bundled", "chrono"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+sha2 = "0.10"
+thiserror = "1"
+unicode-normalization = "0.1"
+
+[dev-dependencies]
+tempfile = "3"
 
 [profile.release]
 lto = true

--- a/plugins/github-autopilot/cli/src/cmd/mod.rs
+++ b/plugins/github-autopilot/cli/src/cmd/mod.rs
@@ -6,6 +6,7 @@ pub mod pipeline;
 pub mod preflight;
 pub mod simhash;
 pub mod stats;
+pub mod task;
 pub mod watch;
 pub mod worktree;
 
@@ -52,6 +53,46 @@ pub enum Commands {
     Stats {
         #[command(subcommand)]
         command: StatsCommands,
+    },
+    /// Operator-facing task store diagnostics
+    Task {
+        #[command(subcommand)]
+        command: TaskCommands,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum TaskCommands {
+    /// List tasks in an epic
+    List {
+        /// Epic name
+        #[arg(long)]
+        epic: String,
+        /// Filter by status
+        #[arg(long)]
+        status: Option<task::TaskStatusArg>,
+        /// Output JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// Show details of a single task
+    Show {
+        /// Task id
+        task_id: String,
+        /// Output JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// Force a task into a specific status (operator override)
+    ForceStatus {
+        /// Task id
+        task_id: String,
+        /// Target status
+        #[arg(long)]
+        to: task::TaskStatusArg,
+        /// Optional reason recorded with the override
+        #[arg(long)]
+        reason: Option<String>,
     },
 }
 

--- a/plugins/github-autopilot/cli/src/cmd/task.rs
+++ b/plugins/github-autopilot/cli/src/cmd/task.rs
@@ -1,0 +1,248 @@
+//! Operator-facing diagnostics for the task store.
+//!
+//! These commands read or override the local SQLite cache directly without
+//! touching git or GitHub — useful for debugging stuck epics, but should be
+//! used sparingly because manual force_status bypasses the normal lifecycle.
+
+use anyhow::{Context, Result};
+use clap::ValueEnum;
+
+use crate::domain::{Task, TaskId, TaskStatus};
+use crate::ports::clock::{Clock, StdClock};
+use crate::ports::task_store::TaskStore;
+
+#[derive(Clone, Copy, Debug, ValueEnum, PartialEq, Eq)]
+pub enum TaskStatusArg {
+    Pending,
+    Ready,
+    Wip,
+    Blocked,
+    Done,
+    Escalated,
+}
+
+impl From<TaskStatusArg> for TaskStatus {
+    fn from(s: TaskStatusArg) -> TaskStatus {
+        match s {
+            TaskStatusArg::Pending => TaskStatus::Pending,
+            TaskStatusArg::Ready => TaskStatus::Ready,
+            TaskStatusArg::Wip => TaskStatus::Wip,
+            TaskStatusArg::Blocked => TaskStatus::Blocked,
+            TaskStatusArg::Done => TaskStatus::Done,
+            TaskStatusArg::Escalated => TaskStatus::Escalated,
+        }
+    }
+}
+
+pub struct TaskService<'a> {
+    store: &'a dyn TaskStore,
+    clock: &'a dyn Clock,
+}
+
+impl<'a> TaskService<'a> {
+    pub fn new(store: &'a dyn TaskStore, clock: &'a dyn Clock) -> Self {
+        Self { store, clock }
+    }
+
+    pub fn list(
+        &self,
+        epic: &str,
+        status: Option<TaskStatusArg>,
+        json: bool,
+        out: &mut dyn std::io::Write,
+    ) -> Result<i32> {
+        let tasks = self
+            .store
+            .list_tasks_by_epic(epic, status.map(TaskStatus::from))
+            .with_context(|| format!("listing tasks for epic '{epic}'"))?;
+        if json {
+            serde_json::to_writer(&mut *out, &tasks)?;
+            writeln!(out)?;
+        } else if tasks.is_empty() {
+            writeln!(out, "(no tasks)")?;
+        } else {
+            writeln!(out, "ID            STATUS     ATTEMPTS  TITLE")?;
+            for t in &tasks {
+                writeln!(
+                    out,
+                    "{:<12}  {:<9}  {:>8}  {}",
+                    t.id.as_str(),
+                    t.status.as_str(),
+                    t.attempts,
+                    t.title
+                )?;
+            }
+        }
+        Ok(0)
+    }
+
+    pub fn show(&self, task_id: &str, json: bool, out: &mut dyn std::io::Write) -> Result<i32> {
+        let id = TaskId::from_raw(task_id);
+        let task = self
+            .store
+            .get_task(&id)
+            .with_context(|| format!("fetching task '{task_id}'"))?;
+        match task {
+            Some(t) => {
+                if json {
+                    serde_json::to_writer(&mut *out, &t)?;
+                    writeln!(out)?;
+                } else {
+                    print_task_human(&t, out)?;
+                }
+                Ok(0)
+            }
+            None => {
+                writeln!(out, "task '{task_id}' not found")?;
+                Ok(1)
+            }
+        }
+    }
+
+    pub fn force_status(
+        &self,
+        task_id: &str,
+        to: TaskStatusArg,
+        reason: Option<&str>,
+        out: &mut dyn std::io::Write,
+    ) -> Result<i32> {
+        let id = TaskId::from_raw(task_id);
+        let now = self.clock.now();
+        self.store
+            .force_status(&id, TaskStatus::from(to), now)
+            .with_context(|| format!("forcing status of task '{task_id}'"))?;
+        if let Some(r) = reason {
+            writeln!(out, "task '{task_id}' status forced to {:?} ({r})", to)?;
+        } else {
+            writeln!(out, "task '{task_id}' status forced to {:?}", to)?;
+        }
+        Ok(0)
+    }
+}
+
+pub fn task_service<'a>(store: &'a dyn TaskStore, clock: &'a dyn Clock) -> TaskService<'a> {
+    TaskService::new(store, clock)
+}
+
+pub fn default_clock() -> StdClock {
+    StdClock
+}
+
+fn print_task_human(t: &Task, out: &mut dyn std::io::Write) -> Result<()> {
+    writeln!(out, "id:              {}", t.id.as_str())?;
+    writeln!(out, "epic:            {}", t.epic_name)?;
+    writeln!(out, "status:          {}", t.status.as_str())?;
+    writeln!(out, "source:          {}", t.source.as_str())?;
+    writeln!(out, "attempts:        {}", t.attempts)?;
+    writeln!(out, "title:           {}", t.title)?;
+    if let Some(b) = &t.branch {
+        writeln!(out, "branch:          {b}")?;
+    }
+    if let Some(pr) = t.pr_number {
+        writeln!(out, "pr_number:       {pr}")?;
+    }
+    if let Some(issue) = t.escalated_issue {
+        writeln!(out, "escalated_issue: {issue}")?;
+    }
+    if let Some(fp) = &t.fingerprint {
+        writeln!(out, "fingerprint:     {fp}")?;
+    }
+    if let Some(body) = &t.body {
+        writeln!(out, "---")?;
+        writeln!(out, "{body}")?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ports::clock::FixedClock;
+    use crate::ports::task_store::{EpicPlan, NewTask};
+    use crate::store::InMemoryTaskStore;
+    use chrono::TimeZone;
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    fn fixture() -> (Arc<dyn TaskStore>, FixedClock) {
+        let store: Arc<dyn TaskStore> = Arc::new(InMemoryTaskStore::new());
+        let clock = FixedClock::new(chrono::Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap());
+        let now = clock.now();
+        store
+            .insert_epic_with_tasks(
+                EpicPlan {
+                    epic: crate::domain::Epic {
+                        name: "e".to_string(),
+                        spec_path: PathBuf::from("spec/x.md"),
+                        branch: "epic/e".to_string(),
+                        status: crate::domain::EpicStatus::Active,
+                        created_at: now,
+                        completed_at: None,
+                    },
+                    tasks: vec![NewTask {
+                        id: TaskId::from_raw("a1b2c3d4e5f6"),
+                        source: crate::domain::TaskSource::Decompose,
+                        fingerprint: None,
+                        title: "first".to_string(),
+                        body: None,
+                    }],
+                    deps: vec![],
+                },
+                now,
+            )
+            .unwrap();
+        (store, clock)
+    }
+
+    #[test]
+    fn list_renders_human_table() {
+        let (store, clock) = fixture();
+        let svc = TaskService::new(store.as_ref(), &clock);
+        let mut buf: Vec<u8> = Vec::new();
+        let code = svc.list("e", None, false, &mut buf).unwrap();
+        assert_eq!(code, 0);
+        let s = String::from_utf8(buf).unwrap();
+        assert!(s.contains("a1b2c3d4e5f6"));
+        assert!(s.contains("ready"));
+        assert!(s.contains("first"));
+    }
+
+    #[test]
+    fn list_renders_json() {
+        let (store, clock) = fixture();
+        let svc = TaskService::new(store.as_ref(), &clock);
+        let mut buf: Vec<u8> = Vec::new();
+        svc.list("e", None, true, &mut buf).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(s.trim()).unwrap();
+        assert!(parsed.is_array());
+    }
+
+    #[test]
+    fn show_returns_1_when_missing() {
+        let (store, clock) = fixture();
+        let svc = TaskService::new(store.as_ref(), &clock);
+        let mut buf: Vec<u8> = Vec::new();
+        let code = svc.show("does-not-exist", false, &mut buf).unwrap();
+        assert_eq!(code, 1);
+    }
+
+    #[test]
+    fn force_status_overrides_lifecycle() {
+        let (store, clock) = fixture();
+        let svc = TaskService::new(store.as_ref(), &clock);
+        let mut buf: Vec<u8> = Vec::new();
+        svc.force_status(
+            "a1b2c3d4e5f6",
+            TaskStatusArg::Done,
+            Some("manual"),
+            &mut buf,
+        )
+        .unwrap();
+        let task = store
+            .get_task(&TaskId::from_raw("a1b2c3d4e5f6"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(task.status, TaskStatus::Done);
+    }
+}

--- a/plugins/github-autopilot/cli/src/domain/deps.rs
+++ b/plugins/github-autopilot/cli/src/domain/deps.rs
@@ -1,0 +1,190 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use super::task_id::TaskId;
+
+#[derive(Debug, Clone)]
+pub struct TaskGraph {
+    edges: BTreeMap<TaskId, BTreeSet<TaskId>>,
+    reverse: BTreeMap<TaskId, BTreeSet<TaskId>>,
+    nodes: BTreeSet<TaskId>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CycleError {
+    pub cycle: Vec<TaskId>,
+}
+
+impl TaskGraph {
+    pub fn build<I>(deps: I) -> Self
+    where
+        I: IntoIterator<Item = (TaskId, TaskId)>,
+    {
+        let mut g = TaskGraph {
+            edges: BTreeMap::new(),
+            reverse: BTreeMap::new(),
+            nodes: BTreeSet::new(),
+        };
+        for (task, depends_on) in deps {
+            g.nodes.insert(task.clone());
+            g.nodes.insert(depends_on.clone());
+            g.edges
+                .entry(task.clone())
+                .or_default()
+                .insert(depends_on.clone());
+            g.reverse.entry(depends_on).or_default().insert(task);
+        }
+        g
+    }
+
+    pub fn detect_cycle(&self) -> Option<Vec<TaskId>> {
+        #[derive(Clone, Copy, PartialEq, Eq)]
+        enum Color {
+            White,
+            Gray,
+            Black,
+        }
+        let mut color: BTreeMap<TaskId, Color> = self
+            .nodes
+            .iter()
+            .map(|n| (n.clone(), Color::White))
+            .collect();
+        let mut path: Vec<TaskId> = Vec::new();
+
+        fn dfs(
+            node: &TaskId,
+            edges: &BTreeMap<TaskId, BTreeSet<TaskId>>,
+            color: &mut BTreeMap<TaskId, Color>,
+            path: &mut Vec<TaskId>,
+        ) -> Option<Vec<TaskId>> {
+            color.insert(node.clone(), Color::Gray);
+            path.push(node.clone());
+            if let Some(adj) = edges.get(node) {
+                for next in adj {
+                    match color.get(next).copied().unwrap_or(Color::White) {
+                        Color::White => {
+                            if let Some(c) = dfs(next, edges, color, path) {
+                                return Some(c);
+                            }
+                        }
+                        Color::Gray => {
+                            let mut cycle: Vec<TaskId> =
+                                path.iter().skip_while(|n| *n != next).cloned().collect();
+                            if cycle.is_empty() {
+                                cycle.push(next.clone());
+                            }
+                            return Some(cycle);
+                        }
+                        Color::Black => {}
+                    }
+                }
+            }
+            path.pop();
+            color.insert(node.clone(), Color::Black);
+            None
+        }
+
+        for n in self.nodes.iter() {
+            if color.get(n).copied().unwrap_or(Color::White) == Color::White {
+                if let Some(c) = dfs(n, &self.edges, &mut color, &mut path) {
+                    return Some(c);
+                }
+                path.clear();
+            }
+        }
+        None
+    }
+
+    pub fn topological_order(&self) -> Result<Vec<TaskId>, CycleError> {
+        if let Some(cycle) = self.detect_cycle() {
+            return Err(CycleError { cycle });
+        }
+        let mut indegree: BTreeMap<TaskId, usize> =
+            self.nodes.iter().map(|n| (n.clone(), 0usize)).collect();
+        for (_task, deps) in &self.edges {
+            for dep in deps {
+                *indegree.entry(dep.clone()).or_insert(0) += 0;
+                let entry = indegree.entry(_task.clone()).or_insert(0);
+                *entry += 1;
+            }
+        }
+
+        let mut ready: Vec<TaskId> = indegree
+            .iter()
+            .filter(|(_, &d)| d == 0)
+            .map(|(k, _)| k.clone())
+            .collect();
+        let mut order: Vec<TaskId> = Vec::with_capacity(self.nodes.len());
+        while let Some(n) = ready.pop() {
+            order.push(n.clone());
+            if let Some(parents) = self.reverse.get(&n) {
+                for parent in parents {
+                    if let Some(d) = indegree.get_mut(parent) {
+                        *d -= 1;
+                        if *d == 0 {
+                            ready.push(parent.clone());
+                        }
+                    }
+                }
+            }
+        }
+        Ok(order)
+    }
+
+    pub fn dependents_of(&self, id: &TaskId) -> Vec<&TaskId> {
+        self.reverse
+            .get(id)
+            .map(|s| s.iter().collect())
+            .unwrap_or_default()
+    }
+
+    pub fn dependencies_of(&self, id: &TaskId) -> Vec<&TaskId> {
+        self.edges
+            .get(id)
+            .map(|s| s.iter().collect())
+            .unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn id(s: &str) -> TaskId {
+        TaskId::from_raw(s)
+    }
+
+    #[test]
+    fn graph_with_no_cycle_passes() {
+        let g = TaskGraph::build([(id("B"), id("A")), (id("C"), id("B"))]);
+        assert!(g.detect_cycle().is_none());
+    }
+
+    #[test]
+    fn graph_with_self_loop_fails() {
+        let g = TaskGraph::build([(id("A"), id("A"))]);
+        let cycle = g.detect_cycle().expect("cycle expected");
+        assert_eq!(cycle, vec![id("A")]);
+    }
+
+    #[test]
+    fn graph_with_2cycle_fails() {
+        let g = TaskGraph::build([(id("A"), id("B")), (id("B"), id("A"))]);
+        assert!(g.detect_cycle().is_some());
+    }
+
+    #[test]
+    fn dependents_of_finds_immediate_children() {
+        let g = TaskGraph::build([(id("B"), id("A")), (id("C"), id("B"))]);
+        assert_eq!(g.dependents_of(&id("A")), vec![&id("B")]);
+        assert_eq!(g.dependents_of(&id("B")), vec![&id("C")]);
+    }
+
+    #[test]
+    fn topological_order_respects_constraints() {
+        let g = TaskGraph::build([(id("B"), id("A")), (id("C"), id("B"))]);
+        let order = g.topological_order().unwrap();
+        let pos = |s: &str| order.iter().position(|i| i.as_str() == s).unwrap();
+        assert!(pos("A") < pos("B"));
+        assert!(pos("B") < pos("C"));
+    }
+}

--- a/plugins/github-autopilot/cli/src/domain/epic.rs
+++ b/plugins/github-autopilot/cli/src/domain/epic.rs
@@ -1,0 +1,41 @@
+use std::path::PathBuf;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Epic {
+    pub name: String,
+    pub spec_path: PathBuf,
+    pub branch: String,
+    pub status: EpicStatus,
+    pub created_at: DateTime<Utc>,
+    pub completed_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum EpicStatus {
+    Active,
+    Completed,
+    Abandoned,
+}
+
+impl EpicStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            EpicStatus::Active => "active",
+            EpicStatus::Completed => "completed",
+            EpicStatus::Abandoned => "abandoned",
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "active" => Some(EpicStatus::Active),
+            "completed" => Some(EpicStatus::Completed),
+            "abandoned" => Some(EpicStatus::Abandoned),
+            _ => None,
+        }
+    }
+}

--- a/plugins/github-autopilot/cli/src/domain/error.rs
+++ b/plugins/github-autopilot/cli/src/domain/error.rs
@@ -1,0 +1,23 @@
+use thiserror::Error;
+
+use super::epic::EpicStatus;
+use super::task::TaskStatus;
+use super::task_id::TaskId;
+
+#[derive(Debug, Error)]
+pub enum DomainError {
+    #[error("dependency cycle detected: {0:?}")]
+    DepCycle(Vec<TaskId>),
+
+    #[error("illegal status transition for task {0}: {1:?} -> {2:?}")]
+    IllegalTransition(TaskId, TaskStatus, TaskStatus),
+
+    #[error("epic '{0}' already exists with status {1:?}")]
+    EpicAlreadyExists(String, EpicStatus),
+
+    #[error("dep references unknown task: {0}")]
+    UnknownDepTarget(TaskId),
+
+    #[error("duplicate task id in plan: {0}")]
+    DuplicateTaskId(TaskId),
+}

--- a/plugins/github-autopilot/cli/src/domain/event.rs
+++ b/plugins/github-autopilot/cli/src/domain/event.rs
@@ -1,0 +1,79 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use super::task_id::TaskId;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Event {
+    pub task_id: Option<TaskId>,
+    pub epic_name: Option<String>,
+    pub kind: EventKind,
+    pub payload: serde_json::Value,
+    pub at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EventKind {
+    EpicStarted,
+    EpicCompleted,
+    EpicAbandoned,
+    TaskInserted,
+    TaskClaimed,
+    TaskStarted,
+    TaskCompleted,
+    TaskFailed,
+    TaskEscalated,
+    TaskBlocked,
+    TaskUnblocked,
+    Reconciled,
+    ClaimLost,
+    MigratedFromIssue,
+    EscalationResolved,
+    WatchDuplicate,
+}
+
+impl EventKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            EventKind::EpicStarted => "epic_started",
+            EventKind::EpicCompleted => "epic_completed",
+            EventKind::EpicAbandoned => "epic_abandoned",
+            EventKind::TaskInserted => "task_inserted",
+            EventKind::TaskClaimed => "task_claimed",
+            EventKind::TaskStarted => "task_started",
+            EventKind::TaskCompleted => "task_completed",
+            EventKind::TaskFailed => "task_failed",
+            EventKind::TaskEscalated => "task_escalated",
+            EventKind::TaskBlocked => "task_blocked",
+            EventKind::TaskUnblocked => "task_unblocked",
+            EventKind::Reconciled => "reconciled",
+            EventKind::ClaimLost => "claim_lost",
+            EventKind::MigratedFromIssue => "migrated_from_issue",
+            EventKind::EscalationResolved => "escalation_resolved",
+            EventKind::WatchDuplicate => "watch_duplicate",
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Self> {
+        Some(match s {
+            "epic_started" => EventKind::EpicStarted,
+            "epic_completed" => EventKind::EpicCompleted,
+            "epic_abandoned" => EventKind::EpicAbandoned,
+            "task_inserted" => EventKind::TaskInserted,
+            "task_claimed" => EventKind::TaskClaimed,
+            "task_started" => EventKind::TaskStarted,
+            "task_completed" => EventKind::TaskCompleted,
+            "task_failed" => EventKind::TaskFailed,
+            "task_escalated" => EventKind::TaskEscalated,
+            "task_blocked" => EventKind::TaskBlocked,
+            "task_unblocked" => EventKind::TaskUnblocked,
+            "reconciled" => EventKind::Reconciled,
+            "claim_lost" => EventKind::ClaimLost,
+            "migrated_from_issue" => EventKind::MigratedFromIssue,
+            "escalation_resolved" => EventKind::EscalationResolved,
+            "watch_duplicate" => EventKind::WatchDuplicate,
+            _ => return None,
+        })
+    }
+}

--- a/plugins/github-autopilot/cli/src/domain/mod.rs
+++ b/plugins/github-autopilot/cli/src/domain/mod.rs
@@ -1,0 +1,13 @@
+pub mod deps;
+pub mod epic;
+pub mod error;
+pub mod event;
+pub mod task;
+pub mod task_id;
+
+pub use deps::{CycleError, TaskGraph};
+pub use epic::{Epic, EpicStatus};
+pub use error::DomainError;
+pub use event::{Event, EventKind};
+pub use task::{Task, TaskFailureOutcome, TaskSource, TaskStatus};
+pub use task_id::TaskId;

--- a/plugins/github-autopilot/cli/src/domain/task.rs
+++ b/plugins/github-autopilot/cli/src/domain/task.rs
@@ -1,0 +1,100 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use super::task_id::TaskId;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Task {
+    pub id: TaskId,
+    pub epic_name: String,
+    pub source: TaskSource,
+    pub fingerprint: Option<String>,
+    pub title: String,
+    pub body: Option<String>,
+    pub status: TaskStatus,
+    pub attempts: u32,
+    pub branch: Option<String>,
+    pub pr_number: Option<u64>,
+    pub escalated_issue: Option<u64>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TaskStatus {
+    Pending,
+    Ready,
+    Wip,
+    Blocked,
+    Done,
+    Escalated,
+}
+
+impl TaskStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            TaskStatus::Pending => "pending",
+            TaskStatus::Ready => "ready",
+            TaskStatus::Wip => "wip",
+            TaskStatus::Blocked => "blocked",
+            TaskStatus::Done => "done",
+            TaskStatus::Escalated => "escalated",
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "pending" => Some(TaskStatus::Pending),
+            "ready" => Some(TaskStatus::Ready),
+            "wip" => Some(TaskStatus::Wip),
+            "blocked" => Some(TaskStatus::Blocked),
+            "done" => Some(TaskStatus::Done),
+            "escalated" => Some(TaskStatus::Escalated),
+            _ => None,
+        }
+    }
+
+    pub fn is_terminal(self) -> bool {
+        matches!(self, TaskStatus::Done | TaskStatus::Escalated)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum TaskSource {
+    Decompose,
+    GapWatch,
+    QaBoost,
+    CiWatch,
+    Human,
+}
+
+impl TaskSource {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            TaskSource::Decompose => "decompose",
+            TaskSource::GapWatch => "gap-watch",
+            TaskSource::QaBoost => "qa-boost",
+            TaskSource::CiWatch => "ci-watch",
+            TaskSource::Human => "human",
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "decompose" => Some(TaskSource::Decompose),
+            "gap-watch" => Some(TaskSource::GapWatch),
+            "qa-boost" => Some(TaskSource::QaBoost),
+            "ci-watch" => Some(TaskSource::CiWatch),
+            "human" => Some(TaskSource::Human),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TaskFailureOutcome {
+    Retried { attempts: u32 },
+    Escalated { attempts: u32 },
+}

--- a/plugins/github-autopilot/cli/src/domain/task_id.rs
+++ b/plugins/github-autopilot/cli/src/domain/task_id.rs
@@ -1,0 +1,121 @@
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use unicode_normalization::UnicodeNormalization;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize, Deserialize)]
+pub struct TaskId(String);
+
+impl TaskId {
+    pub fn new_deterministic(epic: &str, section_path: &str, requirement: &str) -> Self {
+        let canon = format!(
+            "{}::{}::{}",
+            epic,
+            normalize_section(section_path),
+            slug(requirement)
+        );
+        let digest = Sha256::digest(canon.as_bytes());
+        Self(hex::encode(digest)[..12].to_string())
+    }
+
+    pub fn from_raw(raw: impl Into<String>) -> Self {
+        Self(raw.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for TaskId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+fn normalize_section(p: &str) -> String {
+    let nfkc: String = p.nfkc().collect();
+    let lower = nfkc.to_lowercase();
+    let trimmed = lower.trim();
+    let mut out = String::with_capacity(trimmed.len());
+    let mut last_was_space = false;
+    for ch in trimmed.chars() {
+        if ch.is_whitespace() {
+            if !last_was_space {
+                out.push(' ');
+                last_was_space = true;
+            }
+        } else {
+            out.push(ch);
+            last_was_space = false;
+        }
+    }
+    out
+}
+
+fn slug(s: &str) -> String {
+    let nfkc: String = s.nfkc().collect();
+    let lower = nfkc.to_lowercase();
+    let mut out = String::with_capacity(lower.len());
+    let mut last_was_dash = true;
+    for ch in lower.chars() {
+        if ch.is_alphanumeric() {
+            out.push(ch);
+            last_was_dash = false;
+        } else if !last_was_dash {
+            out.push('-');
+            last_was_dash = true;
+        }
+    }
+    while out.ends_with('-') {
+        out.pop();
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn task_id_is_stable_across_runs() {
+        let a = TaskId::new_deterministic("e", "## 인증", "토큰 갱신");
+        let b = TaskId::new_deterministic("e", "## 인증", "토큰 갱신");
+        assert_eq!(a, b);
+        assert_eq!(a.as_str().len(), 12);
+    }
+
+    #[test]
+    fn task_id_normalizes_whitespace_in_section() {
+        let a = TaskId::new_deterministic("e", "## 인증", "토큰 갱신");
+        let b = TaskId::new_deterministic("e", "##  인증  ", "토큰  갱신");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn task_id_normalizes_nfkc() {
+        let a = TaskId::new_deterministic("e", "## 인증", "토큰 갱신");
+        let b = TaskId::new_deterministic("e", "## 인증", "토큰\u{00A0}갱신");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn task_id_differs_on_meaningful_change() {
+        let a = TaskId::new_deterministic("e", "## 인증", "토큰 갱신");
+        let b = TaskId::new_deterministic("e", "## 인증", "토큰 발급");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn task_id_differs_across_epics() {
+        let a = TaskId::new_deterministic("e1", "## 인증", "토큰 갱신");
+        let b = TaskId::new_deterministic("e2", "## 인증", "토큰 갱신");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn slug_collapses_multiple_separators() {
+        assert_eq!(slug("hello   world!!!"), "hello-world");
+        assert_eq!(slug("---abc---"), "abc");
+        assert_eq!(slug("foo/bar.baz"), "foo-bar-baz");
+    }
+}

--- a/plugins/github-autopilot/cli/src/lib.rs
+++ b/plugins/github-autopilot/cli/src/lib.rs
@@ -1,5 +1,8 @@
 pub mod cmd;
+pub mod domain;
 pub mod fs;
 pub mod gh;
 pub mod git;
 pub mod github;
+pub mod ports;
+pub mod store;

--- a/plugins/github-autopilot/cli/src/main.rs
+++ b/plugins/github-autopilot/cli/src/main.rs
@@ -1,10 +1,12 @@
 use autopilot::cmd::{
     CheckCommands, Cli, Commands, IssueCommands, ListArgs, PipelineCommands, PreflightArgs,
-    StatsCommands, WorktreeCommands,
+    StatsCommands, TaskCommands, WorktreeCommands,
 };
+use autopilot::store::SqliteTaskStore;
 use autopilot::{cmd, fs, gh, git, github};
 use clap::Parser;
-use std::path::Path;
+use std::io::stdout;
+use std::path::{Path, PathBuf};
 
 fn main() {
     let cli = Cli::parse();
@@ -147,6 +149,30 @@ fn main() {
                 Path::new(&repo_root),
             )
         }
+        Commands::Task { command } => {
+            let db_path = task_store_db_path();
+            let store = match SqliteTaskStore::open(&db_path) {
+                Ok(s) => s,
+                Err(e) => {
+                    eprintln!("failed to open task store at {}: {e}", db_path.display());
+                    std::process::exit(2);
+                }
+            };
+            let clock = cmd::task::default_clock();
+            let svc = cmd::task::task_service(&store, &clock);
+            let mut out = stdout();
+            match command {
+                TaskCommands::List { epic, status, json } => {
+                    svc.list(&epic, status, json, &mut out)
+                }
+                TaskCommands::Show { task_id, json } => svc.show(&task_id, json, &mut out),
+                TaskCommands::ForceStatus {
+                    task_id,
+                    to,
+                    reason,
+                } => svc.force_status(&task_id, to, reason.as_deref(), &mut out),
+            }
+        }
     };
 
     match result {
@@ -156,4 +182,15 @@ fn main() {
             std::process::exit(2);
         }
     }
+}
+
+fn task_store_db_path() -> PathBuf {
+    if let Ok(p) = std::env::var("AUTOPILOT_DB_PATH") {
+        return PathBuf::from(p);
+    }
+    let dir = PathBuf::from(".autopilot");
+    if !dir.exists() {
+        let _ = std::fs::create_dir_all(&dir);
+    }
+    dir.join("state.db")
 }

--- a/plugins/github-autopilot/cli/src/ports/clock.rs
+++ b/plugins/github-autopilot/cli/src/ports/clock.rs
@@ -1,0 +1,42 @@
+use std::sync::Mutex;
+
+use chrono::{DateTime, Utc};
+
+pub trait Clock: Send + Sync {
+    fn now(&self) -> DateTime<Utc>;
+}
+
+pub struct StdClock;
+
+impl Clock for StdClock {
+    fn now(&self) -> DateTime<Utc> {
+        Utc::now()
+    }
+}
+
+pub struct FixedClock {
+    state: Mutex<DateTime<Utc>>,
+}
+
+impl FixedClock {
+    pub fn new(now: DateTime<Utc>) -> Self {
+        Self {
+            state: Mutex::new(now),
+        }
+    }
+
+    pub fn set(&self, now: DateTime<Utc>) {
+        *self.state.lock().expect("clock poisoned") = now;
+    }
+
+    pub fn advance(&self, by: chrono::Duration) {
+        let mut g = self.state.lock().expect("clock poisoned");
+        *g += by;
+    }
+}
+
+impl Clock for FixedClock {
+    fn now(&self) -> DateTime<Utc> {
+        *self.state.lock().expect("clock poisoned")
+    }
+}

--- a/plugins/github-autopilot/cli/src/ports/mod.rs
+++ b/plugins/github-autopilot/cli/src/ports/mod.rs
@@ -1,0 +1,9 @@
+pub mod clock;
+pub mod task_store;
+
+pub use clock::{Clock, FixedClock, StdClock};
+pub use task_store::{
+    EpicPlan, EpicRepo, EventFilter, EventLog, NewTask, NewWatchTask, ReconciliationPlan,
+    RemotePrState, RemoteTaskState, TaskRepo, TaskStore, TaskStoreError, UnblockReport,
+    UpsertOutcome,
+};

--- a/plugins/github-autopilot/cli/src/ports/task_store.rs
+++ b/plugins/github-autopilot/cli/src/ports/task_store.rs
@@ -1,0 +1,150 @@
+use chrono::{DateTime, Utc};
+use thiserror::Error;
+
+use crate::domain::{
+    DomainError, Epic, EpicStatus, Event, EventKind, Task, TaskFailureOutcome, TaskId, TaskSource,
+    TaskStatus,
+};
+
+pub type Result<T> = std::result::Result<T, TaskStoreError>;
+
+#[derive(Debug, Error)]
+pub enum TaskStoreError {
+    #[error("storage busy")]
+    Busy,
+
+    #[error("storage backend: {0}")]
+    Backend(String),
+
+    #[error("schema mismatch: at v{found}, expected v{expected}")]
+    SchemaMismatch { found: u32, expected: u32 },
+
+    #[error("not found: {0}")]
+    NotFound(String),
+
+    #[error(transparent)]
+    Domain(#[from] DomainError),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NewTask {
+    pub id: TaskId,
+    pub source: TaskSource,
+    pub fingerprint: Option<String>,
+    pub title: String,
+    pub body: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NewWatchTask {
+    pub id: TaskId,
+    pub epic_name: String,
+    pub source: TaskSource,
+    pub fingerprint: String,
+    pub title: String,
+    pub body: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UpsertOutcome {
+    Inserted(TaskId),
+    DuplicateFingerprint(TaskId),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnblockReport {
+    pub completed: TaskId,
+    pub newly_ready: Vec<TaskId>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EpicPlan {
+    pub epic: Epic,
+    pub tasks: Vec<NewTask>,
+    pub deps: Vec<(TaskId, TaskId)>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReconciliationPlan {
+    pub epic: Epic,
+    pub tasks: Vec<NewTask>,
+    pub deps: Vec<(TaskId, TaskId)>,
+    pub remote_state: Vec<RemoteTaskState>,
+    pub orphan_branches: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteTaskState {
+    pub task_id: TaskId,
+    pub branch_exists: bool,
+    pub pr: Option<RemotePrState>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemotePrState {
+    pub number: u64,
+    pub merged: bool,
+    pub closed: bool,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct EventFilter {
+    pub epic: Option<String>,
+    pub task: Option<TaskId>,
+    pub kinds: Vec<EventKind>,
+    pub since: Option<DateTime<Utc>>,
+    pub limit: Option<u32>,
+}
+
+pub trait EpicRepo: Send + Sync {
+    fn upsert_epic(&self, epic: &Epic) -> Result<()>;
+    fn get_epic(&self, name: &str) -> Result<Option<Epic>>;
+    fn list_epics(&self, status: Option<EpicStatus>) -> Result<Vec<Epic>>;
+    fn set_epic_status(&self, name: &str, status: EpicStatus, at: DateTime<Utc>) -> Result<()>;
+}
+
+pub trait TaskRepo: Send + Sync {
+    fn insert_epic_with_tasks(&self, plan: EpicPlan, now: DateTime<Utc>) -> Result<()>;
+
+    fn get_task(&self, id: &TaskId) -> Result<Option<Task>>;
+
+    fn list_tasks_by_epic(&self, epic: &str, status: Option<TaskStatus>) -> Result<Vec<Task>>;
+
+    fn find_by_fingerprint(&self, epic: &str, fingerprint: &str) -> Result<Option<Task>>;
+
+    fn upsert_watch_task(&self, task: NewWatchTask, now: DateTime<Utc>) -> Result<UpsertOutcome>;
+
+    fn claim_next_task(&self, epic: &str, now: DateTime<Utc>) -> Result<Option<Task>>;
+
+    fn complete_task_and_unblock(
+        &self,
+        id: &TaskId,
+        pr_number: u64,
+        now: DateTime<Utc>,
+    ) -> Result<UnblockReport>;
+
+    fn mark_task_failed(
+        &self,
+        id: &TaskId,
+        max_attempts: u32,
+        now: DateTime<Utc>,
+    ) -> Result<TaskFailureOutcome>;
+
+    fn escalate_task(&self, id: &TaskId, issue_number: u64, now: DateTime<Utc>) -> Result<()>;
+
+    fn revert_to_ready(&self, id: &TaskId, now: DateTime<Utc>) -> Result<()>;
+
+    fn force_status(&self, id: &TaskId, new_status: TaskStatus, now: DateTime<Utc>) -> Result<()>;
+
+    fn apply_reconciliation(&self, plan: ReconciliationPlan, now: DateTime<Utc>) -> Result<()>;
+
+    fn list_deps(&self, task_id: &TaskId) -> Result<Vec<TaskId>>;
+}
+
+pub trait EventLog: Send + Sync {
+    fn append_event(&self, event: &Event) -> Result<()>;
+    fn list_events(&self, filter: EventFilter) -> Result<Vec<Event>>;
+}
+
+pub trait TaskStore: EpicRepo + TaskRepo + EventLog + Send + Sync {}
+impl<T: EpicRepo + TaskRepo + EventLog + Send + Sync + ?Sized> TaskStore for T {}

--- a/plugins/github-autopilot/cli/src/store/memory.rs
+++ b/plugins/github-autopilot/cli/src/store/memory.rs
@@ -1,0 +1,753 @@
+use std::collections::BTreeMap;
+use std::sync::Mutex;
+
+use chrono::{DateTime, Utc};
+
+use crate::domain::{
+    DomainError, Epic, EpicStatus, Event, EventKind, Task, TaskFailureOutcome, TaskGraph, TaskId,
+    TaskStatus,
+};
+use crate::ports::task_store::{
+    EpicPlan, EpicRepo, EventFilter, EventLog, NewWatchTask, ReconciliationPlan, RemotePrState,
+    Result, TaskRepo, TaskStoreError, UnblockReport, UpsertOutcome,
+};
+
+#[derive(Default)]
+struct State {
+    epics: BTreeMap<String, Epic>,
+    tasks: BTreeMap<TaskId, Task>,
+    deps: Vec<(TaskId, TaskId)>,
+    events: Vec<Event>,
+}
+
+#[derive(Default)]
+pub struct InMemoryTaskStore {
+    state: Mutex<State>,
+}
+
+impl InMemoryTaskStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl InMemoryTaskStore {
+    fn deps_of(state: &State, id: &TaskId) -> Vec<TaskId> {
+        state
+            .deps
+            .iter()
+            .filter(|(t, _)| t == id)
+            .map(|(_, d)| d.clone())
+            .collect()
+    }
+
+    fn dependents_of(state: &State, id: &TaskId) -> Vec<TaskId> {
+        state
+            .deps
+            .iter()
+            .filter(|(_, d)| d == id)
+            .map(|(t, _)| t.clone())
+            .collect()
+    }
+
+    fn all_deps_done(state: &State, id: &TaskId) -> bool {
+        Self::deps_of(state, id).iter().all(|d| {
+            state
+                .tasks
+                .get(d)
+                .map(|t| t.status == TaskStatus::Done)
+                .unwrap_or(false)
+        })
+    }
+
+    fn push_event(state: &mut State, event: Event) {
+        state.events.push(event);
+    }
+
+    fn make_event(
+        kind: EventKind,
+        epic: Option<String>,
+        task: Option<TaskId>,
+        payload: serde_json::Value,
+        at: DateTime<Utc>,
+    ) -> Event {
+        Event {
+            task_id: task,
+            epic_name: epic,
+            kind,
+            payload,
+            at,
+        }
+    }
+}
+
+impl EpicRepo for InMemoryTaskStore {
+    fn upsert_epic(&self, epic: &Epic) -> Result<()> {
+        let mut s = self.state.lock().expect("poisoned");
+        s.epics.insert(epic.name.clone(), epic.clone());
+        Ok(())
+    }
+
+    fn get_epic(&self, name: &str) -> Result<Option<Epic>> {
+        let s = self.state.lock().expect("poisoned");
+        Ok(s.epics.get(name).cloned())
+    }
+
+    fn list_epics(&self, status: Option<EpicStatus>) -> Result<Vec<Epic>> {
+        let s = self.state.lock().expect("poisoned");
+        let out: Vec<Epic> = s
+            .epics
+            .values()
+            .filter(|e| status.is_none_or(|st| e.status == st))
+            .cloned()
+            .collect();
+        Ok(out)
+    }
+
+    fn set_epic_status(&self, name: &str, status: EpicStatus, at: DateTime<Utc>) -> Result<()> {
+        let mut s = self.state.lock().expect("poisoned");
+        let epic = s
+            .epics
+            .get_mut(name)
+            .ok_or_else(|| TaskStoreError::NotFound(format!("epic '{name}'")))?;
+        epic.status = status;
+        if matches!(status, EpicStatus::Completed | EpicStatus::Abandoned) {
+            epic.completed_at = Some(at);
+        }
+        let kind = match status {
+            EpicStatus::Active => EventKind::EpicStarted,
+            EpicStatus::Completed => EventKind::EpicCompleted,
+            EpicStatus::Abandoned => EventKind::EpicAbandoned,
+        };
+        let event = InMemoryTaskStore::make_event(
+            kind,
+            Some(name.to_string()),
+            None,
+            serde_json::json!({}),
+            at,
+        );
+        InMemoryTaskStore::push_event(&mut s, event);
+        Ok(())
+    }
+}
+
+impl TaskRepo for InMemoryTaskStore {
+    fn insert_epic_with_tasks(&self, plan: EpicPlan, now: DateTime<Utc>) -> Result<()> {
+        // Validate task id uniqueness
+        let mut seen = std::collections::BTreeSet::new();
+        for t in &plan.tasks {
+            if !seen.insert(t.id.clone()) {
+                return Err(DomainError::DuplicateTaskId(t.id.clone()).into());
+            }
+        }
+        // Validate deps reference plan tasks
+        for (a, b) in &plan.deps {
+            if !seen.contains(a) {
+                return Err(DomainError::UnknownDepTarget(a.clone()).into());
+            }
+            if !seen.contains(b) {
+                return Err(DomainError::UnknownDepTarget(b.clone()).into());
+            }
+        }
+        // Validate cycle
+        let graph = TaskGraph::build(plan.deps.iter().cloned());
+        if let Some(cycle) = graph.detect_cycle() {
+            return Err(DomainError::DepCycle(cycle).into());
+        }
+
+        let mut s = self.state.lock().expect("poisoned");
+
+        if let Some(existing) = s.epics.get(&plan.epic.name) {
+            return Err(
+                DomainError::EpicAlreadyExists(plan.epic.name.clone(), existing.status).into(),
+            );
+        }
+
+        // Insert/replace epic as active
+        let epic = Epic {
+            status: EpicStatus::Active,
+            ..plan.epic.clone()
+        };
+        s.epics.insert(epic.name.clone(), epic.clone());
+
+        // Insert tasks (status pending, attempts 0)
+        for nt in &plan.tasks {
+            let task = Task {
+                id: nt.id.clone(),
+                epic_name: epic.name.clone(),
+                source: nt.source,
+                fingerprint: nt.fingerprint.clone(),
+                title: nt.title.clone(),
+                body: nt.body.clone(),
+                status: TaskStatus::Pending,
+                attempts: 0,
+                branch: None,
+                pr_number: None,
+                escalated_issue: None,
+                created_at: now,
+                updated_at: now,
+            };
+            s.tasks.insert(task.id.clone(), task);
+        }
+
+        // Insert deps
+        for (a, b) in plan.deps {
+            s.deps.push((a, b));
+        }
+
+        // Promote entry-points to Ready
+        let plan_ids: Vec<TaskId> = plan.tasks.iter().map(|t| t.id.clone()).collect();
+        let entry_points: Vec<TaskId> = plan_ids
+            .iter()
+            .filter(|id| !s.deps.iter().any(|(t, _)| t == *id))
+            .cloned()
+            .collect();
+        for id in &entry_points {
+            if let Some(t) = s.tasks.get_mut(id) {
+                t.status = TaskStatus::Ready;
+                t.updated_at = now;
+            }
+        }
+
+        // Events
+        InMemoryTaskStore::push_event(
+            &mut s,
+            InMemoryTaskStore::make_event(
+                EventKind::EpicStarted,
+                Some(epic.name.clone()),
+                None,
+                serde_json::json!({}),
+                now,
+            ),
+        );
+        for nt in &plan.tasks {
+            InMemoryTaskStore::push_event(
+                &mut s,
+                InMemoryTaskStore::make_event(
+                    EventKind::TaskInserted,
+                    Some(epic.name.clone()),
+                    Some(nt.id.clone()),
+                    serde_json::json!({"source": nt.source.as_str()}),
+                    now,
+                ),
+            );
+        }
+        Ok(())
+    }
+
+    fn get_task(&self, id: &TaskId) -> Result<Option<Task>> {
+        let s = self.state.lock().expect("poisoned");
+        Ok(s.tasks.get(id).cloned())
+    }
+
+    fn list_tasks_by_epic(&self, epic: &str, status: Option<TaskStatus>) -> Result<Vec<Task>> {
+        let s = self.state.lock().expect("poisoned");
+        let out: Vec<Task> = s
+            .tasks
+            .values()
+            .filter(|t| t.epic_name == epic)
+            .filter(|t| status.is_none_or(|st| t.status == st))
+            .cloned()
+            .collect();
+        Ok(out)
+    }
+
+    fn find_by_fingerprint(&self, epic: &str, fingerprint: &str) -> Result<Option<Task>> {
+        let s = self.state.lock().expect("poisoned");
+        Ok(s.tasks
+            .values()
+            .find(|t| t.epic_name == epic && t.fingerprint.as_deref() == Some(fingerprint))
+            .cloned())
+    }
+
+    fn upsert_watch_task(&self, task: NewWatchTask, now: DateTime<Utc>) -> Result<UpsertOutcome> {
+        let mut s = self.state.lock().expect("poisoned");
+
+        // Duplicate fingerprint check
+        if let Some(existing) = s
+            .tasks
+            .values()
+            .find(|t| {
+                t.epic_name == task.epic_name
+                    && t.fingerprint.as_deref() == Some(task.fingerprint.as_str())
+            })
+            .cloned()
+        {
+            InMemoryTaskStore::push_event(
+                &mut s,
+                InMemoryTaskStore::make_event(
+                    EventKind::WatchDuplicate,
+                    Some(task.epic_name.clone()),
+                    Some(existing.id.clone()),
+                    serde_json::json!({"fingerprint": task.fingerprint}),
+                    now,
+                ),
+            );
+            return Ok(UpsertOutcome::DuplicateFingerprint(existing.id));
+        }
+
+        // Determine initial status: Ready if no deps, else Pending. New watch tasks have no deps
+        // by definition (deps come only from spec decomposition).
+        let initial_status = TaskStatus::Ready;
+
+        let new_task = Task {
+            id: task.id.clone(),
+            epic_name: task.epic_name.clone(),
+            source: task.source,
+            fingerprint: Some(task.fingerprint.clone()),
+            title: task.title.clone(),
+            body: task.body.clone(),
+            status: initial_status,
+            attempts: 0,
+            branch: None,
+            pr_number: None,
+            escalated_issue: None,
+            created_at: now,
+            updated_at: now,
+        };
+        let id = new_task.id.clone();
+        s.tasks.insert(id.clone(), new_task);
+        InMemoryTaskStore::push_event(
+            &mut s,
+            InMemoryTaskStore::make_event(
+                EventKind::TaskInserted,
+                Some(task.epic_name.clone()),
+                Some(id.clone()),
+                serde_json::json!({"source": task.source.as_str(), "fingerprint": task.fingerprint}),
+                now,
+            ),
+        );
+        Ok(UpsertOutcome::Inserted(id))
+    }
+
+    fn claim_next_task(&self, epic: &str, now: DateTime<Utc>) -> Result<Option<Task>> {
+        let mut s = self.state.lock().expect("poisoned");
+        // Candidates: ready tasks in this epic with all deps Done, ordered by created_at then id
+        let mut candidates: Vec<TaskId> = s
+            .tasks
+            .values()
+            .filter(|t| t.epic_name == epic && t.status == TaskStatus::Ready)
+            .filter(|t| InMemoryTaskStore::all_deps_done(&s, &t.id))
+            .map(|t| (t.created_at, t.id.clone()))
+            .collect::<Vec<_>>()
+            .into_iter()
+            .map(|(_, id)| id)
+            .collect();
+        candidates.sort_by(|a, b| {
+            let ta = s.tasks.get(a).unwrap();
+            let tb = s.tasks.get(b).unwrap();
+            ta.created_at.cmp(&tb.created_at).then_with(|| a.cmp(b))
+        });
+
+        let chosen = match candidates.first().cloned() {
+            Some(c) => c,
+            None => return Ok(None),
+        };
+
+        let task = s.tasks.get_mut(&chosen).unwrap();
+        task.status = TaskStatus::Wip;
+        task.attempts += 1;
+        task.updated_at = now;
+        let snapshot = task.clone();
+
+        InMemoryTaskStore::push_event(
+            &mut s,
+            InMemoryTaskStore::make_event(
+                EventKind::TaskClaimed,
+                Some(epic.to_string()),
+                Some(snapshot.id.clone()),
+                serde_json::json!({"attempts": snapshot.attempts}),
+                now,
+            ),
+        );
+
+        Ok(Some(snapshot))
+    }
+
+    fn complete_task_and_unblock(
+        &self,
+        id: &TaskId,
+        pr_number: u64,
+        now: DateTime<Utc>,
+    ) -> Result<UnblockReport> {
+        let mut s = self.state.lock().expect("poisoned");
+        let task = s
+            .tasks
+            .get_mut(id)
+            .ok_or_else(|| TaskStoreError::NotFound(format!("task '{id}'")))?;
+        if task.status != TaskStatus::Wip {
+            let cur = task.status;
+            return Err(DomainError::IllegalTransition(id.clone(), cur, TaskStatus::Done).into());
+        }
+        task.status = TaskStatus::Done;
+        task.pr_number = Some(pr_number);
+        task.updated_at = now;
+        let epic_name = task.epic_name.clone();
+
+        InMemoryTaskStore::push_event(
+            &mut s,
+            InMemoryTaskStore::make_event(
+                EventKind::TaskCompleted,
+                Some(epic_name.clone()),
+                Some(id.clone()),
+                serde_json::json!({"pr_number": pr_number}),
+                now,
+            ),
+        );
+
+        // Unblock dependents
+        let dependents = InMemoryTaskStore::dependents_of(&s, id);
+        let mut newly_ready: Vec<TaskId> = Vec::new();
+        for dep_task_id in dependents {
+            let promote = {
+                let dt = match s.tasks.get(&dep_task_id) {
+                    Some(t) => t,
+                    None => continue,
+                };
+                matches!(dt.status, TaskStatus::Pending | TaskStatus::Blocked)
+                    && InMemoryTaskStore::all_deps_done(&s, &dep_task_id)
+            };
+            if promote {
+                if let Some(dt) = s.tasks.get_mut(&dep_task_id) {
+                    dt.status = TaskStatus::Ready;
+                    dt.updated_at = now;
+                }
+                newly_ready.push(dep_task_id.clone());
+                InMemoryTaskStore::push_event(
+                    &mut s,
+                    InMemoryTaskStore::make_event(
+                        EventKind::TaskUnblocked,
+                        Some(epic_name.clone()),
+                        Some(dep_task_id),
+                        serde_json::json!({}),
+                        now,
+                    ),
+                );
+            }
+        }
+
+        Ok(UnblockReport {
+            completed: id.clone(),
+            newly_ready,
+        })
+    }
+
+    fn mark_task_failed(
+        &self,
+        id: &TaskId,
+        max_attempts: u32,
+        now: DateTime<Utc>,
+    ) -> Result<TaskFailureOutcome> {
+        let mut s = self.state.lock().expect("poisoned");
+        let task = s
+            .tasks
+            .get_mut(id)
+            .ok_or_else(|| TaskStoreError::NotFound(format!("task '{id}'")))?;
+        if task.status != TaskStatus::Wip {
+            let cur = task.status;
+            return Err(DomainError::IllegalTransition(id.clone(), cur, TaskStatus::Ready).into());
+        }
+        let attempts = task.attempts;
+        let epic_name = task.epic_name.clone();
+
+        if attempts >= max_attempts {
+            task.status = TaskStatus::Escalated;
+            task.updated_at = now;
+            InMemoryTaskStore::push_event(
+                &mut s,
+                InMemoryTaskStore::make_event(
+                    EventKind::TaskFailed,
+                    Some(epic_name.clone()),
+                    Some(id.clone()),
+                    serde_json::json!({"final": true, "attempts": attempts}),
+                    now,
+                ),
+            );
+            InMemoryTaskStore::push_event(
+                &mut s,
+                InMemoryTaskStore::make_event(
+                    EventKind::TaskEscalated,
+                    Some(epic_name.clone()),
+                    Some(id.clone()),
+                    serde_json::json!({"attempts": attempts}),
+                    now,
+                ),
+            );
+            // Block dependents
+            let dependents = InMemoryTaskStore::dependents_of(&s, id);
+            for dep_id in dependents {
+                let should_block = matches!(
+                    s.tasks.get(&dep_id).map(|t| t.status),
+                    Some(TaskStatus::Pending) | Some(TaskStatus::Ready)
+                );
+                if should_block {
+                    if let Some(dt) = s.tasks.get_mut(&dep_id) {
+                        dt.status = TaskStatus::Blocked;
+                        dt.updated_at = now;
+                    }
+                    InMemoryTaskStore::push_event(
+                        &mut s,
+                        InMemoryTaskStore::make_event(
+                            EventKind::TaskBlocked,
+                            Some(epic_name.clone()),
+                            Some(dep_id),
+                            serde_json::json!({"reason": "parent_escalated", "parent": id.as_str()}),
+                            now,
+                        ),
+                    );
+                }
+            }
+            Ok(TaskFailureOutcome::Escalated { attempts })
+        } else {
+            task.status = TaskStatus::Ready;
+            task.updated_at = now;
+            InMemoryTaskStore::push_event(
+                &mut s,
+                InMemoryTaskStore::make_event(
+                    EventKind::TaskFailed,
+                    Some(epic_name),
+                    Some(id.clone()),
+                    serde_json::json!({"final": false, "attempts": attempts}),
+                    now,
+                ),
+            );
+            Ok(TaskFailureOutcome::Retried { attempts })
+        }
+    }
+
+    fn escalate_task(&self, id: &TaskId, issue_number: u64, now: DateTime<Utc>) -> Result<()> {
+        let mut s = self.state.lock().expect("poisoned");
+        let task = s
+            .tasks
+            .get_mut(id)
+            .ok_or_else(|| TaskStoreError::NotFound(format!("task '{id}'")))?;
+        task.escalated_issue = Some(issue_number);
+        task.updated_at = now;
+        let epic_name = task.epic_name.clone();
+        InMemoryTaskStore::push_event(
+            &mut s,
+            InMemoryTaskStore::make_event(
+                EventKind::TaskEscalated,
+                Some(epic_name),
+                Some(id.clone()),
+                serde_json::json!({"issue": issue_number}),
+                now,
+            ),
+        );
+        Ok(())
+    }
+
+    fn revert_to_ready(&self, id: &TaskId, now: DateTime<Utc>) -> Result<()> {
+        let mut s = self.state.lock().expect("poisoned");
+        let task = s
+            .tasks
+            .get_mut(id)
+            .ok_or_else(|| TaskStoreError::NotFound(format!("task '{id}'")))?;
+        let cur = task.status;
+        if matches!(cur, TaskStatus::Done | TaskStatus::Escalated) {
+            return Err(DomainError::IllegalTransition(id.clone(), cur, TaskStatus::Ready).into());
+        }
+        task.status = TaskStatus::Ready;
+        task.updated_at = now;
+        Ok(())
+    }
+
+    fn force_status(&self, id: &TaskId, new_status: TaskStatus, now: DateTime<Utc>) -> Result<()> {
+        let mut s = self.state.lock().expect("poisoned");
+        let task = s
+            .tasks
+            .get_mut(id)
+            .ok_or_else(|| TaskStoreError::NotFound(format!("task '{id}'")))?;
+        task.status = new_status;
+        task.updated_at = now;
+        Ok(())
+    }
+
+    fn apply_reconciliation(&self, plan: ReconciliationPlan, now: DateTime<Utc>) -> Result<()> {
+        // Validate cycle in incoming plan
+        let graph = TaskGraph::build(plan.deps.iter().cloned());
+        if let Some(cycle) = graph.detect_cycle() {
+            return Err(DomainError::DepCycle(cycle).into());
+        }
+
+        let mut s = self.state.lock().expect("poisoned");
+
+        // Upsert epic as active
+        let epic_name = plan.epic.name.clone();
+        let merged_epic = match s.epics.get(&epic_name) {
+            Some(existing) => Epic {
+                status: EpicStatus::Active,
+                created_at: existing.created_at,
+                ..plan.epic.clone()
+            },
+            None => Epic {
+                status: EpicStatus::Active,
+                ..plan.epic.clone()
+            },
+        };
+        s.epics.insert(epic_name.clone(), merged_epic);
+
+        // Upsert tasks (preserve attempts, status, branch, pr_number)
+        let plan_ids: std::collections::BTreeSet<TaskId> =
+            plan.tasks.iter().map(|t| t.id.clone()).collect();
+        for nt in &plan.tasks {
+            match s.tasks.get_mut(&nt.id) {
+                Some(existing) => {
+                    existing.title = nt.title.clone();
+                    existing.body = nt.body.clone();
+                    existing.source = nt.source;
+                    if existing.fingerprint.is_none() {
+                        existing.fingerprint = nt.fingerprint.clone();
+                    }
+                    existing.updated_at = now;
+                }
+                None => {
+                    let task = Task {
+                        id: nt.id.clone(),
+                        epic_name: epic_name.clone(),
+                        source: nt.source,
+                        fingerprint: nt.fingerprint.clone(),
+                        title: nt.title.clone(),
+                        body: nt.body.clone(),
+                        status: TaskStatus::Pending,
+                        attempts: 0,
+                        branch: None,
+                        pr_number: None,
+                        escalated_issue: None,
+                        created_at: now,
+                        updated_at: now,
+                    };
+                    s.tasks.insert(task.id.clone(), task);
+                }
+            }
+        }
+
+        // Replace deps for plan tasks: drop existing deps where task_id in plan, insert new
+        s.deps.retain(|(a, _)| !plan_ids.contains(a));
+        for (a, b) in plan.deps {
+            s.deps.push((a, b));
+        }
+
+        // Apply remote_state to determine status
+        for r in &plan.remote_state {
+            let desired = remote_to_status(r, &s);
+            let task = match s.tasks.get_mut(&r.task_id) {
+                Some(t) => t,
+                None => continue,
+            };
+            task.status = desired;
+            if let Some(pr) = &r.pr {
+                task.pr_number = Some(pr.number);
+            }
+            task.updated_at = now;
+        }
+
+        // Tasks in plan but not in remote_state: classify by deps
+        let in_remote: std::collections::BTreeSet<TaskId> = plan
+            .remote_state
+            .iter()
+            .map(|r| r.task_id.clone())
+            .collect();
+        for nt in &plan.tasks {
+            if in_remote.contains(&nt.id) {
+                continue;
+            }
+            let deps_satisfied = InMemoryTaskStore::all_deps_done(&s, &nt.id);
+            let desired = if deps_satisfied {
+                TaskStatus::Ready
+            } else {
+                TaskStatus::Pending
+            };
+            // Only override if currently Pending — preserve any prior progress.
+            if let Some(task) = s.tasks.get_mut(&nt.id) {
+                if matches!(task.status, TaskStatus::Pending) {
+                    task.status = desired;
+                    task.updated_at = now;
+                }
+            }
+        }
+
+        // Orphan branches: emit one reconciled event per orphan
+        for branch in &plan.orphan_branches {
+            InMemoryTaskStore::push_event(
+                &mut s,
+                InMemoryTaskStore::make_event(
+                    EventKind::Reconciled,
+                    Some(epic_name.clone()),
+                    None,
+                    serde_json::json!({"orphan_branch": branch}),
+                    now,
+                ),
+            );
+        }
+
+        InMemoryTaskStore::push_event(
+            &mut s,
+            InMemoryTaskStore::make_event(
+                EventKind::Reconciled,
+                Some(epic_name.clone()),
+                None,
+                serde_json::json!({"tasks": plan.tasks.len()}),
+                now,
+            ),
+        );
+
+        Ok(())
+    }
+
+    fn list_deps(&self, task_id: &TaskId) -> Result<Vec<TaskId>> {
+        let s = self.state.lock().expect("poisoned");
+        Ok(InMemoryTaskStore::deps_of(&s, task_id))
+    }
+}
+
+fn remote_to_status(r: &crate::ports::task_store::RemoteTaskState, s: &State) -> TaskStatus {
+    match (&r.pr, r.branch_exists) {
+        (Some(RemotePrState { merged: true, .. }), _) => TaskStatus::Done,
+        (Some(_), true) => TaskStatus::Wip,
+        (None, true) => TaskStatus::Wip,
+        (None, false) => {
+            if InMemoryTaskStore::all_deps_done(s, &r.task_id) {
+                TaskStatus::Ready
+            } else {
+                TaskStatus::Pending
+            }
+        }
+        (Some(_), false) => TaskStatus::Wip, // PR open without branch is unusual; treat as wip
+    }
+}
+
+impl EventLog for InMemoryTaskStore {
+    fn append_event(&self, event: &Event) -> Result<()> {
+        let mut s = self.state.lock().expect("poisoned");
+        s.events.push(event.clone());
+        Ok(())
+    }
+
+    fn list_events(&self, filter: EventFilter) -> Result<Vec<Event>> {
+        let s = self.state.lock().expect("poisoned");
+        let mut out: Vec<Event> = s
+            .events
+            .iter()
+            .filter(|e| {
+                filter
+                    .epic
+                    .as_deref()
+                    .is_none_or(|n| e.epic_name.as_deref() == Some(n))
+            })
+            .filter(|e| {
+                filter
+                    .task
+                    .as_ref()
+                    .is_none_or(|t| e.task_id.as_ref() == Some(t))
+            })
+            .filter(|e| filter.kinds.is_empty() || filter.kinds.contains(&e.kind))
+            .filter(|e| filter.since.is_none_or(|s| e.at >= s))
+            .cloned()
+            .collect();
+        if let Some(limit) = filter.limit {
+            out.truncate(limit as usize);
+        }
+        Ok(out)
+    }
+}

--- a/plugins/github-autopilot/cli/src/store/migrations/V1__initial.sql
+++ b/plugins/github-autopilot/cli/src/store/migrations/V1__initial.sql
@@ -1,0 +1,60 @@
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS meta (
+  key   TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS epics (
+  name         TEXT PRIMARY KEY,
+  spec_path    TEXT NOT NULL,
+  branch       TEXT NOT NULL,
+  status       TEXT NOT NULL CHECK (status IN ('active','completed','abandoned')),
+  created_at   TEXT NOT NULL,
+  completed_at TEXT
+);
+
+CREATE TABLE IF NOT EXISTS tasks (
+  id              TEXT PRIMARY KEY,
+  epic_name       TEXT NOT NULL REFERENCES epics(name),
+  source          TEXT NOT NULL CHECK (source IN ('decompose','gap-watch','qa-boost','ci-watch','human')),
+  fingerprint     TEXT,
+  title           TEXT NOT NULL,
+  body            TEXT,
+  status          TEXT NOT NULL CHECK (status IN ('pending','ready','wip','blocked','done','escalated')),
+  attempts        INTEGER NOT NULL DEFAULT 0,
+  branch          TEXT,
+  pr_number       INTEGER,
+  escalated_issue INTEGER,
+  created_at      TEXT NOT NULL,
+  updated_at      TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS task_deps (
+  task_id    TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+  depends_on TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+  PRIMARY KEY (task_id, depends_on)
+);
+
+CREATE TABLE IF NOT EXISTS events (
+  id        INTEGER PRIMARY KEY AUTOINCREMENT,
+  epic_name TEXT,
+  task_id   TEXT,
+  kind      TEXT NOT NULL,
+  payload   TEXT NOT NULL DEFAULT '{}',
+  at        TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS escalation_suppression (
+  fingerprint    TEXT NOT NULL,
+  reason         TEXT NOT NULL,
+  suppress_until TEXT NOT NULL,
+  PRIMARY KEY (fingerprint, reason)
+);
+
+CREATE INDEX IF NOT EXISTS idx_tasks_epic_status ON tasks(epic_name, status);
+CREATE INDEX IF NOT EXISTS idx_tasks_fingerprint ON tasks(fingerprint);
+CREATE INDEX IF NOT EXISTS idx_events_epic_at   ON events(epic_name, at);
+CREATE INDEX IF NOT EXISTS idx_events_task_at   ON events(task_id, at);
+
+INSERT OR IGNORE INTO meta(key, value) VALUES ('schema_version', '1');

--- a/plugins/github-autopilot/cli/src/store/mod.rs
+++ b/plugins/github-autopilot/cli/src/store/mod.rs
@@ -1,0 +1,3 @@
+pub mod memory;
+
+pub use memory::InMemoryTaskStore;

--- a/plugins/github-autopilot/cli/src/store/mod.rs
+++ b/plugins/github-autopilot/cli/src/store/mod.rs
@@ -1,3 +1,5 @@
 pub mod memory;
+pub mod sqlite;
 
 pub use memory::InMemoryTaskStore;
+pub use sqlite::SqliteTaskStore;

--- a/plugins/github-autopilot/cli/src/store/sqlite.rs
+++ b/plugins/github-autopilot/cli/src/store/sqlite.rs
@@ -1,16 +1,19 @@
 //! SQLite adapter for the TaskStore port.
 //!
-//! Implementation is built incrementally; methods that are not yet wired up
-//! return [`TaskStoreError::Backend`] so the lib still compiles while the
-//! conformance suite drives in remaining behaviour.
+//! Implementation is built incrementally; transactional write methods that
+//! span multiple steps may still return [`TaskStoreError::Backend`] until
+//! they are wired up to the conformance suite.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
 use chrono::{DateTime, Utc};
-use rusqlite::Connection;
+use rusqlite::{params, Connection, OptionalExtension, Row};
 
-use crate::domain::{Epic, EpicStatus, Event, Task, TaskFailureOutcome, TaskId, TaskStatus};
+use crate::domain::{
+    DomainError, Epic, EpicStatus, Event, EventKind, Task, TaskFailureOutcome, TaskId, TaskSource,
+    TaskStatus,
+};
 use crate::ports::task_store::{
     EpicPlan, EpicRepo, EventFilter, EventLog, NewWatchTask, ReconciliationPlan, Result, TaskRepo,
     TaskStoreError, UnblockReport, UpsertOutcome,
@@ -20,7 +23,6 @@ const SCHEMA_VERSION: u32 = 1;
 const V1_SQL: &str = include_str!("migrations/V1__initial.sql");
 
 pub struct SqliteTaskStore {
-    #[allow(dead_code)] // populated incrementally as methods land
     conn: Mutex<Connection>,
 }
 
@@ -93,22 +95,199 @@ fn unimpl(name: &str) -> TaskStoreError {
     TaskStoreError::Backend(format!("sqlite::{name} not yet implemented"))
 }
 
+fn epic_from_row(row: &Row<'_>) -> rusqlite::Result<Epic> {
+    let status_str: String = row.get("status")?;
+    let status = EpicStatus::parse(&status_str).ok_or_else(|| {
+        rusqlite::Error::FromSqlConversionFailure(
+            0,
+            rusqlite::types::Type::Text,
+            format!("invalid epic status: {status_str}").into(),
+        )
+    })?;
+    Ok(Epic {
+        name: row.get("name")?,
+        spec_path: PathBuf::from(row.get::<_, String>("spec_path")?),
+        branch: row.get("branch")?,
+        status,
+        created_at: row.get("created_at")?,
+        completed_at: row.get("completed_at")?,
+    })
+}
+
+fn task_from_row(row: &Row<'_>) -> rusqlite::Result<Task> {
+    let status_str: String = row.get("status")?;
+    let status = TaskStatus::parse(&status_str).ok_or_else(|| {
+        rusqlite::Error::FromSqlConversionFailure(
+            0,
+            rusqlite::types::Type::Text,
+            format!("invalid task status: {status_str}").into(),
+        )
+    })?;
+    let source_str: String = row.get("source")?;
+    let source = TaskSource::parse(&source_str).ok_or_else(|| {
+        rusqlite::Error::FromSqlConversionFailure(
+            0,
+            rusqlite::types::Type::Text,
+            format!("invalid task source: {source_str}").into(),
+        )
+    })?;
+    Ok(Task {
+        id: TaskId::from_raw(row.get::<_, String>("id")?),
+        epic_name: row.get("epic_name")?,
+        source,
+        fingerprint: row.get("fingerprint")?,
+        title: row.get("title")?,
+        body: row.get("body")?,
+        status,
+        attempts: row.get::<_, i64>("attempts")? as u32,
+        branch: row.get("branch")?,
+        pr_number: row.get::<_, Option<i64>>("pr_number")?.map(|n| n as u64),
+        escalated_issue: row
+            .get::<_, Option<i64>>("escalated_issue")?
+            .map(|n| n as u64),
+        created_at: row.get("created_at")?,
+        updated_at: row.get("updated_at")?,
+    })
+}
+
+fn event_from_row(row: &Row<'_>) -> rusqlite::Result<Event> {
+    let kind_str: String = row.get("kind")?;
+    let kind = EventKind::parse(&kind_str).ok_or_else(|| {
+        rusqlite::Error::FromSqlConversionFailure(
+            0,
+            rusqlite::types::Type::Text,
+            format!("invalid event kind: {kind_str}").into(),
+        )
+    })?;
+    let payload_str: String = row.get("payload")?;
+    let payload: serde_json::Value =
+        serde_json::from_str(&payload_str).unwrap_or(serde_json::Value::Object(Default::default()));
+    let task_id: Option<String> = row.get("task_id")?;
+    Ok(Event {
+        task_id: task_id.map(TaskId::from_raw),
+        epic_name: row.get("epic_name")?,
+        kind,
+        payload,
+        at: row.get("at")?,
+    })
+}
+
+impl SqliteTaskStore {
+    fn append_event_with(
+        conn: &Connection,
+        kind: EventKind,
+        epic: Option<&str>,
+        task: Option<&TaskId>,
+        payload: &serde_json::Value,
+        at: DateTime<Utc>,
+    ) -> rusqlite::Result<()> {
+        conn.execute(
+            "INSERT INTO events(epic_name, task_id, kind, payload, at) VALUES (?, ?, ?, ?, ?)",
+            params![
+                epic,
+                task.map(|t| t.as_str().to_string()),
+                kind.as_str(),
+                payload.to_string(),
+                at,
+            ],
+        )?;
+        Ok(())
+    }
+}
+
 impl EpicRepo for SqliteTaskStore {
-    fn upsert_epic(&self, _epic: &Epic) -> Result<()> {
-        Err(unimpl("upsert_epic"))
+    fn upsert_epic(&self, epic: &Epic) -> Result<()> {
+        let conn = self.conn.lock().expect("poisoned");
+        conn.execute(
+            "INSERT INTO epics(name, spec_path, branch, status, created_at, completed_at)
+             VALUES (?, ?, ?, ?, ?, ?)
+             ON CONFLICT(name) DO UPDATE SET
+               spec_path=excluded.spec_path,
+               branch=excluded.branch,
+               status=excluded.status,
+               completed_at=excluded.completed_at",
+            params![
+                epic.name,
+                epic.spec_path.to_string_lossy(),
+                epic.branch,
+                epic.status.as_str(),
+                epic.created_at,
+                epic.completed_at,
+            ],
+        )
+        .map_err(backend)?;
+        Ok(())
     }
 
     fn get_epic(&self, name: &str) -> Result<Option<Epic>> {
-        let _ = name;
-        Err(unimpl("get_epic"))
+        let conn = self.conn.lock().expect("poisoned");
+        conn.query_row(
+            "SELECT name, spec_path, branch, status, created_at, completed_at FROM epics WHERE name=?",
+            params![name],
+            epic_from_row,
+        )
+        .optional()
+        .map_err(backend)
     }
 
-    fn list_epics(&self, _status: Option<EpicStatus>) -> Result<Vec<Epic>> {
-        Err(unimpl("list_epics"))
+    fn list_epics(&self, status: Option<EpicStatus>) -> Result<Vec<Epic>> {
+        let conn = self.conn.lock().expect("poisoned");
+        let (sql, status_str) = match status {
+            Some(s) => (
+                "SELECT name, spec_path, branch, status, created_at, completed_at
+                   FROM epics WHERE status=? ORDER BY name",
+                Some(s.as_str().to_string()),
+            ),
+            None => (
+                "SELECT name, spec_path, branch, status, created_at, completed_at
+                   FROM epics ORDER BY name",
+                None,
+            ),
+        };
+        let mut stmt = conn.prepare(sql).map_err(backend)?;
+        let rows = if let Some(s) = status_str {
+            stmt.query_map(params![s], epic_from_row)
+                .map_err(backend)?
+                .collect::<std::result::Result<Vec<_>, _>>()
+        } else {
+            stmt.query_map([], epic_from_row)
+                .map_err(backend)?
+                .collect::<std::result::Result<Vec<_>, _>>()
+        };
+        rows.map_err(backend)
     }
 
-    fn set_epic_status(&self, _name: &str, _status: EpicStatus, _at: DateTime<Utc>) -> Result<()> {
-        Err(unimpl("set_epic_status"))
+    fn set_epic_status(&self, name: &str, status: EpicStatus, at: DateTime<Utc>) -> Result<()> {
+        let conn = self.conn.lock().expect("poisoned");
+        let completed_at = if matches!(status, EpicStatus::Completed | EpicStatus::Abandoned) {
+            Some(at)
+        } else {
+            None
+        };
+        let updated = conn
+            .execute(
+                "UPDATE epics SET status=?, completed_at=COALESCE(?, completed_at) WHERE name=?",
+                params![status.as_str(), completed_at, name],
+            )
+            .map_err(backend)?;
+        if updated == 0 {
+            return Err(TaskStoreError::NotFound(format!("epic '{name}'")));
+        }
+        let kind = match status {
+            EpicStatus::Active => EventKind::EpicStarted,
+            EpicStatus::Completed => EventKind::EpicCompleted,
+            EpicStatus::Abandoned => EventKind::EpicAbandoned,
+        };
+        SqliteTaskStore::append_event_with(
+            &conn,
+            kind,
+            Some(name),
+            None,
+            &serde_json::json!({}),
+            at,
+        )
+        .map_err(backend)?;
+        Ok(())
     }
 }
 
@@ -117,16 +296,58 @@ impl TaskRepo for SqliteTaskStore {
         Err(unimpl("insert_epic_with_tasks"))
     }
 
-    fn get_task(&self, _id: &TaskId) -> Result<Option<Task>> {
-        Err(unimpl("get_task"))
+    fn get_task(&self, id: &TaskId) -> Result<Option<Task>> {
+        let conn = self.conn.lock().expect("poisoned");
+        conn.query_row(
+            "SELECT id, epic_name, source, fingerprint, title, body, status, attempts,
+                    branch, pr_number, escalated_issue, created_at, updated_at
+               FROM tasks WHERE id=?",
+            params![id.as_str()],
+            task_from_row,
+        )
+        .optional()
+        .map_err(backend)
     }
 
-    fn list_tasks_by_epic(&self, _epic: &str, _status: Option<TaskStatus>) -> Result<Vec<Task>> {
-        Err(unimpl("list_tasks_by_epic"))
+    fn list_tasks_by_epic(&self, epic: &str, status: Option<TaskStatus>) -> Result<Vec<Task>> {
+        let conn = self.conn.lock().expect("poisoned");
+        let mut stmt = if status.is_some() {
+            conn.prepare(
+                "SELECT id, epic_name, source, fingerprint, title, body, status, attempts,
+                        branch, pr_number, escalated_issue, created_at, updated_at
+                   FROM tasks WHERE epic_name=? AND status=? ORDER BY created_at, id",
+            )
+        } else {
+            conn.prepare(
+                "SELECT id, epic_name, source, fingerprint, title, body, status, attempts,
+                        branch, pr_number, escalated_issue, created_at, updated_at
+                   FROM tasks WHERE epic_name=? ORDER BY created_at, id",
+            )
+        }
+        .map_err(backend)?;
+        let rows = if let Some(s) = status {
+            stmt.query_map(params![epic, s.as_str()], task_from_row)
+                .map_err(backend)?
+                .collect::<std::result::Result<Vec<_>, _>>()
+        } else {
+            stmt.query_map(params![epic], task_from_row)
+                .map_err(backend)?
+                .collect::<std::result::Result<Vec<_>, _>>()
+        };
+        rows.map_err(backend)
     }
 
-    fn find_by_fingerprint(&self, _epic: &str, _fingerprint: &str) -> Result<Option<Task>> {
-        Err(unimpl("find_by_fingerprint"))
+    fn find_by_fingerprint(&self, epic: &str, fingerprint: &str) -> Result<Option<Task>> {
+        let conn = self.conn.lock().expect("poisoned");
+        conn.query_row(
+            "SELECT id, epic_name, source, fingerprint, title, body, status, attempts,
+                    branch, pr_number, escalated_issue, created_at, updated_at
+               FROM tasks WHERE epic_name=? AND fingerprint=? LIMIT 1",
+            params![epic, fingerprint],
+            task_from_row,
+        )
+        .optional()
+        .map_err(backend)
     }
 
     fn upsert_watch_task(&self, _task: NewWatchTask, _now: DateTime<Utc>) -> Result<UpsertOutcome> {
@@ -155,39 +376,152 @@ impl TaskRepo for SqliteTaskStore {
         Err(unimpl("mark_task_failed"))
     }
 
-    fn escalate_task(&self, _id: &TaskId, _issue_number: u64, _now: DateTime<Utc>) -> Result<()> {
-        Err(unimpl("escalate_task"))
+    fn escalate_task(&self, id: &TaskId, issue_number: u64, now: DateTime<Utc>) -> Result<()> {
+        let conn = self.conn.lock().expect("poisoned");
+        let updated = conn
+            .execute(
+                "UPDATE tasks SET escalated_issue=?, updated_at=? WHERE id=?",
+                params![issue_number as i64, now, id.as_str()],
+            )
+            .map_err(backend)?;
+        if updated == 0 {
+            return Err(TaskStoreError::NotFound(format!("task '{id}'")));
+        }
+        let epic_name: String = conn
+            .query_row(
+                "SELECT epic_name FROM tasks WHERE id=?",
+                params![id.as_str()],
+                |row| row.get(0),
+            )
+            .map_err(backend)?;
+        SqliteTaskStore::append_event_with(
+            &conn,
+            EventKind::TaskEscalated,
+            Some(&epic_name),
+            Some(id),
+            &serde_json::json!({"issue": issue_number}),
+            now,
+        )
+        .map_err(backend)?;
+        Ok(())
     }
 
-    fn revert_to_ready(&self, _id: &TaskId, _now: DateTime<Utc>) -> Result<()> {
-        Err(unimpl("revert_to_ready"))
+    fn revert_to_ready(&self, id: &TaskId, now: DateTime<Utc>) -> Result<()> {
+        let conn = self.conn.lock().expect("poisoned");
+        let cur: Option<String> = conn
+            .query_row(
+                "SELECT status FROM tasks WHERE id=?",
+                params![id.as_str()],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(backend)?;
+        let cur = cur.ok_or_else(|| TaskStoreError::NotFound(format!("task '{id}'")))?;
+        let cur_status = TaskStatus::parse(&cur)
+            .ok_or_else(|| TaskStoreError::Backend(format!("invalid stored task status: {cur}")))?;
+        if matches!(cur_status, TaskStatus::Done | TaskStatus::Escalated) {
+            return Err(
+                DomainError::IllegalTransition(id.clone(), cur_status, TaskStatus::Ready).into(),
+            );
+        }
+        conn.execute(
+            "UPDATE tasks SET status='ready', updated_at=? WHERE id=?",
+            params![now, id.as_str()],
+        )
+        .map_err(backend)?;
+        Ok(())
     }
 
-    fn force_status(
-        &self,
-        _id: &TaskId,
-        _new_status: TaskStatus,
-        _now: DateTime<Utc>,
-    ) -> Result<()> {
-        Err(unimpl("force_status"))
+    fn force_status(&self, id: &TaskId, new_status: TaskStatus, now: DateTime<Utc>) -> Result<()> {
+        let conn = self.conn.lock().expect("poisoned");
+        let updated = conn
+            .execute(
+                "UPDATE tasks SET status=?, updated_at=? WHERE id=?",
+                params![new_status.as_str(), now, id.as_str()],
+            )
+            .map_err(backend)?;
+        if updated == 0 {
+            return Err(TaskStoreError::NotFound(format!("task '{id}'")));
+        }
+        Ok(())
     }
 
     fn apply_reconciliation(&self, _plan: ReconciliationPlan, _now: DateTime<Utc>) -> Result<()> {
         Err(unimpl("apply_reconciliation"))
     }
 
-    fn list_deps(&self, _task_id: &TaskId) -> Result<Vec<TaskId>> {
-        Err(unimpl("list_deps"))
+    fn list_deps(&self, task_id: &TaskId) -> Result<Vec<TaskId>> {
+        let conn = self.conn.lock().expect("poisoned");
+        let mut stmt = conn
+            .prepare("SELECT depends_on FROM task_deps WHERE task_id=?")
+            .map_err(backend)?;
+        let rows = stmt
+            .query_map(params![task_id.as_str()], |row| {
+                row.get::<_, String>(0).map(TaskId::from_raw)
+            })
+            .map_err(backend)?
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(backend)?;
+        Ok(rows)
     }
 }
 
 impl EventLog for SqliteTaskStore {
-    fn append_event(&self, _event: &Event) -> Result<()> {
-        Err(unimpl("append_event"))
+    fn append_event(&self, event: &Event) -> Result<()> {
+        let conn = self.conn.lock().expect("poisoned");
+        SqliteTaskStore::append_event_with(
+            &conn,
+            event.kind,
+            event.epic_name.as_deref(),
+            event.task_id.as_ref(),
+            &event.payload,
+            event.at,
+        )
+        .map_err(backend)?;
+        Ok(())
     }
 
-    fn list_events(&self, _filter: EventFilter) -> Result<Vec<Event>> {
-        Err(unimpl("list_events"))
+    fn list_events(&self, filter: EventFilter) -> Result<Vec<Event>> {
+        let conn = self.conn.lock().expect("poisoned");
+        let mut sql =
+            String::from("SELECT epic_name, task_id, kind, payload, at FROM events WHERE 1=1");
+        let mut binds: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+        if let Some(epic) = &filter.epic {
+            sql.push_str(" AND epic_name=?");
+            binds.push(Box::new(epic.clone()));
+        }
+        if let Some(task) = &filter.task {
+            sql.push_str(" AND task_id=?");
+            binds.push(Box::new(task.as_str().to_string()));
+        }
+        if !filter.kinds.is_empty() {
+            sql.push_str(" AND kind IN (");
+            for (i, k) in filter.kinds.iter().enumerate() {
+                if i > 0 {
+                    sql.push(',');
+                }
+                sql.push('?');
+                binds.push(Box::new(k.as_str().to_string()));
+            }
+            sql.push(')');
+        }
+        if let Some(since) = filter.since {
+            sql.push_str(" AND at >= ?");
+            binds.push(Box::new(since));
+        }
+        sql.push_str(" ORDER BY id ASC");
+        if let Some(limit) = filter.limit {
+            sql.push_str(&format!(" LIMIT {limit}"));
+        }
+
+        let mut stmt = conn.prepare(&sql).map_err(backend)?;
+        let bind_refs: Vec<&dyn rusqlite::ToSql> = binds.iter().map(|b| b.as_ref()).collect();
+        let rows = stmt
+            .query_map(bind_refs.as_slice(), event_from_row)
+            .map_err(backend)?
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(backend)?;
+        Ok(rows)
     }
 }
 
@@ -226,5 +560,22 @@ mod tests {
             }
             other => panic!("expected SchemaMismatch, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn upsert_and_get_epic_round_trip() {
+        let store = SqliteTaskStore::open_in_memory().unwrap();
+        let epic = Epic {
+            name: "e".to_string(),
+            spec_path: PathBuf::from("spec/x.md"),
+            branch: "epic/e".to_string(),
+            status: EpicStatus::Active,
+            created_at: chrono::Utc::now(),
+            completed_at: None,
+        };
+        store.upsert_epic(&epic).unwrap();
+        let got = store.get_epic("e").unwrap().unwrap();
+        assert_eq!(got.branch, "epic/e");
+        assert_eq!(got.status, EpicStatus::Active);
     }
 }

--- a/plugins/github-autopilot/cli/src/store/sqlite.rs
+++ b/plugins/github-autopilot/cli/src/store/sqlite.rs
@@ -1,0 +1,230 @@
+//! SQLite adapter for the TaskStore port.
+//!
+//! Implementation is built incrementally; methods that are not yet wired up
+//! return [`TaskStoreError::Backend`] so the lib still compiles while the
+//! conformance suite drives in remaining behaviour.
+
+use std::path::Path;
+use std::sync::Mutex;
+
+use chrono::{DateTime, Utc};
+use rusqlite::Connection;
+
+use crate::domain::{Epic, EpicStatus, Event, Task, TaskFailureOutcome, TaskId, TaskStatus};
+use crate::ports::task_store::{
+    EpicPlan, EpicRepo, EventFilter, EventLog, NewWatchTask, ReconciliationPlan, Result, TaskRepo,
+    TaskStoreError, UnblockReport, UpsertOutcome,
+};
+
+const SCHEMA_VERSION: u32 = 1;
+const V1_SQL: &str = include_str!("migrations/V1__initial.sql");
+
+pub struct SqliteTaskStore {
+    #[allow(dead_code)] // populated incrementally as methods land
+    conn: Mutex<Connection>,
+}
+
+impl SqliteTaskStore {
+    pub fn open(path: &Path) -> Result<Self> {
+        let conn = Connection::open(path).map_err(backend)?;
+        Self::init(conn)
+    }
+
+    pub fn open_in_memory() -> Result<Self> {
+        let conn = Connection::open_in_memory().map_err(backend)?;
+        Self::init(conn)
+    }
+
+    fn init(mut conn: Connection) -> Result<Self> {
+        conn.pragma_update(None, "journal_mode", "WAL")
+            .map_err(backend)?;
+        conn.pragma_update(None, "synchronous", "NORMAL")
+            .map_err(backend)?;
+        conn.pragma_update(None, "foreign_keys", "ON")
+            .map_err(backend)?;
+        conn.busy_timeout(std::time::Duration::from_millis(5_000))
+            .map_err(backend)?;
+        Self::migrate(&mut conn)?;
+        Ok(Self {
+            conn: Mutex::new(conn),
+        })
+    }
+
+    fn migrate(conn: &mut Connection) -> Result<()> {
+        let has_meta: bool = conn
+            .query_row(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='meta'",
+                [],
+                |_| Ok(true),
+            )
+            .unwrap_or(false);
+
+        if !has_meta {
+            conn.execute_batch(V1_SQL).map_err(backend)?;
+            return Ok(());
+        }
+
+        let found: u32 = conn
+            .query_row(
+                "SELECT value FROM meta WHERE key='schema_version'",
+                [],
+                |row| {
+                    row.get::<_, String>(0)
+                        .map(|s| s.parse::<u32>().unwrap_or(0))
+                },
+            )
+            .map_err(backend)?;
+
+        if found > SCHEMA_VERSION {
+            return Err(TaskStoreError::SchemaMismatch {
+                found,
+                expected: SCHEMA_VERSION,
+            });
+        }
+        Ok(())
+    }
+}
+
+fn backend(e: rusqlite::Error) -> TaskStoreError {
+    TaskStoreError::Backend(e.to_string())
+}
+
+fn unimpl(name: &str) -> TaskStoreError {
+    TaskStoreError::Backend(format!("sqlite::{name} not yet implemented"))
+}
+
+impl EpicRepo for SqliteTaskStore {
+    fn upsert_epic(&self, _epic: &Epic) -> Result<()> {
+        Err(unimpl("upsert_epic"))
+    }
+
+    fn get_epic(&self, name: &str) -> Result<Option<Epic>> {
+        let _ = name;
+        Err(unimpl("get_epic"))
+    }
+
+    fn list_epics(&self, _status: Option<EpicStatus>) -> Result<Vec<Epic>> {
+        Err(unimpl("list_epics"))
+    }
+
+    fn set_epic_status(&self, _name: &str, _status: EpicStatus, _at: DateTime<Utc>) -> Result<()> {
+        Err(unimpl("set_epic_status"))
+    }
+}
+
+impl TaskRepo for SqliteTaskStore {
+    fn insert_epic_with_tasks(&self, _plan: EpicPlan, _now: DateTime<Utc>) -> Result<()> {
+        Err(unimpl("insert_epic_with_tasks"))
+    }
+
+    fn get_task(&self, _id: &TaskId) -> Result<Option<Task>> {
+        Err(unimpl("get_task"))
+    }
+
+    fn list_tasks_by_epic(&self, _epic: &str, _status: Option<TaskStatus>) -> Result<Vec<Task>> {
+        Err(unimpl("list_tasks_by_epic"))
+    }
+
+    fn find_by_fingerprint(&self, _epic: &str, _fingerprint: &str) -> Result<Option<Task>> {
+        Err(unimpl("find_by_fingerprint"))
+    }
+
+    fn upsert_watch_task(&self, _task: NewWatchTask, _now: DateTime<Utc>) -> Result<UpsertOutcome> {
+        Err(unimpl("upsert_watch_task"))
+    }
+
+    fn claim_next_task(&self, _epic: &str, _now: DateTime<Utc>) -> Result<Option<Task>> {
+        Err(unimpl("claim_next_task"))
+    }
+
+    fn complete_task_and_unblock(
+        &self,
+        _id: &TaskId,
+        _pr_number: u64,
+        _now: DateTime<Utc>,
+    ) -> Result<UnblockReport> {
+        Err(unimpl("complete_task_and_unblock"))
+    }
+
+    fn mark_task_failed(
+        &self,
+        _id: &TaskId,
+        _max_attempts: u32,
+        _now: DateTime<Utc>,
+    ) -> Result<TaskFailureOutcome> {
+        Err(unimpl("mark_task_failed"))
+    }
+
+    fn escalate_task(&self, _id: &TaskId, _issue_number: u64, _now: DateTime<Utc>) -> Result<()> {
+        Err(unimpl("escalate_task"))
+    }
+
+    fn revert_to_ready(&self, _id: &TaskId, _now: DateTime<Utc>) -> Result<()> {
+        Err(unimpl("revert_to_ready"))
+    }
+
+    fn force_status(
+        &self,
+        _id: &TaskId,
+        _new_status: TaskStatus,
+        _now: DateTime<Utc>,
+    ) -> Result<()> {
+        Err(unimpl("force_status"))
+    }
+
+    fn apply_reconciliation(&self, _plan: ReconciliationPlan, _now: DateTime<Utc>) -> Result<()> {
+        Err(unimpl("apply_reconciliation"))
+    }
+
+    fn list_deps(&self, _task_id: &TaskId) -> Result<Vec<TaskId>> {
+        Err(unimpl("list_deps"))
+    }
+}
+
+impl EventLog for SqliteTaskStore {
+    fn append_event(&self, _event: &Event) -> Result<()> {
+        Err(unimpl("append_event"))
+    }
+
+    fn list_events(&self, _filter: EventFilter) -> Result<Vec<Event>> {
+        Err(unimpl("list_events"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn open_in_memory_initializes_schema_v1() {
+        let store = SqliteTaskStore::open_in_memory().expect("open");
+        let conn = store.conn.lock().unwrap();
+        let v: String = conn
+            .query_row(
+                "SELECT value FROM meta WHERE key='schema_version'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(v, "1");
+    }
+
+    #[test]
+    fn rejects_unknown_higher_version() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(V1_SQL).unwrap();
+        conn.execute("UPDATE meta SET value='999' WHERE key='schema_version'", [])
+            .unwrap();
+        let err = match SqliteTaskStore::init(conn) {
+            Err(e) => e,
+            Ok(_) => panic!("expected SchemaMismatch error"),
+        };
+        match err {
+            TaskStoreError::SchemaMismatch { found, expected } => {
+                assert_eq!(found, 999);
+                assert_eq!(expected, 1);
+            }
+            other => panic!("expected SchemaMismatch, got {other:?}"),
+        }
+    }
+}

--- a/plugins/github-autopilot/cli/src/store/sqlite.rs
+++ b/plugins/github-autopilot/cli/src/store/sqlite.rs
@@ -11,8 +11,8 @@ use chrono::{DateTime, Utc};
 use rusqlite::{params, Connection, OptionalExtension, Row};
 
 use crate::domain::{
-    DomainError, Epic, EpicStatus, Event, EventKind, Task, TaskFailureOutcome, TaskId, TaskSource,
-    TaskStatus,
+    DomainError, Epic, EpicStatus, Event, EventKind, Task, TaskFailureOutcome, TaskGraph, TaskId,
+    TaskSource, TaskStatus,
 };
 use crate::ports::task_store::{
     EpicPlan, EpicRepo, EventFilter, EventLog, NewWatchTask, ReconciliationPlan, Result, TaskRepo,
@@ -89,10 +89,6 @@ impl SqliteTaskStore {
 
 fn backend(e: rusqlite::Error) -> TaskStoreError {
     TaskStoreError::Backend(e.to_string())
-}
-
-fn unimpl(name: &str) -> TaskStoreError {
-    TaskStoreError::Backend(format!("sqlite::{name} not yet implemented"))
 }
 
 fn epic_from_row(row: &Row<'_>) -> rusqlite::Result<Epic> {
@@ -292,8 +288,113 @@ impl EpicRepo for SqliteTaskStore {
 }
 
 impl TaskRepo for SqliteTaskStore {
-    fn insert_epic_with_tasks(&self, _plan: EpicPlan, _now: DateTime<Utc>) -> Result<()> {
-        Err(unimpl("insert_epic_with_tasks"))
+    fn insert_epic_with_tasks(&self, plan: EpicPlan, now: DateTime<Utc>) -> Result<()> {
+        let mut seen = std::collections::BTreeSet::new();
+        for t in &plan.tasks {
+            if !seen.insert(t.id.clone()) {
+                return Err(DomainError::DuplicateTaskId(t.id.clone()).into());
+            }
+        }
+        for (a, b) in &plan.deps {
+            if !seen.contains(a) {
+                return Err(DomainError::UnknownDepTarget(a.clone()).into());
+            }
+            if !seen.contains(b) {
+                return Err(DomainError::UnknownDepTarget(b.clone()).into());
+            }
+        }
+        let graph = TaskGraph::build(plan.deps.iter().cloned());
+        if let Some(cycle) = graph.detect_cycle() {
+            return Err(DomainError::DepCycle(cycle).into());
+        }
+
+        let mut conn = self.conn.lock().expect("poisoned");
+        let tx = conn.transaction().map_err(backend)?;
+
+        let exists: Option<String> = tx
+            .query_row(
+                "SELECT status FROM epics WHERE name=?",
+                params![plan.epic.name],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(backend)?;
+        if let Some(status_str) = exists {
+            let status = EpicStatus::parse(&status_str).unwrap_or(EpicStatus::Active);
+            return Err(DomainError::EpicAlreadyExists(plan.epic.name.clone(), status).into());
+        }
+
+        tx.execute(
+            "INSERT INTO epics(name, spec_path, branch, status, created_at, completed_at)
+             VALUES (?, ?, ?, 'active', ?, NULL)",
+            params![
+                plan.epic.name,
+                plan.epic.spec_path.to_string_lossy(),
+                plan.epic.branch,
+                plan.epic.created_at,
+            ],
+        )
+        .map_err(backend)?;
+
+        for nt in &plan.tasks {
+            tx.execute(
+                "INSERT INTO tasks(id, epic_name, source, fingerprint, title, body,
+                                   status, attempts, branch, pr_number, escalated_issue,
+                                   created_at, updated_at)
+                 VALUES (?, ?, ?, ?, ?, ?, 'pending', 0, NULL, NULL, NULL, ?, ?)",
+                params![
+                    nt.id.as_str(),
+                    plan.epic.name,
+                    nt.source.as_str(),
+                    nt.fingerprint,
+                    nt.title,
+                    nt.body,
+                    now,
+                    now,
+                ],
+            )
+            .map_err(backend)?;
+        }
+
+        for (a, b) in &plan.deps {
+            tx.execute(
+                "INSERT INTO task_deps(task_id, depends_on) VALUES (?, ?)",
+                params![a.as_str(), b.as_str()],
+            )
+            .map_err(backend)?;
+        }
+
+        tx.execute(
+            "UPDATE tasks SET status='ready', updated_at=?
+              WHERE epic_name=? AND status='pending'
+                AND id NOT IN (SELECT task_id FROM task_deps)",
+            params![now, plan.epic.name],
+        )
+        .map_err(backend)?;
+
+        SqliteTaskStore::append_event_with(
+            &tx,
+            EventKind::EpicStarted,
+            Some(&plan.epic.name),
+            None,
+            &serde_json::json!({}),
+            now,
+        )
+        .map_err(backend)?;
+        for nt in &plan.tasks {
+            SqliteTaskStore::append_event_with(
+                &tx,
+                EventKind::TaskInserted,
+                Some(&plan.epic.name),
+                Some(&nt.id),
+                &serde_json::json!({"source": nt.source.as_str()}),
+                now,
+            )
+            .map_err(backend)?;
+        }
+
+        tx.commit().map_err(backend)?;
+        Ok(())
     }
 
     fn get_task(&self, id: &TaskId) -> Result<Option<Task>> {
@@ -350,30 +451,342 @@ impl TaskRepo for SqliteTaskStore {
         .map_err(backend)
     }
 
-    fn upsert_watch_task(&self, _task: NewWatchTask, _now: DateTime<Utc>) -> Result<UpsertOutcome> {
-        Err(unimpl("upsert_watch_task"))
+    fn upsert_watch_task(&self, task: NewWatchTask, now: DateTime<Utc>) -> Result<UpsertOutcome> {
+        let mut conn = self.conn.lock().expect("poisoned");
+        let tx = conn.transaction().map_err(backend)?;
+
+        let existing: Option<String> = tx
+            .query_row(
+                "SELECT id FROM tasks WHERE epic_name=? AND fingerprint=? LIMIT 1",
+                params![task.epic_name, task.fingerprint],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(backend)?;
+
+        if let Some(existing_id) = existing {
+            SqliteTaskStore::append_event_with(
+                &tx,
+                EventKind::WatchDuplicate,
+                Some(&task.epic_name),
+                Some(&TaskId::from_raw(existing_id.clone())),
+                &serde_json::json!({"fingerprint": task.fingerprint}),
+                now,
+            )
+            .map_err(backend)?;
+            tx.commit().map_err(backend)?;
+            return Ok(UpsertOutcome::DuplicateFingerprint(TaskId::from_raw(
+                existing_id,
+            )));
+        }
+
+        tx.execute(
+            "INSERT INTO tasks(id, epic_name, source, fingerprint, title, body,
+                               status, attempts, branch, pr_number, escalated_issue,
+                               created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, 'ready', 0, NULL, NULL, NULL, ?, ?)",
+            params![
+                task.id.as_str(),
+                task.epic_name,
+                task.source.as_str(),
+                task.fingerprint,
+                task.title,
+                task.body,
+                now,
+                now,
+            ],
+        )
+        .map_err(backend)?;
+
+        SqliteTaskStore::append_event_with(
+            &tx,
+            EventKind::TaskInserted,
+            Some(&task.epic_name),
+            Some(&task.id),
+            &serde_json::json!({"source": task.source.as_str(), "fingerprint": task.fingerprint}),
+            now,
+        )
+        .map_err(backend)?;
+
+        tx.commit().map_err(backend)?;
+        Ok(UpsertOutcome::Inserted(task.id))
     }
 
-    fn claim_next_task(&self, _epic: &str, _now: DateTime<Utc>) -> Result<Option<Task>> {
-        Err(unimpl("claim_next_task"))
+    fn claim_next_task(&self, epic: &str, now: DateTime<Utc>) -> Result<Option<Task>> {
+        let mut conn = self.conn.lock().expect("poisoned");
+        let tx = conn.transaction().map_err(backend)?;
+
+        let candidate_id: Option<String> = tx
+            .query_row(
+                "SELECT t.id FROM tasks t
+                  WHERE t.epic_name = ? AND t.status = 'ready'
+                    AND NOT EXISTS (
+                      SELECT 1 FROM task_deps d
+                      JOIN tasks dep ON dep.id = d.depends_on
+                      WHERE d.task_id = t.id AND dep.status != 'done'
+                    )
+                  ORDER BY t.created_at, t.id
+                  LIMIT 1",
+                params![epic],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(backend)?;
+
+        let id = match candidate_id {
+            Some(id) => id,
+            None => return Ok(None),
+        };
+
+        let updated = tx
+            .execute(
+                "UPDATE tasks SET status='wip', attempts = attempts + 1, updated_at=?
+                  WHERE id=? AND status='ready'",
+                params![now, id],
+            )
+            .map_err(backend)?;
+        if updated != 1 {
+            return Ok(None);
+        }
+
+        let task = tx
+            .query_row(
+                "SELECT id, epic_name, source, fingerprint, title, body, status, attempts,
+                        branch, pr_number, escalated_issue, created_at, updated_at
+                   FROM tasks WHERE id=?",
+                params![id],
+                task_from_row,
+            )
+            .map_err(backend)?;
+
+        SqliteTaskStore::append_event_with(
+            &tx,
+            EventKind::TaskClaimed,
+            Some(epic),
+            Some(&task.id),
+            &serde_json::json!({"attempts": task.attempts}),
+            now,
+        )
+        .map_err(backend)?;
+
+        tx.commit().map_err(backend)?;
+        Ok(Some(task))
     }
 
     fn complete_task_and_unblock(
         &self,
-        _id: &TaskId,
-        _pr_number: u64,
-        _now: DateTime<Utc>,
+        id: &TaskId,
+        pr_number: u64,
+        now: DateTime<Utc>,
     ) -> Result<UnblockReport> {
-        Err(unimpl("complete_task_and_unblock"))
+        let mut conn = self.conn.lock().expect("poisoned");
+        let tx = conn.transaction().map_err(backend)?;
+
+        let cur_status: Option<String> = tx
+            .query_row(
+                "SELECT status FROM tasks WHERE id=?",
+                params![id.as_str()],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(backend)?;
+        let cur = cur_status.ok_or_else(|| TaskStoreError::NotFound(format!("task '{id}'")))?;
+        if cur != "wip" {
+            let cur_status = TaskStatus::parse(&cur).unwrap_or(TaskStatus::Pending);
+            return Err(
+                DomainError::IllegalTransition(id.clone(), cur_status, TaskStatus::Done).into(),
+            );
+        }
+
+        let updated = tx
+            .execute(
+                "UPDATE tasks SET status='done', pr_number=?, updated_at=?
+                  WHERE id=? AND status='wip'",
+                params![pr_number as i64, now, id.as_str()],
+            )
+            .map_err(backend)?;
+        if updated != 1 {
+            return Err(DomainError::IllegalTransition(
+                id.clone(),
+                TaskStatus::Wip,
+                TaskStatus::Done,
+            )
+            .into());
+        }
+
+        let epic_name: String = tx
+            .query_row(
+                "SELECT epic_name FROM tasks WHERE id=?",
+                params![id.as_str()],
+                |row| row.get(0),
+            )
+            .map_err(backend)?;
+
+        SqliteTaskStore::append_event_with(
+            &tx,
+            EventKind::TaskCompleted,
+            Some(&epic_name),
+            Some(id),
+            &serde_json::json!({"pr_number": pr_number}),
+            now,
+        )
+        .map_err(backend)?;
+
+        let newly_ready_ids: Vec<String> = {
+            let mut stmt = tx
+                .prepare(
+                    "SELECT d.task_id FROM task_deps d
+                     JOIN tasks t ON t.id = d.task_id
+                      WHERE d.depends_on = ?
+                        AND t.status IN ('pending','blocked')
+                        AND NOT EXISTS (
+                          SELECT 1 FROM task_deps d2
+                          JOIN tasks dep ON dep.id = d2.depends_on
+                          WHERE d2.task_id = d.task_id AND dep.status != 'done'
+                        )",
+                )
+                .map_err(backend)?;
+            let iter = stmt
+                .query_map(params![id.as_str()], |row| row.get::<_, String>(0))
+                .map_err(backend)?;
+            let mut out: Vec<String> = Vec::new();
+            for row in iter {
+                out.push(row.map_err(backend)?);
+            }
+            out
+        };
+
+        for nid in &newly_ready_ids {
+            tx.execute(
+                "UPDATE tasks SET status='ready', updated_at=?
+                  WHERE id=? AND status IN ('pending','blocked')",
+                params![now, nid],
+            )
+            .map_err(backend)?;
+            SqliteTaskStore::append_event_with(
+                &tx,
+                EventKind::TaskUnblocked,
+                Some(&epic_name),
+                Some(&TaskId::from_raw(nid.clone())),
+                &serde_json::json!({}),
+                now,
+            )
+            .map_err(backend)?;
+        }
+
+        tx.commit().map_err(backend)?;
+        Ok(UnblockReport {
+            completed: id.clone(),
+            newly_ready: newly_ready_ids.into_iter().map(TaskId::from_raw).collect(),
+        })
     }
 
     fn mark_task_failed(
         &self,
-        _id: &TaskId,
-        _max_attempts: u32,
-        _now: DateTime<Utc>,
+        id: &TaskId,
+        max_attempts: u32,
+        now: DateTime<Utc>,
     ) -> Result<TaskFailureOutcome> {
-        Err(unimpl("mark_task_failed"))
+        let mut conn = self.conn.lock().expect("poisoned");
+        let tx = conn.transaction().map_err(backend)?;
+
+        let row: Option<(String, i64, String)> = tx
+            .query_row(
+                "SELECT status, attempts, epic_name FROM tasks WHERE id=?",
+                params![id.as_str()],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .optional()
+            .map_err(backend)?;
+        let (cur, attempts, epic_name) =
+            row.ok_or_else(|| TaskStoreError::NotFound(format!("task '{id}'")))?;
+        if cur != "wip" {
+            let cur_status = TaskStatus::parse(&cur).unwrap_or(TaskStatus::Pending);
+            return Err(
+                DomainError::IllegalTransition(id.clone(), cur_status, TaskStatus::Ready).into(),
+            );
+        }
+        let attempts = attempts as u32;
+
+        if attempts >= max_attempts {
+            tx.execute(
+                "UPDATE tasks SET status='escalated', updated_at=? WHERE id=?",
+                params![now, id.as_str()],
+            )
+            .map_err(backend)?;
+            SqliteTaskStore::append_event_with(
+                &tx,
+                EventKind::TaskFailed,
+                Some(&epic_name),
+                Some(id),
+                &serde_json::json!({"final": true, "attempts": attempts}),
+                now,
+            )
+            .map_err(backend)?;
+            SqliteTaskStore::append_event_with(
+                &tx,
+                EventKind::TaskEscalated,
+                Some(&epic_name),
+                Some(id),
+                &serde_json::json!({"attempts": attempts}),
+                now,
+            )
+            .map_err(backend)?;
+
+            let dependents: Vec<String> = {
+                let mut stmt = tx
+                    .prepare("SELECT task_id FROM task_deps WHERE depends_on=?")
+                    .map_err(backend)?;
+                let iter = stmt
+                    .query_map(params![id.as_str()], |row| row.get::<_, String>(0))
+                    .map_err(backend)?;
+                let mut out: Vec<String> = Vec::new();
+                for row in iter {
+                    out.push(row.map_err(backend)?);
+                }
+                out
+            };
+            for dep_id in dependents {
+                let updated = tx
+                    .execute(
+                        "UPDATE tasks SET status='blocked', updated_at=?
+                          WHERE id=? AND status IN ('pending','ready')",
+                        params![now, dep_id],
+                    )
+                    .map_err(backend)?;
+                if updated > 0 {
+                    SqliteTaskStore::append_event_with(
+                        &tx,
+                        EventKind::TaskBlocked,
+                        Some(&epic_name),
+                        Some(&TaskId::from_raw(dep_id.clone())),
+                        &serde_json::json!({"reason":"parent_escalated","parent": id.as_str()}),
+                        now,
+                    )
+                    .map_err(backend)?;
+                }
+            }
+
+            tx.commit().map_err(backend)?;
+            Ok(TaskFailureOutcome::Escalated { attempts })
+        } else {
+            tx.execute(
+                "UPDATE tasks SET status='ready', updated_at=? WHERE id=?",
+                params![now, id.as_str()],
+            )
+            .map_err(backend)?;
+            SqliteTaskStore::append_event_with(
+                &tx,
+                EventKind::TaskFailed,
+                Some(&epic_name),
+                Some(id),
+                &serde_json::json!({"final": false, "attempts": attempts}),
+                now,
+            )
+            .map_err(backend)?;
+            tx.commit().map_err(backend)?;
+            Ok(TaskFailureOutcome::Retried { attempts })
+        }
     }
 
     fn escalate_task(&self, id: &TaskId, issue_number: u64, now: DateTime<Utc>) -> Result<()> {
@@ -446,8 +859,213 @@ impl TaskRepo for SqliteTaskStore {
         Ok(())
     }
 
-    fn apply_reconciliation(&self, _plan: ReconciliationPlan, _now: DateTime<Utc>) -> Result<()> {
-        Err(unimpl("apply_reconciliation"))
+    fn apply_reconciliation(&self, plan: ReconciliationPlan, now: DateTime<Utc>) -> Result<()> {
+        let graph = TaskGraph::build(plan.deps.iter().cloned());
+        if let Some(cycle) = graph.detect_cycle() {
+            return Err(DomainError::DepCycle(cycle).into());
+        }
+
+        let mut conn = self.conn.lock().expect("poisoned");
+        let tx = conn.transaction().map_err(backend)?;
+
+        // Upsert epic as active, preserving created_at if existing.
+        let existing_created: Option<DateTime<Utc>> = tx
+            .query_row(
+                "SELECT created_at FROM epics WHERE name=?",
+                params![plan.epic.name],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(backend)?;
+        let created_at = existing_created.unwrap_or(plan.epic.created_at);
+        tx.execute(
+            "INSERT INTO epics(name, spec_path, branch, status, created_at, completed_at)
+             VALUES (?, ?, ?, 'active', ?, NULL)
+             ON CONFLICT(name) DO UPDATE SET
+               spec_path=excluded.spec_path,
+               branch=excluded.branch,
+               status='active',
+               completed_at=NULL",
+            params![
+                plan.epic.name,
+                plan.epic.spec_path.to_string_lossy(),
+                plan.epic.branch,
+                created_at,
+            ],
+        )
+        .map_err(backend)?;
+
+        // Upsert tasks: insert if missing, else update title/body (preserve attempts/status).
+        for nt in &plan.tasks {
+            let exists: bool = tx
+                .query_row(
+                    "SELECT 1 FROM tasks WHERE id=?",
+                    params![nt.id.as_str()],
+                    |_| Ok(true),
+                )
+                .optional()
+                .map_err(backend)?
+                .unwrap_or(false);
+            if exists {
+                tx.execute(
+                    "UPDATE tasks SET title=?, body=?, source=?, updated_at=?,
+                                       fingerprint = COALESCE(fingerprint, ?)
+                      WHERE id=?",
+                    params![
+                        nt.title,
+                        nt.body,
+                        nt.source.as_str(),
+                        now,
+                        nt.fingerprint,
+                        nt.id.as_str()
+                    ],
+                )
+                .map_err(backend)?;
+            } else {
+                tx.execute(
+                    "INSERT INTO tasks(id, epic_name, source, fingerprint, title, body,
+                                       status, attempts, branch, pr_number, escalated_issue,
+                                       created_at, updated_at)
+                     VALUES (?, ?, ?, ?, ?, ?, 'pending', 0, NULL, NULL, NULL, ?, ?)",
+                    params![
+                        nt.id.as_str(),
+                        plan.epic.name,
+                        nt.source.as_str(),
+                        nt.fingerprint,
+                        nt.title,
+                        nt.body,
+                        now,
+                        now,
+                    ],
+                )
+                .map_err(backend)?;
+            }
+        }
+
+        // Replace deps for plan tasks.
+        let plan_ids: Vec<String> = plan
+            .tasks
+            .iter()
+            .map(|t| t.id.as_str().to_string())
+            .collect();
+        if !plan_ids.is_empty() {
+            let placeholders = std::iter::repeat_n("?", plan_ids.len())
+                .collect::<Vec<_>>()
+                .join(",");
+            let sql = format!("DELETE FROM task_deps WHERE task_id IN ({placeholders})");
+            let bind: Vec<&dyn rusqlite::ToSql> =
+                plan_ids.iter().map(|s| s as &dyn rusqlite::ToSql).collect();
+            tx.execute(&sql, bind.as_slice()).map_err(backend)?;
+        }
+        for (a, b) in &plan.deps {
+            tx.execute(
+                "INSERT OR IGNORE INTO task_deps(task_id, depends_on) VALUES (?, ?)",
+                params![a.as_str(), b.as_str()],
+            )
+            .map_err(backend)?;
+        }
+
+        // Apply remote_state to set status and pr_number.
+        let in_remote: std::collections::BTreeSet<String> = plan
+            .remote_state
+            .iter()
+            .map(|r| r.task_id.as_str().to_string())
+            .collect();
+        for r in &plan.remote_state {
+            let desired = match (&r.pr, r.branch_exists) {
+                (Some(pr), _) if pr.merged => "done",
+                (Some(_), _) => "wip",
+                (None, true) => "wip",
+                (None, false) => {
+                    let deps_satisfied: i64 = tx
+                        .query_row(
+                            "SELECT CASE WHEN NOT EXISTS (
+                              SELECT 1 FROM task_deps d
+                              JOIN tasks dep ON dep.id = d.depends_on
+                              WHERE d.task_id = ? AND dep.status != 'done'
+                            ) THEN 1 ELSE 0 END",
+                            params![r.task_id.as_str()],
+                            |row| row.get(0),
+                        )
+                        .map_err(backend)?;
+                    if deps_satisfied == 1 {
+                        "ready"
+                    } else {
+                        "pending"
+                    }
+                }
+            };
+            let pr_num = r.pr.as_ref().map(|p| p.number as i64);
+            tx.execute(
+                "UPDATE tasks SET status=?, pr_number=COALESCE(?, pr_number), updated_at=?
+                  WHERE id=?",
+                params![desired, pr_num, now, r.task_id.as_str()],
+            )
+            .map_err(backend)?;
+        }
+
+        // For tasks in plan but not in remote_state: re-classify Pending only.
+        for nt in &plan.tasks {
+            if in_remote.contains(nt.id.as_str()) {
+                continue;
+            }
+            let cur: Option<String> = tx
+                .query_row(
+                    "SELECT status FROM tasks WHERE id=?",
+                    params![nt.id.as_str()],
+                    |row| row.get(0),
+                )
+                .optional()
+                .map_err(backend)?;
+            if cur.as_deref() != Some("pending") {
+                continue;
+            }
+            let deps_satisfied: i64 = tx
+                .query_row(
+                    "SELECT CASE WHEN NOT EXISTS (
+                      SELECT 1 FROM task_deps d
+                      JOIN tasks dep ON dep.id = d.depends_on
+                      WHERE d.task_id = ? AND dep.status != 'done'
+                    ) THEN 1 ELSE 0 END",
+                    params![nt.id.as_str()],
+                    |row| row.get(0),
+                )
+                .map_err(backend)?;
+            let desired = if deps_satisfied == 1 {
+                "ready"
+            } else {
+                "pending"
+            };
+            tx.execute(
+                "UPDATE tasks SET status=?, updated_at=? WHERE id=? AND status='pending'",
+                params![desired, now, nt.id.as_str()],
+            )
+            .map_err(backend)?;
+        }
+
+        for branch in &plan.orphan_branches {
+            SqliteTaskStore::append_event_with(
+                &tx,
+                EventKind::Reconciled,
+                Some(&plan.epic.name),
+                None,
+                &serde_json::json!({"orphan_branch": branch}),
+                now,
+            )
+            .map_err(backend)?;
+        }
+        SqliteTaskStore::append_event_with(
+            &tx,
+            EventKind::Reconciled,
+            Some(&plan.epic.name),
+            None,
+            &serde_json::json!({"tasks": plan.tasks.len()}),
+            now,
+        )
+        .map_err(backend)?;
+
+        tx.commit().map_err(backend)?;
+        Ok(())
     }
 
     fn list_deps(&self, task_id: &TaskId) -> Result<Vec<TaskId>> {

--- a/plugins/github-autopilot/cli/tests/store_conformance.rs
+++ b/plugins/github-autopilot/cli/tests/store_conformance.rs
@@ -85,7 +85,10 @@ fn insert_creates_epic_tasks_deps_and_promotes_entry_points() {
     let kinds: Vec<EventKind> = events.iter().map(|e| e.kind).collect();
     assert!(kinds.contains(&EventKind::EpicStarted));
     assert_eq!(
-        kinds.iter().filter(|k| **k == EventKind::TaskInserted).count(),
+        kinds
+            .iter()
+            .filter(|k| **k == EventKind::TaskInserted)
+            .count(),
         3
     );
 }
@@ -149,7 +152,10 @@ fn claim_returns_oldest_ready_task() {
         )
         .unwrap();
 
-    let claimed = store.claim_next_task("e", t0() + Duration::seconds(20)).unwrap().unwrap();
+    let claimed = store
+        .claim_next_task("e", t0() + Duration::seconds(20))
+        .unwrap()
+        .unwrap();
     assert_eq!(claimed.id.as_str(), "A");
     assert_eq!(claimed.status, TaskStatus::Wip);
     assert_eq!(claimed.attempts, 1);
@@ -160,11 +166,7 @@ fn claim_skips_tasks_with_unsatisfied_deps() {
     let store = make_store();
     store
         .insert_epic_with_tasks(
-            plan(
-                "e",
-                vec![nt("A", "a"), nt("B", "b")],
-                vec![("B", "A")],
-            ),
+            plan("e", vec![nt("A", "a"), nt("B", "b")], vec![("B", "A")]),
             t0(),
         )
         .unwrap();
@@ -271,7 +273,11 @@ fn failure_below_max_returns_to_ready() {
         .unwrap();
     assert_eq!(outcome, TaskFailureOutcome::Retried { attempts: 1 });
     assert_eq!(
-        store.get_task(&TaskId::from_raw("A")).unwrap().unwrap().status,
+        store
+            .get_task(&TaskId::from_raw("A"))
+            .unwrap()
+            .unwrap()
+            .status,
         TaskStatus::Ready
     );
 }
@@ -281,18 +287,16 @@ fn failure_at_max_escalates_and_blocks_dependents() {
     let store = make_store();
     store
         .insert_epic_with_tasks(
-            plan(
-                "e",
-                vec![nt("A", "a"), nt("B", "b")],
-                vec![("B", "A")],
-            ),
+            plan("e", vec![nt("A", "a"), nt("B", "b")], vec![("B", "A")]),
             t0(),
         )
         .unwrap();
     // Drive A to attempts=3
     for _ in 0..3 {
         let _ = store.claim_next_task("e", t0()).unwrap().unwrap();
-        let _ = store.mark_task_failed(&TaskId::from_raw("A"), 3, t0()).unwrap();
+        let _ = store
+            .mark_task_failed(&TaskId::from_raw("A"), 3, t0())
+            .unwrap();
     }
     let by_id = |id: &str| store.get_task(&TaskId::from_raw(id)).unwrap().unwrap();
     assert_eq!(by_id("A").status, TaskStatus::Escalated);
@@ -371,7 +375,9 @@ fn reconcile_preserves_attempts_counter() {
         .insert_epic_with_tasks(plan("e", vec![nt("A", "a")], vec![]), t0())
         .unwrap();
     let _ = store.claim_next_task("e", t0()).unwrap().unwrap();
-    let _ = store.mark_task_failed(&TaskId::from_raw("A"), 3, t0()).unwrap();
+    let _ = store
+        .mark_task_failed(&TaskId::from_raw("A"), 3, t0())
+        .unwrap();
     let _ = store.claim_next_task("e", t0()).unwrap().unwrap();
     let plan = ReconciliationPlan {
         epic: epic("e"),

--- a/plugins/github-autopilot/cli/tests/store_conformance.rs
+++ b/plugins/github-autopilot/cli/tests/store_conformance.rs
@@ -1,0 +1,465 @@
+//! L2 TaskStore conformance suite.
+//!
+//! Mirrors the scenarios in plans/github-autopilot/04-test-scenarios.md §4.
+//! When a SqliteTaskStore is added, the same suite is executed against both
+//! adapters via a macro to enforce LSP.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use autopilot::domain::{
+    Epic, EpicStatus, EventKind, TaskFailureOutcome, TaskGraph, TaskId, TaskSource, TaskStatus,
+};
+use autopilot::ports::task_store::{
+    EpicPlan, EventFilter, NewTask, NewWatchTask, ReconciliationPlan, RemotePrState,
+    RemoteTaskState, TaskStore, UpsertOutcome,
+};
+use autopilot::store::InMemoryTaskStore;
+use chrono::{DateTime, Duration, TimeZone, Utc};
+
+fn t0() -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 4, 28, 9, 0, 0).unwrap()
+}
+
+fn epic(name: &str) -> Epic {
+    Epic {
+        name: name.to_string(),
+        spec_path: PathBuf::from(format!("spec/{name}.md")),
+        branch: format!("epic/{name}"),
+        status: EpicStatus::Active,
+        created_at: t0(),
+        completed_at: None,
+    }
+}
+
+fn nt(id: &str, title: &str) -> NewTask {
+    NewTask {
+        id: TaskId::from_raw(id),
+        source: TaskSource::Decompose,
+        fingerprint: None,
+        title: title.to_string(),
+        body: None,
+    }
+}
+
+fn plan(name: &str, tasks: Vec<NewTask>, deps: Vec<(&str, &str)>) -> EpicPlan {
+    EpicPlan {
+        epic: epic(name),
+        tasks,
+        deps: deps
+            .into_iter()
+            .map(|(a, b)| (TaskId::from_raw(a), TaskId::from_raw(b)))
+            .collect(),
+    }
+}
+
+fn make_store() -> Arc<dyn TaskStore> {
+    Arc::new(InMemoryTaskStore::new())
+}
+
+// 4.1 insert_epic_with_tasks ----------------------------------------------
+
+#[test]
+fn insert_creates_epic_tasks_deps_and_promotes_entry_points() {
+    let store = make_store();
+    store
+        .insert_epic_with_tasks(
+            plan(
+                "e",
+                vec![nt("A", "task A"), nt("B", "task B"), nt("C", "task C")],
+                vec![("B", "A"), ("C", "A")],
+            ),
+            t0(),
+        )
+        .unwrap();
+
+    assert!(store.get_epic("e").unwrap().is_some());
+
+    let by_id = |id: &str| store.get_task(&TaskId::from_raw(id)).unwrap().unwrap();
+    assert_eq!(by_id("A").status, TaskStatus::Ready);
+    assert_eq!(by_id("B").status, TaskStatus::Pending);
+    assert_eq!(by_id("C").status, TaskStatus::Pending);
+    assert_eq!(store.list_deps(&TaskId::from_raw("B")).unwrap().len(), 1);
+
+    let events = store.list_events(EventFilter::default()).unwrap();
+    let kinds: Vec<EventKind> = events.iter().map(|e| e.kind).collect();
+    assert!(kinds.contains(&EventKind::EpicStarted));
+    assert_eq!(
+        kinds.iter().filter(|k| **k == EventKind::TaskInserted).count(),
+        3
+    );
+}
+
+#[test]
+fn insert_rejects_dep_cycle() {
+    let store = make_store();
+    let err = store
+        .insert_epic_with_tasks(
+            plan(
+                "e",
+                vec![nt("A", "a"), nt("B", "b")],
+                vec![("A", "B"), ("B", "A")],
+            ),
+            t0(),
+        )
+        .unwrap_err();
+    let msg = format!("{err}");
+    assert!(msg.contains("cycle"), "expected cycle error, got: {msg}");
+    assert!(store.get_epic("e").unwrap().is_none());
+}
+
+#[test]
+fn insert_is_atomic_on_existing_active_epic() {
+    let store = make_store();
+    store
+        .insert_epic_with_tasks(plan("e", vec![nt("A", "a")], vec![]), t0())
+        .unwrap();
+    let before_tasks = store.list_tasks_by_epic("e", None).unwrap().len();
+
+    let err = store
+        .insert_epic_with_tasks(plan("e", vec![nt("X", "x"), nt("Y", "y")], vec![]), t0())
+        .unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("already exists"),
+        "expected already-exists error, got: {msg}"
+    );
+    let after_tasks = store.list_tasks_by_epic("e", None).unwrap().len();
+    assert_eq!(before_tasks, after_tasks);
+}
+
+// 4.2 claim_next_task ------------------------------------------------------
+
+#[test]
+fn claim_returns_none_when_no_ready_task() {
+    let store = make_store();
+    assert!(store.claim_next_task("e", t0()).unwrap().is_none());
+}
+
+#[test]
+fn claim_returns_oldest_ready_task() {
+    let store = make_store();
+    store
+        .insert_epic_with_tasks(plan("e", vec![nt("A", "a")], vec![]), t0())
+        .unwrap();
+    store
+        .insert_epic_with_tasks(
+            plan("f", vec![nt("Z", "z")], vec![]),
+            t0() + Duration::seconds(10),
+        )
+        .unwrap();
+
+    let claimed = store.claim_next_task("e", t0() + Duration::seconds(20)).unwrap().unwrap();
+    assert_eq!(claimed.id.as_str(), "A");
+    assert_eq!(claimed.status, TaskStatus::Wip);
+    assert_eq!(claimed.attempts, 1);
+}
+
+#[test]
+fn claim_skips_tasks_with_unsatisfied_deps() {
+    let store = make_store();
+    store
+        .insert_epic_with_tasks(
+            plan(
+                "e",
+                vec![nt("A", "a"), nt("B", "b")],
+                vec![("B", "A")],
+            ),
+            t0(),
+        )
+        .unwrap();
+    let claimed = store.claim_next_task("e", t0()).unwrap().unwrap();
+    assert_eq!(claimed.id.as_str(), "A");
+    // Only A should be claimable; B is gated.
+    let claimed_again = store.claim_next_task("e", t0()).unwrap();
+    assert!(claimed_again.is_none());
+}
+
+#[test]
+fn claim_increments_attempts_on_each_call_after_revert() {
+    let store = make_store();
+    store
+        .insert_epic_with_tasks(plan("e", vec![nt("A", "a")], vec![]), t0())
+        .unwrap();
+    let _ = store.claim_next_task("e", t0()).unwrap().unwrap();
+    store.revert_to_ready(&TaskId::from_raw("A"), t0()).unwrap();
+    let claimed = store.claim_next_task("e", t0()).unwrap().unwrap();
+    assert_eq!(claimed.attempts, 2);
+}
+
+#[test]
+fn claim_is_atomic_under_concurrent_callers() {
+    use std::sync::Barrier;
+    use std::thread;
+
+    let store: Arc<dyn TaskStore> = make_store();
+    store
+        .insert_epic_with_tasks(plan("e", vec![nt("A", "a")], vec![]), t0())
+        .unwrap();
+
+    let barrier = Arc::new(Barrier::new(8));
+    let mut handles = Vec::new();
+    for _ in 0..8 {
+        let s = Arc::clone(&store);
+        let b = Arc::clone(&barrier);
+        handles.push(thread::spawn(move || {
+            b.wait();
+            s.claim_next_task("e", t0()).unwrap()
+        }));
+    }
+    let winners: usize = handles
+        .into_iter()
+        .map(|h| h.join().unwrap())
+        .filter(|c| c.is_some())
+        .count();
+    assert_eq!(winners, 1);
+    let task = store.get_task(&TaskId::from_raw("A")).unwrap().unwrap();
+    assert_eq!(task.attempts, 1);
+}
+
+// 4.3 complete_task_and_unblock -------------------------------------------
+
+#[test]
+fn completing_a_task_unblocks_dependents_with_satisfied_deps() {
+    let store = make_store();
+    store
+        .insert_epic_with_tasks(
+            plan(
+                "e",
+                vec![nt("A", "a"), nt("B", "b"), nt("C", "c")],
+                vec![("B", "A"), ("C", "A"), ("C", "B")],
+            ),
+            t0(),
+        )
+        .unwrap();
+    let _ = store.claim_next_task("e", t0()).unwrap().unwrap();
+    let report = store
+        .complete_task_and_unblock(&TaskId::from_raw("A"), 42, t0())
+        .unwrap();
+    assert_eq!(report.completed.as_str(), "A");
+    let by_id = |id: &str| store.get_task(&TaskId::from_raw(id)).unwrap().unwrap();
+    assert_eq!(by_id("A").status, TaskStatus::Done);
+    assert_eq!(by_id("A").pr_number, Some(42));
+    assert_eq!(by_id("B").status, TaskStatus::Ready);
+    assert_eq!(by_id("C").status, TaskStatus::Pending);
+    assert!(report.newly_ready.contains(&TaskId::from_raw("B")));
+}
+
+#[test]
+fn complete_rejects_when_status_not_wip() {
+    let store = make_store();
+    store
+        .insert_epic_with_tasks(plan("e", vec![nt("A", "a")], vec![]), t0())
+        .unwrap();
+    let err = store
+        .complete_task_and_unblock(&TaskId::from_raw("A"), 1, t0())
+        .unwrap_err();
+    assert!(format!("{err}").contains("illegal status transition"));
+}
+
+// 4.4 mark_task_failed -----------------------------------------------------
+
+#[test]
+fn failure_below_max_returns_to_ready() {
+    let store = make_store();
+    store
+        .insert_epic_with_tasks(plan("e", vec![nt("A", "a")], vec![]), t0())
+        .unwrap();
+    let _ = store.claim_next_task("e", t0()).unwrap().unwrap(); // attempts=1
+    let outcome = store
+        .mark_task_failed(&TaskId::from_raw("A"), 3, t0())
+        .unwrap();
+    assert_eq!(outcome, TaskFailureOutcome::Retried { attempts: 1 });
+    assert_eq!(
+        store.get_task(&TaskId::from_raw("A")).unwrap().unwrap().status,
+        TaskStatus::Ready
+    );
+}
+
+#[test]
+fn failure_at_max_escalates_and_blocks_dependents() {
+    let store = make_store();
+    store
+        .insert_epic_with_tasks(
+            plan(
+                "e",
+                vec![nt("A", "a"), nt("B", "b")],
+                vec![("B", "A")],
+            ),
+            t0(),
+        )
+        .unwrap();
+    // Drive A to attempts=3
+    for _ in 0..3 {
+        let _ = store.claim_next_task("e", t0()).unwrap().unwrap();
+        let _ = store.mark_task_failed(&TaskId::from_raw("A"), 3, t0()).unwrap();
+    }
+    let by_id = |id: &str| store.get_task(&TaskId::from_raw(id)).unwrap().unwrap();
+    assert_eq!(by_id("A").status, TaskStatus::Escalated);
+    assert_eq!(by_id("B").status, TaskStatus::Blocked);
+}
+
+// 4.5 apply_reconciliation -------------------------------------------------
+
+#[test]
+fn reconcile_is_idempotent() {
+    let store = make_store();
+    let plan = ReconciliationPlan {
+        epic: epic("e"),
+        tasks: vec![nt("A", "a"), nt("B", "b")],
+        deps: vec![(TaskId::from_raw("B"), TaskId::from_raw("A"))],
+        remote_state: vec![RemoteTaskState {
+            task_id: TaskId::from_raw("A"),
+            branch_exists: true,
+            pr: Some(RemotePrState {
+                number: 10,
+                merged: true,
+                closed: true,
+            }),
+        }],
+        orphan_branches: vec![],
+    };
+    store.apply_reconciliation(plan.clone(), t0()).unwrap();
+    let snapshot1 = store.list_tasks_by_epic("e", None).unwrap();
+    store
+        .apply_reconciliation(plan, t0() + Duration::seconds(1))
+        .unwrap();
+    let snapshot2 = store.list_tasks_by_epic("e", None).unwrap();
+    let key = |t: &autopilot::domain::Task| {
+        (
+            t.id.clone(),
+            t.status.as_str().to_string(),
+            t.pr_number,
+            t.attempts,
+        )
+    };
+    let mut s1: Vec<_> = snapshot1.iter().map(key).collect();
+    let mut s2: Vec<_> = snapshot2.iter().map(key).collect();
+    s1.sort();
+    s2.sort();
+    assert_eq!(s1, s2);
+}
+
+#[test]
+fn reconcile_overrides_status_from_remote_truth() {
+    let store = make_store();
+    let plan = ReconciliationPlan {
+        epic: epic("e"),
+        tasks: vec![nt("A", "a")],
+        deps: vec![],
+        remote_state: vec![RemoteTaskState {
+            task_id: TaskId::from_raw("A"),
+            branch_exists: true,
+            pr: Some(RemotePrState {
+                number: 7,
+                merged: true,
+                closed: true,
+            }),
+        }],
+        orphan_branches: vec![],
+    };
+    store.apply_reconciliation(plan, t0()).unwrap();
+    let a = store.get_task(&TaskId::from_raw("A")).unwrap().unwrap();
+    assert_eq!(a.status, TaskStatus::Done);
+    assert_eq!(a.pr_number, Some(7));
+}
+
+#[test]
+fn reconcile_preserves_attempts_counter() {
+    let store = make_store();
+    store
+        .insert_epic_with_tasks(plan("e", vec![nt("A", "a")], vec![]), t0())
+        .unwrap();
+    let _ = store.claim_next_task("e", t0()).unwrap().unwrap();
+    let _ = store.mark_task_failed(&TaskId::from_raw("A"), 3, t0()).unwrap();
+    let _ = store.claim_next_task("e", t0()).unwrap().unwrap();
+    let plan = ReconciliationPlan {
+        epic: epic("e"),
+        tasks: vec![nt("A", "a")],
+        deps: vec![],
+        remote_state: vec![RemoteTaskState {
+            task_id: TaskId::from_raw("A"),
+            branch_exists: true,
+            pr: None,
+        }],
+        orphan_branches: vec![],
+    };
+    store.apply_reconciliation(plan, t0()).unwrap();
+    let a = store.get_task(&TaskId::from_raw("A")).unwrap().unwrap();
+    assert_eq!(a.attempts, 2);
+    assert_eq!(a.status, TaskStatus::Wip);
+}
+
+// 4.6 fingerprint upsert ---------------------------------------------------
+
+#[test]
+fn upsert_watch_task_inserts_new_when_no_fingerprint_match() {
+    let store = make_store();
+    store
+        .insert_epic_with_tasks(plan("e", vec![], vec![]), t0())
+        .unwrap();
+    let outcome = store
+        .upsert_watch_task(
+            NewWatchTask {
+                id: TaskId::from_raw("watch1"),
+                epic_name: "e".to_string(),
+                source: TaskSource::GapWatch,
+                fingerprint: "fp-1".to_string(),
+                title: "watch finding".to_string(),
+                body: None,
+            },
+            t0(),
+        )
+        .unwrap();
+    assert!(matches!(outcome, UpsertOutcome::Inserted(_)));
+}
+
+#[test]
+fn upsert_watch_task_returns_duplicate_on_existing_fingerprint() {
+    let store = make_store();
+    store
+        .insert_epic_with_tasks(plan("e", vec![], vec![]), t0())
+        .unwrap();
+    let _ = store
+        .upsert_watch_task(
+            NewWatchTask {
+                id: TaskId::from_raw("watch1"),
+                epic_name: "e".to_string(),
+                source: TaskSource::GapWatch,
+                fingerprint: "fp-1".to_string(),
+                title: "first".to_string(),
+                body: None,
+            },
+            t0(),
+        )
+        .unwrap();
+    let outcome = store
+        .upsert_watch_task(
+            NewWatchTask {
+                id: TaskId::from_raw("watch2"),
+                epic_name: "e".to_string(),
+                source: TaskSource::GapWatch,
+                fingerprint: "fp-1".to_string(),
+                title: "duplicate".to_string(),
+                body: None,
+            },
+            t0(),
+        )
+        .unwrap();
+    match outcome {
+        UpsertOutcome::DuplicateFingerprint(id) => assert_eq!(id.as_str(), "watch1"),
+        other => panic!("expected duplicate, got {other:?}"),
+    }
+    let tasks = store.list_tasks_by_epic("e", None).unwrap();
+    assert_eq!(tasks.len(), 1);
+}
+
+// Domain helpers: TaskGraph cycle detection sanity (cross-checks 4.x).
+#[test]
+fn graph_cycle_detection_works_through_domain() {
+    let g = TaskGraph::build([
+        (TaskId::from_raw("A"), TaskId::from_raw("B")),
+        (TaskId::from_raw("B"), TaskId::from_raw("A")),
+    ]);
+    assert!(g.detect_cycle().is_some());
+}

--- a/plugins/github-autopilot/cli/tests/store_conformance.rs
+++ b/plugins/github-autopilot/cli/tests/store_conformance.rs
@@ -1,8 +1,10 @@
 //! L2 TaskStore conformance suite.
 //!
 //! Mirrors the scenarios in plans/github-autopilot/04-test-scenarios.md §4.
-//! When a SqliteTaskStore is added, the same suite is executed against both
-//! adapters via a macro to enforce LSP.
+//! Each scenario is a body fn taking `Arc<dyn TaskStore>`; the
+//! `conformance_suite!` macro generates `#[test]` wrappers that run every
+//! body against both `InMemoryTaskStore` and `SqliteTaskStore`, enforcing
+//! LSP across the two adapters.
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -14,7 +16,6 @@ use autopilot::ports::task_store::{
     EpicPlan, EventFilter, NewTask, NewWatchTask, ReconciliationPlan, RemotePrState,
     RemoteTaskState, TaskStore, UpsertOutcome,
 };
-use autopilot::store::InMemoryTaskStore;
 use chrono::{DateTime, Duration, TimeZone, Utc};
 
 fn t0() -> DateTime<Utc> {
@@ -53,15 +54,7 @@ fn plan(name: &str, tasks: Vec<NewTask>, deps: Vec<(&str, &str)>) -> EpicPlan {
     }
 }
 
-fn make_store() -> Arc<dyn TaskStore> {
-    Arc::new(InMemoryTaskStore::new())
-}
-
-// 4.1 insert_epic_with_tasks ----------------------------------------------
-
-#[test]
-fn insert_creates_epic_tasks_deps_and_promotes_entry_points() {
-    let store = make_store();
+fn body_insert_creates_epic_tasks_deps_and_promotes_entry_points(store: Arc<dyn TaskStore>) {
     store
         .insert_epic_with_tasks(
             plan(
@@ -72,15 +65,12 @@ fn insert_creates_epic_tasks_deps_and_promotes_entry_points() {
             t0(),
         )
         .unwrap();
-
     assert!(store.get_epic("e").unwrap().is_some());
-
     let by_id = |id: &str| store.get_task(&TaskId::from_raw(id)).unwrap().unwrap();
     assert_eq!(by_id("A").status, TaskStatus::Ready);
     assert_eq!(by_id("B").status, TaskStatus::Pending);
     assert_eq!(by_id("C").status, TaskStatus::Pending);
     assert_eq!(store.list_deps(&TaskId::from_raw("B")).unwrap().len(), 1);
-
     let events = store.list_events(EventFilter::default()).unwrap();
     let kinds: Vec<EventKind> = events.iter().map(|e| e.kind).collect();
     assert!(kinds.contains(&EventKind::EpicStarted));
@@ -93,9 +83,7 @@ fn insert_creates_epic_tasks_deps_and_promotes_entry_points() {
     );
 }
 
-#[test]
-fn insert_rejects_dep_cycle() {
-    let store = make_store();
+fn body_insert_rejects_dep_cycle(store: Arc<dyn TaskStore>) {
     let err = store
         .insert_epic_with_tasks(
             plan(
@@ -111,14 +99,11 @@ fn insert_rejects_dep_cycle() {
     assert!(store.get_epic("e").unwrap().is_none());
 }
 
-#[test]
-fn insert_is_atomic_on_existing_active_epic() {
-    let store = make_store();
+fn body_insert_is_atomic_on_existing_active_epic(store: Arc<dyn TaskStore>) {
     store
         .insert_epic_with_tasks(plan("e", vec![nt("A", "a")], vec![]), t0())
         .unwrap();
     let before_tasks = store.list_tasks_by_epic("e", None).unwrap().len();
-
     let err = store
         .insert_epic_with_tasks(plan("e", vec![nt("X", "x"), nt("Y", "y")], vec![]), t0())
         .unwrap_err();
@@ -131,17 +116,11 @@ fn insert_is_atomic_on_existing_active_epic() {
     assert_eq!(before_tasks, after_tasks);
 }
 
-// 4.2 claim_next_task ------------------------------------------------------
-
-#[test]
-fn claim_returns_none_when_no_ready_task() {
-    let store = make_store();
+fn body_claim_returns_none_when_no_ready_task(store: Arc<dyn TaskStore>) {
     assert!(store.claim_next_task("e", t0()).unwrap().is_none());
 }
 
-#[test]
-fn claim_returns_oldest_ready_task() {
-    let store = make_store();
+fn body_claim_returns_oldest_ready_task(store: Arc<dyn TaskStore>) {
     store
         .insert_epic_with_tasks(plan("e", vec![nt("A", "a")], vec![]), t0())
         .unwrap();
@@ -151,7 +130,6 @@ fn claim_returns_oldest_ready_task() {
             t0() + Duration::seconds(10),
         )
         .unwrap();
-
     let claimed = store
         .claim_next_task("e", t0() + Duration::seconds(20))
         .unwrap()
@@ -161,9 +139,7 @@ fn claim_returns_oldest_ready_task() {
     assert_eq!(claimed.attempts, 1);
 }
 
-#[test]
-fn claim_skips_tasks_with_unsatisfied_deps() {
-    let store = make_store();
+fn body_claim_skips_tasks_with_unsatisfied_deps(store: Arc<dyn TaskStore>) {
     store
         .insert_epic_with_tasks(
             plan("e", vec![nt("A", "a"), nt("B", "b")], vec![("B", "A")]),
@@ -172,14 +148,11 @@ fn claim_skips_tasks_with_unsatisfied_deps() {
         .unwrap();
     let claimed = store.claim_next_task("e", t0()).unwrap().unwrap();
     assert_eq!(claimed.id.as_str(), "A");
-    // Only A should be claimable; B is gated.
     let claimed_again = store.claim_next_task("e", t0()).unwrap();
     assert!(claimed_again.is_none());
 }
 
-#[test]
-fn claim_increments_attempts_on_each_call_after_revert() {
-    let store = make_store();
+fn body_claim_increments_attempts_on_each_call_after_revert(store: Arc<dyn TaskStore>) {
     store
         .insert_epic_with_tasks(plan("e", vec![nt("A", "a")], vec![]), t0())
         .unwrap();
@@ -189,16 +162,13 @@ fn claim_increments_attempts_on_each_call_after_revert() {
     assert_eq!(claimed.attempts, 2);
 }
 
-#[test]
-fn claim_is_atomic_under_concurrent_callers() {
+fn body_claim_is_atomic_under_concurrent_callers(store: Arc<dyn TaskStore>) {
     use std::sync::Barrier;
     use std::thread;
 
-    let store: Arc<dyn TaskStore> = make_store();
     store
         .insert_epic_with_tasks(plan("e", vec![nt("A", "a")], vec![]), t0())
         .unwrap();
-
     let barrier = Arc::new(Barrier::new(8));
     let mut handles = Vec::new();
     for _ in 0..8 {
@@ -219,11 +189,7 @@ fn claim_is_atomic_under_concurrent_callers() {
     assert_eq!(task.attempts, 1);
 }
 
-// 4.3 complete_task_and_unblock -------------------------------------------
-
-#[test]
-fn completing_a_task_unblocks_dependents_with_satisfied_deps() {
-    let store = make_store();
+fn body_completing_a_task_unblocks_dependents_with_satisfied_deps(store: Arc<dyn TaskStore>) {
     store
         .insert_epic_with_tasks(
             plan(
@@ -247,9 +213,7 @@ fn completing_a_task_unblocks_dependents_with_satisfied_deps() {
     assert!(report.newly_ready.contains(&TaskId::from_raw("B")));
 }
 
-#[test]
-fn complete_rejects_when_status_not_wip() {
-    let store = make_store();
+fn body_complete_rejects_when_status_not_wip(store: Arc<dyn TaskStore>) {
     store
         .insert_epic_with_tasks(plan("e", vec![nt("A", "a")], vec![]), t0())
         .unwrap();
@@ -259,15 +223,11 @@ fn complete_rejects_when_status_not_wip() {
     assert!(format!("{err}").contains("illegal status transition"));
 }
 
-// 4.4 mark_task_failed -----------------------------------------------------
-
-#[test]
-fn failure_below_max_returns_to_ready() {
-    let store = make_store();
+fn body_failure_below_max_returns_to_ready(store: Arc<dyn TaskStore>) {
     store
         .insert_epic_with_tasks(plan("e", vec![nt("A", "a")], vec![]), t0())
         .unwrap();
-    let _ = store.claim_next_task("e", t0()).unwrap().unwrap(); // attempts=1
+    let _ = store.claim_next_task("e", t0()).unwrap().unwrap();
     let outcome = store
         .mark_task_failed(&TaskId::from_raw("A"), 3, t0())
         .unwrap();
@@ -282,16 +242,13 @@ fn failure_below_max_returns_to_ready() {
     );
 }
 
-#[test]
-fn failure_at_max_escalates_and_blocks_dependents() {
-    let store = make_store();
+fn body_failure_at_max_escalates_and_blocks_dependents(store: Arc<dyn TaskStore>) {
     store
         .insert_epic_with_tasks(
             plan("e", vec![nt("A", "a"), nt("B", "b")], vec![("B", "A")]),
             t0(),
         )
         .unwrap();
-    // Drive A to attempts=3
     for _ in 0..3 {
         let _ = store.claim_next_task("e", t0()).unwrap().unwrap();
         let _ = store
@@ -303,12 +260,8 @@ fn failure_at_max_escalates_and_blocks_dependents() {
     assert_eq!(by_id("B").status, TaskStatus::Blocked);
 }
 
-// 4.5 apply_reconciliation -------------------------------------------------
-
-#[test]
-fn reconcile_is_idempotent() {
-    let store = make_store();
-    let plan = ReconciliationPlan {
+fn body_reconcile_is_idempotent(store: Arc<dyn TaskStore>) {
+    let p = ReconciliationPlan {
         epic: epic("e"),
         tasks: vec![nt("A", "a"), nt("B", "b")],
         deps: vec![(TaskId::from_raw("B"), TaskId::from_raw("A"))],
@@ -323,10 +276,10 @@ fn reconcile_is_idempotent() {
         }],
         orphan_branches: vec![],
     };
-    store.apply_reconciliation(plan.clone(), t0()).unwrap();
+    store.apply_reconciliation(p.clone(), t0()).unwrap();
     let snapshot1 = store.list_tasks_by_epic("e", None).unwrap();
     store
-        .apply_reconciliation(plan, t0() + Duration::seconds(1))
+        .apply_reconciliation(p, t0() + Duration::seconds(1))
         .unwrap();
     let snapshot2 = store.list_tasks_by_epic("e", None).unwrap();
     let key = |t: &autopilot::domain::Task| {
@@ -344,10 +297,8 @@ fn reconcile_is_idempotent() {
     assert_eq!(s1, s2);
 }
 
-#[test]
-fn reconcile_overrides_status_from_remote_truth() {
-    let store = make_store();
-    let plan = ReconciliationPlan {
+fn body_reconcile_overrides_status_from_remote_truth(store: Arc<dyn TaskStore>) {
+    let p = ReconciliationPlan {
         epic: epic("e"),
         tasks: vec![nt("A", "a")],
         deps: vec![],
@@ -362,15 +313,13 @@ fn reconcile_overrides_status_from_remote_truth() {
         }],
         orphan_branches: vec![],
     };
-    store.apply_reconciliation(plan, t0()).unwrap();
+    store.apply_reconciliation(p, t0()).unwrap();
     let a = store.get_task(&TaskId::from_raw("A")).unwrap().unwrap();
     assert_eq!(a.status, TaskStatus::Done);
     assert_eq!(a.pr_number, Some(7));
 }
 
-#[test]
-fn reconcile_preserves_attempts_counter() {
-    let store = make_store();
+fn body_reconcile_preserves_attempts_counter(store: Arc<dyn TaskStore>) {
     store
         .insert_epic_with_tasks(plan("e", vec![nt("A", "a")], vec![]), t0())
         .unwrap();
@@ -379,7 +328,7 @@ fn reconcile_preserves_attempts_counter() {
         .mark_task_failed(&TaskId::from_raw("A"), 3, t0())
         .unwrap();
     let _ = store.claim_next_task("e", t0()).unwrap().unwrap();
-    let plan = ReconciliationPlan {
+    let p = ReconciliationPlan {
         epic: epic("e"),
         tasks: vec![nt("A", "a")],
         deps: vec![],
@@ -390,17 +339,13 @@ fn reconcile_preserves_attempts_counter() {
         }],
         orphan_branches: vec![],
     };
-    store.apply_reconciliation(plan, t0()).unwrap();
+    store.apply_reconciliation(p, t0()).unwrap();
     let a = store.get_task(&TaskId::from_raw("A")).unwrap().unwrap();
     assert_eq!(a.attempts, 2);
     assert_eq!(a.status, TaskStatus::Wip);
 }
 
-// 4.6 fingerprint upsert ---------------------------------------------------
-
-#[test]
-fn upsert_watch_task_inserts_new_when_no_fingerprint_match() {
-    let store = make_store();
+fn body_upsert_watch_task_inserts_new_when_no_fingerprint_match(store: Arc<dyn TaskStore>) {
     store
         .insert_epic_with_tasks(plan("e", vec![], vec![]), t0())
         .unwrap();
@@ -420,9 +365,7 @@ fn upsert_watch_task_inserts_new_when_no_fingerprint_match() {
     assert!(matches!(outcome, UpsertOutcome::Inserted(_)));
 }
 
-#[test]
-fn upsert_watch_task_returns_duplicate_on_existing_fingerprint() {
-    let store = make_store();
+fn body_upsert_watch_task_returns_duplicate_on_existing_fingerprint(store: Arc<dyn TaskStore>) {
     store
         .insert_epic_with_tasks(plan("e", vec![], vec![]), t0())
         .unwrap();
@@ -460,7 +403,56 @@ fn upsert_watch_task_returns_duplicate_on_existing_fingerprint() {
     assert_eq!(tasks.len(), 1);
 }
 
-// Domain helpers: TaskGraph cycle detection sanity (cross-checks 4.x).
+macro_rules! conformance_suite {
+    ($($name:ident),* $(,)?) => {
+        mod in_memory {
+            use std::sync::Arc;
+            use autopilot::ports::task_store::TaskStore;
+            use autopilot::store::InMemoryTaskStore;
+            $(
+                #[test]
+                fn $name() {
+                    let store: Arc<dyn TaskStore> = Arc::new(InMemoryTaskStore::new());
+                    super::$name(store);
+                }
+            )*
+        }
+        mod sqlite {
+            use std::sync::Arc;
+            use autopilot::ports::task_store::TaskStore;
+            use autopilot::store::SqliteTaskStore;
+            $(
+                #[test]
+                fn $name() {
+                    let store: Arc<dyn TaskStore> =
+                        Arc::new(SqliteTaskStore::open_in_memory().unwrap());
+                    super::$name(store);
+                }
+            )*
+        }
+    };
+}
+
+conformance_suite!(
+    body_insert_creates_epic_tasks_deps_and_promotes_entry_points,
+    body_insert_rejects_dep_cycle,
+    body_insert_is_atomic_on_existing_active_epic,
+    body_claim_returns_none_when_no_ready_task,
+    body_claim_returns_oldest_ready_task,
+    body_claim_skips_tasks_with_unsatisfied_deps,
+    body_claim_increments_attempts_on_each_call_after_revert,
+    body_claim_is_atomic_under_concurrent_callers,
+    body_completing_a_task_unblocks_dependents_with_satisfied_deps,
+    body_complete_rejects_when_status_not_wip,
+    body_failure_below_max_returns_to_ready,
+    body_failure_at_max_escalates_and_blocks_dependents,
+    body_reconcile_is_idempotent,
+    body_reconcile_overrides_status_from_remote_truth,
+    body_reconcile_preserves_attempts_counter,
+    body_upsert_watch_task_inserts_new_when_no_fingerprint_match,
+    body_upsert_watch_task_returns_duplicate_on_existing_fingerprint,
+);
+
 #[test]
 fn graph_cycle_detection_works_through_domain() {
     let g = TaskGraph::build([


### PR DESCRIPTION
## Summary
This PR introduces the core domain layer and a complete in-memory implementation of the task store, establishing the foundation for task lifecycle management in the GitHub Autopilot CLI.

## Key Changes

### Domain Models (`src/domain/`)
- **Task and Epic entities**: Core domain objects representing work units and their containers
  - `Task`: Tracks status, attempts, PR numbers, and escalation state
  - `Epic`: Groups related tasks with lifecycle management (active/completed/abandoned)
- **Task ID generation**: Deterministic SHA256-based IDs with Unicode normalization for stable task identification across runs
- **Event model**: Immutable event log for audit trails with 16 event kinds (task lifecycle, epic transitions, reconciliation)
- **Dependency graph**: Cycle detection and topological ordering for task dependencies using DFS-based algorithms
- **Domain errors**: Type-safe error handling for illegal state transitions and constraint violations

### Task Store Abstraction (`src/ports/task_store.rs`)
- **EpicRepo trait**: Epic CRUD and status management
- **TaskRepo trait**: Task lifecycle operations (claim, complete, fail, escalate)
- **EventLog trait**: Event filtering and retrieval
- **Data structures**: `EpicPlan`, `ReconciliationPlan`, `RemoteTaskState` for coordinating between local and remote state

### In-Memory Implementation (`src/store/memory.rs`)
- **753-line implementation** with full task lifecycle support:
  - Epic insertion with atomic validation (cycle detection, uniqueness)
  - Task claiming with dependency-aware ordering (oldest-first, respecting deps)
  - Task completion with automatic dependent unblocking
  - Failure handling with retry logic and escalation
  - Reconciliation with remote PR state
  - Event logging for all state transitions
- **Thread-safe**: Uses `Mutex<State>` for concurrent access
- **Comprehensive event tracking**: Emits events for all operations enabling audit trails

### Conformance Test Suite (`tests/store_conformance.rs`)
- 465-line test suite covering 4.1-4.5 scenarios from design spec
- Tests for atomicity, dependency resolution, concurrent claims, and reconciliation idempotency
- Designed to be reusable across multiple store implementations (in-memory, SQLite)

### Supporting Infrastructure
- **Clock abstraction** (`src/ports/clock.rs`): `StdClock` for production, `FixedClock` for testing
- **SQL migrations** (`src/store/migrations/V1__initial.sql`): Schema for future SQLite implementation
- **Dependencies**: Added chrono, rusqlite, sha2, unicode-normalization, serde_json

## Notable Implementation Details

- **Entry-point promotion**: Tasks with no dependencies are automatically promoted to `Ready` status on epic insertion
- **Dependency blocking**: When a task escalates, all dependent tasks are marked `Blocked` to prevent cascading failures
- **Idempotent reconciliation**: Applying the same reconciliation plan multiple times produces identical state
- **Atomic operations**: Epic insertion validates all constraints before any state mutation
- **Deterministic task IDs**: Enables stable task identification even when specs are regenerated

## Testing
The conformance suite validates:
- Cycle detection and rejection
- Dependency-aware task ordering
- Concurrent claim atomicity (8-thread stress test)
- Unblocking logic with partial dependency satisfaction
- Escalation and blocking propagation
- Reconciliation idempotency

https://claude.ai/code/session_01K1QddP6cPmEvmmjjcGAS1h