### PR TITLE
docs(github-autopilot): refine task store spec

### DIFF
--- a/plans/github-autopilot/02-architecture.md
+++ b/plans/github-autopilot/02-architecture.md
@@ -23,7 +23,7 @@
 +----------------------------v---------------------------+
 |                    Orchestration                       |
 |  EpicManager  BuildLoop  WatchDispatcher  Reconciler   |
-|              MergeLoop   Escalator                     |
+|  MergeLoop    Escalator  EscalationWatcher             |
 +----------------------------+---------------------------+
                              |
 +----------------------------v---------------------------+
@@ -94,9 +94,10 @@ plugins/github-autopilot/cli/src/
 │   ├── epic_manager.rs              # start / resume / stop / status
 │   ├── build_loop.rs                # claim → IM 호출 → push 결과 처리
 │   ├── watch_dispatcher.rs          # watch 결과 → epic 매칭 / append / escalate
-│   ├── merge_loop.rs                # PR 머지 + task done 전이
+│   ├── merge_loop.rs                # PR 머지 + task done 전이 + epic 완료 판정
 │   ├── reconciler.rs                # git remote ↔ DB
-│   └── escalator.rs                 # escalation 이슈 + suppression
+│   ├── escalator.rs                 # escalation 이슈 + suppression
+│   └── escalation_watcher.rs        # escalated task 의 issue close 폴링 → reconcile
 │
 └── cmd/                             # CLI 핸들러 (clap subcommand 매핑)
     ├── mod.rs
@@ -289,9 +290,9 @@ src/store/migrations/
 | 3 | TaskStore | claim 시 deps 필터, complete 시 unblock_dependents |
 | 4-5 | TaskStore + GitClient + SpecDecomposer + GitHubClient | Reconciler::reconcile_epic → fetch + ls-remote + PR 스캔 → apply_reconciliation |
 | 6 | TaskStore | WatchDispatcher::dispatch → epic 매칭 → upsert task |
-| 7-9 | GitHubClient + TaskStore | Escalator::escalate → 이슈 발행 + escalated_issue 기록 |
+| 7-9 | GitHubClient + TaskStore | Escalator::escalate → 이슈 발행 + escalated_issue 기록. EscalationWatcher → 사람이 close 한 이슈 자동 인식 → reconcile |
 | 8 | TaskStore | mark_task_failed → outcome 분기 |
-| 10 | TaskStore + Notifier | EpicManager::check_completion → notifier.send |
+| 10 | TaskStore + Notifier | MergeLoop::tick → all_tasks_done 판정 → notifier.send. escalated 잔류 시 EpicCompleted 미발송 (사람이 force-status 또는 코드 push 로 해소해야 함) |
 | 11 | GitClient | BuildLoop 의 push reject 처리 (DB 변경 없음) |
 | 12 | TaskStore | EpicManager::stop → epic.status=abandoned |
 | 13 | TaskStore + GitHubClient | MigrateCommand → import_issue → upsert task + 이슈 라벨 정리 |

--- a/plans/github-autopilot/03-detailed-spec.md
+++ b/plans/github-autopilot/03-detailed-spec.md
@@ -89,6 +89,7 @@ pub enum EventKind {
     TaskInserted, TaskClaimed, TaskStarted, TaskCompleted, TaskFailed,
     TaskEscalated, TaskBlocked, TaskUnblocked,
     Reconciled, ClaimLost, MigratedFromIssue, EscalationResolved,
+    TaskForceStatus,    // 운영자 force_status (payload: {target, reason})
 }
 ```
 
@@ -117,6 +118,12 @@ pub trait EpicRepo {
     fn get_epic(&self, name: &str) -> Result<Option<Epic>>;
     fn list_epics(&self, status: Option<EpicStatus>) -> Result<Vec<Epic>>;
     fn set_epic_status(&self, name: &str, status: EpicStatus, at: DateTime<Utc>) -> Result<()>;
+
+    /// 활성 epic 중 spec_path 가 일치하는 것을 반환. WatchDispatcher 가 갭 발견 시
+    /// "이 spec 이 어느 활성 epic 에 속하는지" 매칭에 사용 (UC-6).
+    /// 동일 spec_path 의 active epic 은 최대 1개라는 invariant 가정 — 2개 이상 발견 시
+    /// `Err(DomainError::Inconsistency)` 반환.
+    fn find_active_by_spec_path(&self, spec_path: &Path) -> Result<Option<Epic>>;
 }
 
 pub trait TaskRepo {
@@ -124,6 +131,10 @@ pub trait TaskRepo {
     fn get_task(&self, id: &TaskId) -> Result<Option<Task>>;
     fn list_tasks_by_epic(&self, epic: &str, status: Option<TaskStatus>) -> Result<Vec<Task>>;
     fn find_by_fingerprint(&self, epic: &str, fp: &str) -> Result<Option<Task>>;
+
+    /// 머지된 PR 번호로 task 역조회. MergeLoop 가 PR 머지 후 task.status='done' 전이
+    /// 대상을 찾기 위해 사용 (UC-2, §5.8).
+    fn find_task_by_pr(&self, pr_number: u64) -> Result<Option<Task>>;
 
     fn upsert_watch_task(&self, task: NewWatchTask, now: DateTime<Utc>) -> Result<UpsertOutcome>;
 
@@ -141,11 +152,23 @@ pub trait TaskRepo {
         &self, id: &TaskId, issue_number: u64, now: DateTime<Utc>
     ) -> Result<()>;
 
-    fn revert_to_ready(&self, id: &TaskId, now: DateTime<Utc>) -> Result<()>;
+    /// 시도조차 실패한 claim 을 되돌린다 (UC-11 의 push reject = claim_lost).
+    /// `claim_next_task` 에서 +1 된 attempts 를 차감하여 max_attempts 카운트에 영향이
+    /// 없도록 한다. 상태 wip → ready, 변화량 != 1 이면 IllegalTransition.
+    /// 주의: push 후 CI 실패 / 구현 실패는 `mark_task_failed` 사용 (attempts 보존).
+    fn release_claim(&self, id: &TaskId, now: DateTime<Utc>) -> Result<()>;
 
     fn apply_reconciliation(&self, plan: ReconciliationPlan, now: DateTime<Utc>) -> Result<()>;
 
     fn list_deps(&self, task_id: &TaskId) -> Result<Vec<TaskId>>;
+
+    /// 운영자 오버라이드 (CLI `task force-status`). 일반 상태 전이 검증을 우회하지만,
+    /// (a) 도메인 enum 에 정의된 상태로만 전이 가능, (b) reason 을 events 에 기록한다.
+    /// 의존성 재평가 / 자식 unblock 은 수행하지 않는다 — 필요하면 호출자가 reconcile
+    /// 또는 후속 메서드를 명시적으로 호출.
+    fn force_status(
+        &self, id: &TaskId, target: TaskStatus, reason: &str, now: DateTime<Utc>
+    ) -> Result<()>;
 }
 
 pub trait EventLog {
@@ -153,8 +176,20 @@ pub trait EventLog {
     fn list_events(&self, filter: EventFilter) -> Result<Vec<Event>>;
 }
 
-pub trait TaskStore: EpicRepo + TaskRepo + EventLog + Send + Sync {}
-impl<T: EpicRepo + TaskRepo + EventLog + Send + Sync> TaskStore for T {}
+/// HITL escalation 의 fingerprint 기반 중복 발행 억제 (UC-7).
+/// 동일 fingerprint + reason 조합이 suppress_until 시점까지 escalate 되지 않게 한다.
+pub trait SuppressionRepo {
+    fn suppress(
+        &self, fingerprint: &str, reason: &str, suppress_until: DateTime<Utc>
+    ) -> Result<()>;
+    fn is_suppressed(
+        &self, fingerprint: &str, reason: &str, now: DateTime<Utc>
+    ) -> Result<bool>;
+    fn clear(&self, fingerprint: &str, reason: &str) -> Result<()>;
+}
+
+pub trait TaskStore: EpicRepo + TaskRepo + EventLog + SuppressionRepo + Send + Sync {}
+impl<T: EpicRepo + TaskRepo + EventLog + SuppressionRepo + Send + Sync> TaskStore for T {}
 ```
 
 보조 타입:
@@ -253,6 +288,7 @@ pub trait GitHubClient: Send + Sync {
     fn add_issue_labels(&self, number: u64, labels: &[String]) -> Result<()>;
     fn remove_issue_labels(&self, number: u64, labels: &[String]) -> Result<()>;
     fn list_issues(&self, filter: IssueFilter) -> Result<Vec<IssueRef>>;
+    fn get_issue(&self, number: u64) -> Result<Option<IssueRef>>;
 
     fn create_pr(&self, req: CreatePr) -> Result<u64>;
     fn merge_pr(&self, number: u64, method: MergeMethod) -> Result<()>;
@@ -263,7 +299,13 @@ pub trait GitHubClient: Send + Sync {
 pub struct CreateIssue { pub title: String, pub body: String, pub labels: Vec<String> }
 pub struct CreatePr { pub head: String, pub base: String, pub title: String, pub body: String, pub labels: Vec<String> }
 pub struct PrRef { pub number: u64, pub head: String, pub base: String, pub merged: bool, pub closed: bool, pub labels: Vec<String> }
-pub struct IssueRef { pub number: u64, pub title: String, pub labels: Vec<String>, pub body_meta: Option<EscalationMeta> }
+pub struct IssueRef {
+    pub number: u64,
+    pub title: String,
+    pub closed: bool,
+    pub labels: Vec<String>,
+    pub body_meta: Option<EscalationMeta>,
+}
 pub struct IssueFilter { pub labels: Vec<String>, pub state: IssueState }
 pub enum IssueState { Open, Closed, All }
 pub enum MergeMethod { Squash, Merge, Rebase }
@@ -391,9 +433,16 @@ CREATE TABLE escalation_suppression (
 
 CREATE INDEX idx_tasks_epic_status ON tasks(epic_name, status);
 CREATE INDEX idx_tasks_fingerprint ON tasks(fingerprint);
+CREATE INDEX idx_tasks_pr_number   ON tasks(pr_number) WHERE pr_number IS NOT NULL;
+CREATE INDEX idx_epics_active_spec ON epics(spec_path) WHERE status='active';
 CREATE INDEX idx_events_epic_at ON events(epic_name, at);
 CREATE INDEX idx_events_task_at ON events(task_id, at);
 ```
+
+신규 인덱스 사유:
+
+- `idx_tasks_pr_number` — `find_task_by_pr` 의 O(1) 조회 (대부분 task 가 PR 미할당이므로 partial index 로 크기 절감).
+- `idx_epics_active_spec` — `find_active_by_spec_path` 가 watch 빈번 호출이라 partial index 권장. 동일 spec_path 의 active epic 은 1개라는 invariant 와 일치.
 
 마이그레이션 적용: 시작 시 `meta.schema_version` 을 읽고 누락된 V_n 을 순서대로 실행. 단일 트랜잭션 안에서 적용.
 
@@ -564,7 +613,7 @@ idempotency: 동일 plan 으로 N번 호출해도 결과 동일. attempts 카운
 
 ```
 fn dispatch_finding(finding: WatchFinding):
-  match epic_for_spec(finding.spec_path):
+  match task_store.find_active_by_spec_path(finding.spec_path):
     Some(epic):
       task_id = TaskId::new_deterministic(epic.name, finding.section, finding.requirement)
       outcome = task_store.upsert_watch_task(NewWatchTask{
@@ -577,10 +626,14 @@ fn dispatch_finding(finding: WatchFinding):
       }, now)
       log event accordingly
     None:
-      if escalation_suppressed(finding.fingerprint): return
+      if task_store.is_suppressed(finding.fingerprint, "unmatched_watch", now): return
       issue_number = github.create_issue(escalation_template(finding))
       task_store.append_event(kind='escalated', payload={...})
-      task_store.suppress(finding.fingerprint, reason='unmatched_watch', until = now + 24h)
+      task_store.suppress(
+        finding.fingerprint,
+        reason="unmatched_watch",
+        suppress_until = now + Duration::hours(escalation_suppression_window_hours),
+      )
 ```
 
 `upsert_watch_task` 는 fingerprint 충돌 시 `DuplicateFingerprint(existing_id)` 반환, orchestration 에서 이를 보고 신규 발행 skip.
@@ -595,29 +648,77 @@ fn tick():
       if task is None: break
       branch = format!("{prefix}/{epic.name}/{task.id}", prefix=epic_branch_prefix)
       spawn_implementer(epic, task, branch)
-        on_success(pr_number) -> task_store.complete_task_and_unblock(...)
-        on_push_rejected     -> task_store.revert_to_ready(task.id, now)
-                                  task_store.append_event(kind='claim_lost', ...)
-        on_other_failure     -> outcome = task_store.mark_task_failed(task.id, max_attempts, now)
-                                  if Escalated: escalator.escalate(...)
+        on_pr_created(pr_number) ->
+            -- PR 생성 성공. 머지는 MergeLoop 가 후속 처리.
+            task_store.append_event(kind='task_started', task=task.id, payload={pr: pr_number})
+        on_push_rejected         ->
+            -- UC-11: 다른 머신 / 다른 sub-loop 가 먼저 가져감. 시도 회복.
+            task_store.release_claim(task.id, now)
+            task_store.append_event(kind='claim_lost', task=task.id)
+        on_implementation_failed ->
+            -- 코드 작성 실패 / push 후 PR 생성 실패 / CI 실패 등. 시도는 보존.
+            outcome = task_store.mark_task_failed(task.id, max_attempts, now)
+            if Escalated: escalator.escalate(task)
 ```
+
+`release_claim` 과 `mark_task_failed` 의 선택 기준: **시도조차 못 했으면** `release_claim`, **시도했으나 실패** 면 `mark_task_failed`.
 
 ### 5.8 MergeLoop tick (UC-2, UC-10)
 
 ```
 fn tick():
-  prs = github.list_prs_targeting(epic.branch, labels=[":auto"], state=open)
-  for pr in prs:
-    if pr 의 ci 상태 통과 + 충돌 없음:
-      github.merge_pr(pr.number, MergeMethod::Squash)
-      task = task_store.find_by_pr(pr.number)
-      task_store.complete_task_and_unblock(task.id, pr.number, now)
+  for epic in active_epics:
+    prs = github.list_prs_targeting(epic.branch, labels=[":auto"], state=open)
+    for pr in prs:
+      if pr 의 ci 상태 통과 + 충돌 없음:
+        github.merge_pr(pr.number, MergeMethod::Squash)
+        task = task_store.find_task_by_pr(pr.number)
+        if task is Some: task_store.complete_task_and_unblock(task.id, pr.number, now)
 
-  -- epic 완료 판정
-  if all_tasks_terminal(epic):       -- done | (escalated AND issue_closed)
-    epic_manager.complete(epic.name)
-    notifier.send(EpicCompleted { epic: epic.name })
+    -- epic 완료 판정
+    -- "사람이 close 한 escalated" 의 자동 인식은 §5.9 EscalationWatcher 가 별도로 처리.
+    -- 본 루프에서는 task.status ∈ {done} 여부만 본다.
+    if all_tasks_done(epic):
+      epic_manager.complete(epic.name)
+      notifier.send(EpicCompleted { epic: epic.name })
 ```
+
+### 5.9 EscalationWatcher tick (UC-9, UC-10)
+
+`EscalationWatcher` 는 escalated task 의 GitHub 이슈 close 를 주기 폴링하여 사람의 직접 해소를
+자동 인식한다. MergeLoop 와 분리한 이유: SRP — MergeLoop 는 PR 머지 흐름만, 본 루프는
+escalation 해소 흐름만 담당. 폴링 주기는 MergeLoop 보다 길게 (예: 5분).
+
+```
+fn tick():
+  for epic in active_epics:
+    escalated = task_store.list_tasks_by_epic(epic.name, status=Escalated)
+    for task in escalated:
+      if task.escalated_issue is None: continue
+      issue = github.get_issue(task.escalated_issue)
+      if issue is None or !issue.closed: continue
+
+      -- 사람이 issue 를 close 했음. 두 케이스:
+      -- (a) 사람이 직접 코드를 작성하여 epic 브랜치에 PR 머지 → reconcile 이 done 으로 인식
+      -- (b) 단순 거부 / 무시 close → suppression 등록 (해당 fingerprint 추가 escalate 차단)
+      reconciler.reconcile_epic(epic.name, now)
+      task_after = task_store.get_task(task.id)
+      if task_after.status != Done:
+        -- (b) 케이스. 사람이 코드 작업 없이 close 한 것으로 간주.
+        if task.fingerprint is Some:
+          task_store.suppress(
+            task.fingerprint, reason="rejected_by_human",
+            suppress_until = now + Duration::days(30),
+          )
+        task_store.append_event(kind='escalation_resolved',
+                                payload={resolution: 'rejected'}, task=task.id)
+      else:
+        task_store.append_event(kind='escalation_resolved',
+                                payload={resolution: 'human_fixed'}, task=task.id)
+```
+
+**중요한 invariant**: 본 루프는 `force_status` 를 직접 호출하지 않는다. 상태 전이는 reconcile
+(idempotent) 또는 다른 정상 경로를 통해서만 일어난다.
 
 ## 6. CLI 시그니처 (clap)
 
@@ -666,6 +767,10 @@ pub enum DomainError {
     IllegalTransition(TaskId, TaskStatus, TaskStatus),
     #[error("epic '{0}' already exists with status {1:?}")]
     EpicAlreadyExists(String, EpicStatus),
+    /// 데이터 불변식 위반 (예: 동일 spec_path 의 active epic 이 2개 이상).
+    /// 정상 흐름에서는 발생할 수 없으며, 발생 시 사람 개입 필요.
+    #[error("inconsistency: {0}")]
+    Inconsistency(String),
 }
 
 // ports/task_store.rs

--- a/plans/github-autopilot/04-test-scenarios.md
+++ b/plans/github-autopilot/04-test-scenarios.md
@@ -144,10 +144,18 @@ test: claim_is_atomic_under_concurrent_callers
   then:  정확히 한쪽만 Some(A) 를 받고 다른 쪽은 None
          get_task(A).attempts == 1   # 한 번만 증가
 
-test: claim_increments_attempts_on_each_call
+test: claim_increments_attempts_only_on_real_attempt
   given: 1 ready task A
-  when:  claim → revert_to_ready → claim
+  when:  claim → release_claim → claim
+  then:  attempts == 1
+         -- release_claim 은 시도조차 못 한 경우(UC-11)에 사용되며,
+         -- claim 의 +1 을 차감하여 max_attempts 카운트에 영향 없음
+
+test: mark_task_failed_preserves_attempts_for_retry
+  given: 1 ready task A, max_attempts=3
+  when:  claim → mark_task_failed (Retried) → claim → mark_task_failed (Retried)
   then:  attempts == 2
+         -- 시도 후 실패는 attempts 보존 (escalation 카운트에 반영)
 ```
 
 ### 4.3 complete_task_and_unblock
@@ -226,7 +234,77 @@ test: upsert_watch_task_returns_duplicate_on_existing_fingerprint
          no new task inserted
 ```
 
-### 4.7 schema_version 일관성 (SQLite 전용)
+### 4.7 lookup helpers
+
+```
+test: find_task_by_pr_returns_owning_task
+  given: A(done, pr_number=42), B(wip, pr_number=None)
+  when:  find_task_by_pr(42)
+  then:  Ok(Some(A))
+
+test: find_task_by_pr_returns_none_when_unknown
+  when:  find_task_by_pr(9999)
+  then:  Ok(None)
+
+test: find_active_by_spec_path_matches_active_only
+  given: epic e1(active, spec="spec/auth.md"), e2(abandoned, spec="spec/auth.md")
+  when:  find_active_by_spec_path("spec/auth.md")
+  then:  Ok(Some(e1))   # abandoned 는 제외
+
+test: find_active_by_spec_path_returns_none_when_no_match
+  given: epic e1(active, spec="spec/payments.md")
+  when:  find_active_by_spec_path("spec/auth.md")
+  then:  Ok(None)
+
+test: find_active_by_spec_path_rejects_invariant_violation
+  given: epic e1(active, spec="spec/auth.md"), e2(active, spec="spec/auth.md")
+         # 정상 흐름에서는 만들 수 없으나 직접 삽입했다고 가정
+  when:  find_active_by_spec_path("spec/auth.md")
+  then:  Err(DomainError::Inconsistency(_))
+```
+
+### 4.8 force_status
+
+```
+test: force_status_bypasses_normal_transition
+  given: A(escalated)
+  when:  force_status(A, target=Pending, reason="manual reset")
+  then:  A.status == 'pending'
+         events kind 에 reason 이 payload 로 기록됨
+
+test: force_status_does_not_unblock_dependents
+  given: A(escalated), B(blocked, deps=[A])
+  when:  force_status(A, target=Done, reason="human fixed")
+  then:  A.status == 'done'
+         B.status == 'blocked'   # force_status 는 자식 unblock 안 함
+         # → 호출자가 별도로 reconcile / 메서드를 호출해야 함
+
+test: force_status_records_event_with_reason
+  given: A(wip)
+  when:  force_status(A, target=Ready, reason="rollback")
+  then:  events 에 force_status 기록, payload.reason == "rollback"
+```
+
+### 4.9 suppression
+
+```
+test: suppression_blocks_until_window_expires
+  fixture: clock at t0
+  when:  suppress(fp="fp-1", reason="unmatched_watch", until=t0+1h)
+         is_suppressed(fp-1, "unmatched_watch", at=t0+30m) -> true
+         is_suppressed(fp-1, "unmatched_watch", at=t0+2h)  -> false
+
+test: suppression_is_scoped_by_reason
+  when:  suppress(fp="fp-1", reason="unmatched_watch", ...)
+         is_suppressed(fp-1, "rejected_by_human", now) -> false
+
+test: suppression_clear_unblocks_immediately
+  when:  suppress(fp-1, "r", until=far_future)
+         clear(fp-1, "r")
+         is_suppressed(fp-1, "r", now) -> false
+```
+
+### 4.10 schema_version 일관성 (SQLite 전용)
 
 ```
 test: sqlite_initializes_schema_v1_on_empty_db
@@ -420,6 +498,27 @@ test: uc9d_human_fixed_directly_marks_done_on_resume
   fixture: A.status='escalated', 사람이 직접 코드 push 후 PR merged
   when:  EpicManager::resume(...)
   then:  reconcile 로 A.status='done' 으로 전이
+
+test: uc9_escalation_watcher_picks_up_human_close_without_resume
+  fixture:
+    epic "e" active, A.status='escalated', A.escalated_issue=#42
+    github.issues[42].closed = true
+    git.remote: PR head=epic/e/<A_id> base=epic/e merged=true
+    decomposer: tasks 에 A 포함
+  when:  EscalationWatcher::tick()
+  then:  A.status == 'done'
+         events kind='escalation_resolved', payload.resolution=='human_fixed'
+         # resume 호출 없이 자동 인식
+
+test: uc9_escalation_watcher_records_rejection_on_close_without_code
+  fixture:
+    epic "e" active, A.status='escalated', A.escalated_issue=#42, fingerprint='fp-A'
+    github.issues[42].closed = true
+    git.remote: 해당 task 의 feature 브랜치 / PR 없음
+  when:  EscalationWatcher::tick()
+  then:  A.status == 'escalated' 유지   # reconcile 결과 done 아님
+         suppression(fp='fp-A', reason='rejected_by_human') 활성
+         events kind='escalation_resolved', payload.resolution=='rejected'
 ```
 
 ### UC-10. Epic 완료
@@ -442,12 +541,12 @@ test: uc10_does_not_complete_with_open_escalations
 ### UC-11. 동시 진행 자연 차단
 
 ```
-test: uc11_push_reject_reverts_task_to_ready
+test: uc11_push_reject_releases_claim_without_attempt_charge
   fixture: BuildLoop 가 task A 를 claim, IM 이 push 시도하나 git.push_rejects 로 reject
   when:  IM 결과 처리
   then:  A.status == 'ready'
          events kind='claim_lost'
-         tasks 의 attempts 는 증가했지만 다음 cycle 에 다시 claim 가능
+         A.attempts == 0   # release_claim 으로 차감되어 다음 cycle 에서 새 시도
 
 test: uc11_concurrent_claim_yields_one_winner
   given: store 에 ready task A 1건


### PR DESCRIPTION
## Summary
Round 2 구현 진입 전 spec 정제. 03/04/02 의 누락 시그니처와 모호한 의미 정정. 본 PR 은 epic 브랜치 base.

## 변경 항목

### A. 누락 시그니처 추가
- `TaskRepo::find_task_by_pr(pr_number)` — MergeLoop 가 PR 머지 후 task 역조회 (§5.8)
- `EpicRepo::find_active_by_spec_path(path)` — WatchDispatcher 의 `epic_for_spec` 실체 (§5.6)
- `TaskRepo::force_status(id, target, reason, now)` — CLI \`task force-status\` 백엔드
- `SuppressionRepo` 신규 trait (`suppress`/`is_suppressed`/`clear`) — TaskStore 슈퍼트레이트 포함
- `GitHubClient::get_issue(number)` + `IssueRef.closed` — escalation issue close 폴링용

### B. 의미 명시
- `revert_to_ready` → `release_claim` 으로 명칭 변경, **claim 의 attempts +1 차감** 명시
  - claim_lost (UC-11) vs tried-and-failed (UC-2 alt) 구분
  - `mark_task_failed` 는 기존대로 attempts 보존 (escalation 카운트 반영)
- BuildLoop pseudocode `on_pr_created` / `on_implementation_failed` 로 명명 정리

### C. EscalationWatcher 신규 (§5.9)
- 사람이 escalation 이슈를 close 했을 때 \`epic-resume\` 없이도 자동 인식
- 폴링 → reconcile → done 또는 suppression 등록
- \`force_status\` 직접 호출 안 함 (상태 전이는 reconcile 경유, invariant 명시)

### D. 보조
- `DomainError::Inconsistency` 추가
- `EventKind::TaskForceStatus`
- partial index `idx_tasks_pr_number`, `idx_epics_active_spec`

### 04 테스트 갱신
- §4.7 lookup helpers, §4.8 force_status, §4.9 suppression 신설 (기존 4.7 → 4.10)
- §4.2 attempts 시나리오 release_claim 의미 반영
- UC-9 에 EscalationWatcher tick 시나리오 2건
- UC-11 attempts 차감 명시

## 영향 범위
- spec 문서만 수정 (plans/github-autopilot/02,03,04). 코드 영향 없음.
- 머지된 PR #646 의 기존 trait/구현은 본 spec 변경 후 Round 2 구현 시 conformance suite 와 함께 갱신 예정.

## Test plan
- [ ] 03 시그니처와 의사코드의 메서드 명칭 정합 확인 (`grep release_claim|find_task_by_pr|...`)
- [ ] 04 시나리오와 03 시그니처 연결 확인
- [ ] 02 모듈 다이어그램에 EscalationWatcher 반영 확인
- [ ] 후속 Round 2 PR-1 작성 시 본 spec 으로 trait 갱신 가능한지 검토

🤖 Generated with [Claude Code](https://claude.com/claude-code)