### PR TITLE
feat(github-autopilot): expand task store trait per refined spec

### DIFF
--- a/plugins/github-autopilot/cli/src/cmd/task.rs
+++ b/plugins/github-autopilot/cli/src/cmd/task.rs
@@ -109,7 +109,7 @@ impl<'a> TaskService<'a> {
         let id = TaskId::from_raw(task_id);
         let now = self.clock.now();
         self.store
-            .force_status(&id, TaskStatus::from(to), now)
+            .force_status(&id, TaskStatus::from(to), reason.unwrap_or(""), now)
             .with_context(|| format!("forcing status of task '{task_id}'"))?;
         if let Some(r) = reason {
             writeln!(out, "task '{task_id}' status forced to {:?} ({r})", to)?;

--- a/plugins/github-autopilot/cli/src/domain/error.rs
+++ b/plugins/github-autopilot/cli/src/domain/error.rs
@@ -20,4 +20,7 @@ pub enum DomainError {
 
     #[error("duplicate task id in plan: {0}")]
     DuplicateTaskId(TaskId),
+
+    #[error("inconsistency: {0}")]
+    Inconsistency(String),
 }

--- a/plugins/github-autopilot/cli/src/domain/event.rs
+++ b/plugins/github-autopilot/cli/src/domain/event.rs
@@ -31,6 +31,7 @@ pub enum EventKind {
     MigratedFromIssue,
     EscalationResolved,
     WatchDuplicate,
+    TaskForceStatus,
 }
 
 impl EventKind {
@@ -52,6 +53,7 @@ impl EventKind {
             EventKind::MigratedFromIssue => "migrated_from_issue",
             EventKind::EscalationResolved => "escalation_resolved",
             EventKind::WatchDuplicate => "watch_duplicate",
+            EventKind::TaskForceStatus => "task_force_status",
         }
     }
 
@@ -73,6 +75,7 @@ impl EventKind {
             "migrated_from_issue" => EventKind::MigratedFromIssue,
             "escalation_resolved" => EventKind::EscalationResolved,
             "watch_duplicate" => EventKind::WatchDuplicate,
+            "task_force_status" => EventKind::TaskForceStatus,
             _ => return None,
         })
     }

--- a/plugins/github-autopilot/cli/src/ports/task_store.rs
+++ b/plugins/github-autopilot/cli/src/ports/task_store.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use chrono::{DateTime, Utc};
 use thiserror::Error;
 
@@ -106,7 +108,7 @@ pub trait EpicRepo: Send + Sync {
     /// invariant is that at most one active epic owns a given spec; if two
     /// or more are observed, returns [`DomainError::Inconsistency`] so the
     /// caller can surface it rather than silently picking one.
-    fn find_active_by_spec_path(&self, spec_path: &std::path::Path) -> Result<Option<Epic>>;
+    fn find_active_by_spec_path(&self, spec_path: &Path) -> Result<Option<Epic>>;
 }
 
 pub trait TaskRepo: Send + Sync {

--- a/plugins/github-autopilot/cli/src/ports/task_store.rs
+++ b/plugins/github-autopilot/cli/src/ports/task_store.rs
@@ -101,6 +101,12 @@ pub trait EpicRepo: Send + Sync {
     fn get_epic(&self, name: &str) -> Result<Option<Epic>>;
     fn list_epics(&self, status: Option<EpicStatus>) -> Result<Vec<Epic>>;
     fn set_epic_status(&self, name: &str, status: EpicStatus, at: DateTime<Utc>) -> Result<()>;
+
+    /// Returns the unique active epic for `spec_path`, if any. The
+    /// invariant is that at most one active epic owns a given spec; if two
+    /// or more are observed, returns [`DomainError::Inconsistency`] so the
+    /// caller can surface it rather than silently picking one.
+    fn find_active_by_spec_path(&self, spec_path: &std::path::Path) -> Result<Option<Epic>>;
 }
 
 pub trait TaskRepo: Send + Sync {
@@ -111,6 +117,10 @@ pub trait TaskRepo: Send + Sync {
     fn list_tasks_by_epic(&self, epic: &str, status: Option<TaskStatus>) -> Result<Vec<Task>>;
 
     fn find_by_fingerprint(&self, epic: &str, fingerprint: &str) -> Result<Option<Task>>;
+
+    /// Looks up the task that owns a merged PR. Used by `MergeLoop` after a
+    /// PR merges to drive the corresponding task to `Done`.
+    fn find_task_by_pr(&self, pr_number: u64) -> Result<Option<Task>>;
 
     fn upsert_watch_task(&self, task: NewWatchTask, now: DateTime<Utc>) -> Result<UpsertOutcome>;
 
@@ -132,9 +142,24 @@ pub trait TaskRepo: Send + Sync {
 
     fn escalate_task(&self, id: &TaskId, issue_number: u64, now: DateTime<Utc>) -> Result<()>;
 
-    fn revert_to_ready(&self, id: &TaskId, now: DateTime<Utc>) -> Result<()>;
+    /// Releases an unused claim (UC-11 push-reject / claim_lost). Decrements
+    /// `attempts` so the cancelled try does not count toward `max_attempts`.
+    /// Use [`TaskRepo::mark_task_failed`] instead when an attempt was made
+    /// and failed (CI failure, implementer error, ...): that path preserves
+    /// `attempts` and feeds escalation.
+    fn release_claim(&self, id: &TaskId, now: DateTime<Utc>) -> Result<()>;
 
-    fn force_status(&self, id: &TaskId, new_status: TaskStatus, now: DateTime<Utc>) -> Result<()>;
+    /// Operator override (CLI `task force-status`). Bypasses the normal
+    /// transition graph but records `reason` in the emitted event for audit.
+    /// Does NOT cascade dependents (no auto-unblock / auto-block); the
+    /// caller must drive any further reconciliation explicitly.
+    fn force_status(
+        &self,
+        id: &TaskId,
+        target: TaskStatus,
+        reason: &str,
+        now: DateTime<Utc>,
+    ) -> Result<()>;
 
     fn apply_reconciliation(&self, plan: ReconciliationPlan, now: DateTime<Utc>) -> Result<()>;
 
@@ -146,5 +171,21 @@ pub trait EventLog: Send + Sync {
     fn list_events(&self, filter: EventFilter) -> Result<Vec<Event>>;
 }
 
-pub trait TaskStore: EpicRepo + TaskRepo + EventLog + Send + Sync {}
-impl<T: EpicRepo + TaskRepo + EventLog + Send + Sync + ?Sized> TaskStore for T {}
+/// Fingerprint-scoped suppression for HITL escalation (UC-7 unmatched
+/// watch, UC-9c rejected close). Prevents repeat-issue spam for the same
+/// finding within a configurable window.
+pub trait SuppressionRepo: Send + Sync {
+    fn suppress(
+        &self,
+        fingerprint: &str,
+        reason: &str,
+        suppress_until: DateTime<Utc>,
+    ) -> Result<()>;
+
+    fn is_suppressed(&self, fingerprint: &str, reason: &str, now: DateTime<Utc>) -> Result<bool>;
+
+    fn clear(&self, fingerprint: &str, reason: &str) -> Result<()>;
+}
+
+pub trait TaskStore: EpicRepo + TaskRepo + EventLog + SuppressionRepo + Send + Sync {}
+impl<T: EpicRepo + TaskRepo + EventLog + SuppressionRepo + Send + Sync + ?Sized> TaskStore for T {}

--- a/plugins/github-autopilot/cli/src/store/memory.rs
+++ b/plugins/github-autopilot/cli/src/store/memory.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::path::Path;
 use std::sync::Mutex;
 
 use chrono::{DateTime, Utc};
@@ -131,7 +132,7 @@ impl EpicRepo for InMemoryTaskStore {
         Ok(())
     }
 
-    fn find_active_by_spec_path(&self, spec_path: &std::path::Path) -> Result<Option<Epic>> {
+    fn find_active_by_spec_path(&self, spec_path: &Path) -> Result<Option<Epic>> {
         let s = self.state.lock().expect("poisoned");
         let matches: Vec<&Epic> = s
             .epics

--- a/plugins/github-autopilot/cli/src/store/memory.rs
+++ b/plugins/github-autopilot/cli/src/store/memory.rs
@@ -9,7 +9,7 @@ use crate::domain::{
 };
 use crate::ports::task_store::{
     EpicPlan, EpicRepo, EventFilter, EventLog, NewWatchTask, ReconciliationPlan, RemotePrState,
-    Result, TaskRepo, TaskStoreError, UnblockReport, UpsertOutcome,
+    Result, SuppressionRepo, TaskRepo, TaskStoreError, UnblockReport, UpsertOutcome,
 };
 
 #[derive(Default)]
@@ -18,6 +18,7 @@ struct State {
     tasks: BTreeMap<TaskId, Task>,
     deps: Vec<(TaskId, TaskId)>,
     events: Vec<Event>,
+    suppressions: BTreeMap<(String, String), DateTime<Utc>>,
 }
 
 #[derive(Default)]
@@ -128,6 +129,26 @@ impl EpicRepo for InMemoryTaskStore {
         );
         InMemoryTaskStore::push_event(&mut s, event);
         Ok(())
+    }
+
+    fn find_active_by_spec_path(&self, spec_path: &std::path::Path) -> Result<Option<Epic>> {
+        let s = self.state.lock().expect("poisoned");
+        let matches: Vec<&Epic> = s
+            .epics
+            .values()
+            .filter(|e| e.status == EpicStatus::Active && e.spec_path == spec_path)
+            .collect();
+        match matches.as_slice() {
+            [] => Ok(None),
+            [one] => Ok(Some((*one).clone())),
+            many => Err(DomainError::Inconsistency(format!(
+                "{} active epics share spec_path {:?}: {:?}",
+                many.len(),
+                spec_path,
+                many.iter().map(|e| &e.name).collect::<Vec<_>>()
+            ))
+            .into()),
+        }
     }
 }
 
@@ -537,30 +558,61 @@ impl TaskRepo for InMemoryTaskStore {
         Ok(())
     }
 
-    fn revert_to_ready(&self, id: &TaskId, now: DateTime<Utc>) -> Result<()> {
+    fn release_claim(&self, id: &TaskId, now: DateTime<Utc>) -> Result<()> {
         let mut s = self.state.lock().expect("poisoned");
         let task = s
             .tasks
             .get_mut(id)
             .ok_or_else(|| TaskStoreError::NotFound(format!("task '{id}'")))?;
         let cur = task.status;
-        if matches!(cur, TaskStatus::Done | TaskStatus::Escalated) {
+        if cur != TaskStatus::Wip {
             return Err(DomainError::IllegalTransition(id.clone(), cur, TaskStatus::Ready).into());
         }
         task.status = TaskStatus::Ready;
+        task.attempts = task.attempts.saturating_sub(1);
         task.updated_at = now;
         Ok(())
     }
 
-    fn force_status(&self, id: &TaskId, new_status: TaskStatus, now: DateTime<Utc>) -> Result<()> {
+    fn force_status(
+        &self,
+        id: &TaskId,
+        target: TaskStatus,
+        reason: &str,
+        now: DateTime<Utc>,
+    ) -> Result<()> {
         let mut s = self.state.lock().expect("poisoned");
-        let task = s
-            .tasks
-            .get_mut(id)
-            .ok_or_else(|| TaskStoreError::NotFound(format!("task '{id}'")))?;
-        task.status = new_status;
-        task.updated_at = now;
+        let (epic_name, prev) = {
+            let task = s
+                .tasks
+                .get_mut(id)
+                .ok_or_else(|| TaskStoreError::NotFound(format!("task '{id}'")))?;
+            let prev = task.status;
+            task.status = target;
+            task.updated_at = now;
+            (task.epic_name.clone(), prev)
+        };
+        let event = InMemoryTaskStore::make_event(
+            EventKind::TaskForceStatus,
+            Some(epic_name),
+            Some(id.clone()),
+            serde_json::json!({
+                "from": prev.as_str(),
+                "to": target.as_str(),
+                "reason": reason,
+            }),
+            now,
+        );
+        InMemoryTaskStore::push_event(&mut s, event);
         Ok(())
+    }
+
+    fn find_task_by_pr(&self, pr_number: u64) -> Result<Option<Task>> {
+        let s = self.state.lock().expect("poisoned");
+        Ok(s.tasks
+            .values()
+            .find(|t| t.pr_number == Some(pr_number))
+            .cloned())
     }
 
     fn apply_reconciliation(&self, plan: ReconciliationPlan, now: DateTime<Utc>) -> Result<()> {
@@ -714,6 +766,36 @@ fn remote_to_status(r: &crate::ports::task_store::RemoteTaskState, s: &State) ->
             }
         }
         (Some(_), false) => TaskStatus::Wip, // PR open without branch is unusual; treat as wip
+    }
+}
+
+impl SuppressionRepo for InMemoryTaskStore {
+    fn suppress(
+        &self,
+        fingerprint: &str,
+        reason: &str,
+        suppress_until: DateTime<Utc>,
+    ) -> Result<()> {
+        let mut s = self.state.lock().expect("poisoned");
+        s.suppressions.insert(
+            (fingerprint.to_string(), reason.to_string()),
+            suppress_until,
+        );
+        Ok(())
+    }
+
+    fn is_suppressed(&self, fingerprint: &str, reason: &str, now: DateTime<Utc>) -> Result<bool> {
+        let s = self.state.lock().expect("poisoned");
+        Ok(s.suppressions
+            .get(&(fingerprint.to_string(), reason.to_string()))
+            .is_some_and(|until| now < *until))
+    }
+
+    fn clear(&self, fingerprint: &str, reason: &str) -> Result<()> {
+        let mut s = self.state.lock().expect("poisoned");
+        s.suppressions
+            .remove(&(fingerprint.to_string(), reason.to_string()));
+        Ok(())
     }
 }
 

--- a/plugins/github-autopilot/cli/src/store/migrations/V2__lookup_indexes.sql
+++ b/plugins/github-autopilot/cli/src/store/migrations/V2__lookup_indexes.sql
@@ -1,12 +1,8 @@
--- Partial indexes for the lookup helpers added in the spec refinement.
--- find_task_by_pr / find_active_by_spec_path are called frequently from
--- MergeLoop and WatchDispatcher; full scans are unnecessary.
---
--- The indexes are partial because:
---   * Most tasks are not bound to a PR (pr_number IS NULL), so a full
+-- Partial indexes:
+--   * idx_tasks_pr_number — most tasks have pr_number IS NULL, so a full
 --     index would mostly store NULL keys.
---   * Only active epics are matched by spec_path; abandoned/completed
---     epics never participate in WatchDispatcher routing.
+--   * idx_epics_active_spec — abandoned/completed epics never participate
+--     in WatchDispatcher routing, so the index only needs active rows.
 
 CREATE INDEX IF NOT EXISTS idx_tasks_pr_number
   ON tasks(pr_number)

--- a/plugins/github-autopilot/cli/src/store/migrations/V2__lookup_indexes.sql
+++ b/plugins/github-autopilot/cli/src/store/migrations/V2__lookup_indexes.sql
@@ -1,0 +1,19 @@
+-- Partial indexes for the lookup helpers added in the spec refinement.
+-- find_task_by_pr / find_active_by_spec_path are called frequently from
+-- MergeLoop and WatchDispatcher; full scans are unnecessary.
+--
+-- The indexes are partial because:
+--   * Most tasks are not bound to a PR (pr_number IS NULL), so a full
+--     index would mostly store NULL keys.
+--   * Only active epics are matched by spec_path; abandoned/completed
+--     epics never participate in WatchDispatcher routing.
+
+CREATE INDEX IF NOT EXISTS idx_tasks_pr_number
+  ON tasks(pr_number)
+  WHERE pr_number IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_epics_active_spec
+  ON epics(spec_path)
+  WHERE status = 'active';
+
+UPDATE meta SET value = '2' WHERE key = 'schema_version';

--- a/plugins/github-autopilot/cli/src/store/sqlite.rs
+++ b/plugins/github-autopilot/cli/src/store/sqlite.rs
@@ -15,12 +15,13 @@ use crate::domain::{
     TaskSource, TaskStatus,
 };
 use crate::ports::task_store::{
-    EpicPlan, EpicRepo, EventFilter, EventLog, NewWatchTask, ReconciliationPlan, Result, TaskRepo,
-    TaskStoreError, UnblockReport, UpsertOutcome,
+    EpicPlan, EpicRepo, EventFilter, EventLog, NewWatchTask, ReconciliationPlan, Result,
+    SuppressionRepo, TaskRepo, TaskStoreError, UnblockReport, UpsertOutcome,
 };
 
-const SCHEMA_VERSION: u32 = 1;
+const SCHEMA_VERSION: u32 = 2;
 const V1_SQL: &str = include_str!("migrations/V1__initial.sql");
+const V2_SQL: &str = include_str!("migrations/V2__lookup_indexes.sql");
 
 pub struct SqliteTaskStore {
     conn: Mutex<Connection>,
@@ -63,6 +64,7 @@ impl SqliteTaskStore {
 
         if !has_meta {
             conn.execute_batch(V1_SQL).map_err(backend)?;
+            conn.execute_batch(V2_SQL).map_err(backend)?;
             return Ok(());
         }
 
@@ -82,6 +84,10 @@ impl SqliteTaskStore {
                 found,
                 expected: SCHEMA_VERSION,
             });
+        }
+
+        if found < 2 {
+            conn.execute_batch(V2_SQL).map_err(backend)?;
         }
         Ok(())
     }
@@ -284,6 +290,32 @@ impl EpicRepo for SqliteTaskStore {
         )
         .map_err(backend)?;
         Ok(())
+    }
+
+    fn find_active_by_spec_path(&self, spec_path: &std::path::Path) -> Result<Option<Epic>> {
+        let conn = self.conn.lock().expect("poisoned");
+        let path_str = spec_path.to_string_lossy().to_string();
+        let mut stmt = conn
+            .prepare(
+                "SELECT * FROM epics WHERE status='active' AND spec_path=? ORDER BY name LIMIT 2",
+            )
+            .map_err(backend)?;
+        let mut rows = stmt
+            .query_map(params![path_str], epic_from_row)
+            .map_err(backend)?;
+        let first = match rows.next() {
+            None => return Ok(None),
+            Some(r) => r.map_err(backend)?,
+        };
+        if let Some(second) = rows.next() {
+            let second = second.map_err(backend)?;
+            return Err(DomainError::Inconsistency(format!(
+                "active epics share spec_path {path_str:?}: {} vs {}",
+                first.name, second.name
+            ))
+            .into());
+        }
+        Ok(Some(first))
     }
 }
 
@@ -819,7 +851,7 @@ impl TaskRepo for SqliteTaskStore {
         Ok(())
     }
 
-    fn revert_to_ready(&self, id: &TaskId, now: DateTime<Utc>) -> Result<()> {
+    fn release_claim(&self, id: &TaskId, now: DateTime<Utc>) -> Result<()> {
         let conn = self.conn.lock().expect("poisoned");
         let cur: Option<String> = conn
             .query_row(
@@ -832,31 +864,72 @@ impl TaskRepo for SqliteTaskStore {
         let cur = cur.ok_or_else(|| TaskStoreError::NotFound(format!("task '{id}'")))?;
         let cur_status = TaskStatus::parse(&cur)
             .ok_or_else(|| TaskStoreError::Backend(format!("invalid stored task status: {cur}")))?;
-        if matches!(cur_status, TaskStatus::Done | TaskStatus::Escalated) {
+        if cur_status != TaskStatus::Wip {
             return Err(
                 DomainError::IllegalTransition(id.clone(), cur_status, TaskStatus::Ready).into(),
             );
         }
         conn.execute(
-            "UPDATE tasks SET status='ready', updated_at=? WHERE id=?",
+            "UPDATE tasks
+                SET status='ready',
+                    attempts = MAX(attempts - 1, 0),
+                    updated_at=?
+              WHERE id=? AND status='wip'",
             params![now, id.as_str()],
         )
         .map_err(backend)?;
         Ok(())
     }
 
-    fn force_status(&self, id: &TaskId, new_status: TaskStatus, now: DateTime<Utc>) -> Result<()> {
+    fn force_status(
+        &self,
+        id: &TaskId,
+        target: TaskStatus,
+        reason: &str,
+        now: DateTime<Utc>,
+    ) -> Result<()> {
         let conn = self.conn.lock().expect("poisoned");
-        let updated = conn
-            .execute(
-                "UPDATE tasks SET status=?, updated_at=? WHERE id=?",
-                params![new_status.as_str(), now, id.as_str()],
+        let prev: Option<(String, String)> = conn
+            .query_row(
+                "SELECT epic_name, status FROM tasks WHERE id=?",
+                params![id.as_str()],
+                |row| Ok((row.get(0)?, row.get(1)?)),
             )
+            .optional()
             .map_err(backend)?;
-        if updated == 0 {
-            return Err(TaskStoreError::NotFound(format!("task '{id}'")));
-        }
+        let (epic_name, prev_status_str) =
+            prev.ok_or_else(|| TaskStoreError::NotFound(format!("task '{id}'")))?;
+        conn.execute(
+            "UPDATE tasks SET status=?, updated_at=? WHERE id=?",
+            params![target.as_str(), now, id.as_str()],
+        )
+        .map_err(backend)?;
+        SqliteTaskStore::append_event_with(
+            &conn,
+            EventKind::TaskForceStatus,
+            Some(&epic_name),
+            Some(id),
+            &serde_json::json!({
+                "from": prev_status_str,
+                "to": target.as_str(),
+                "reason": reason,
+            }),
+            now,
+        )
+        .map_err(backend)?;
         Ok(())
+    }
+
+    fn find_task_by_pr(&self, pr_number: u64) -> Result<Option<Task>> {
+        let conn = self.conn.lock().expect("poisoned");
+        let mut stmt = conn
+            .prepare("SELECT * FROM tasks WHERE pr_number=? LIMIT 1")
+            .map_err(backend)?;
+        let task = stmt
+            .query_row(params![pr_number as i64], task_from_row)
+            .optional()
+            .map_err(backend)?;
+        Ok(task)
     }
 
     fn apply_reconciliation(&self, plan: ReconciliationPlan, now: DateTime<Utc>) -> Result<()> {
@@ -1084,6 +1157,49 @@ impl TaskRepo for SqliteTaskStore {
     }
 }
 
+impl SuppressionRepo for SqliteTaskStore {
+    fn suppress(
+        &self,
+        fingerprint: &str,
+        reason: &str,
+        suppress_until: DateTime<Utc>,
+    ) -> Result<()> {
+        let conn = self.conn.lock().expect("poisoned");
+        conn.execute(
+            "INSERT INTO escalation_suppression(fingerprint, reason, suppress_until)
+             VALUES (?, ?, ?)
+             ON CONFLICT(fingerprint, reason) DO UPDATE SET suppress_until=excluded.suppress_until",
+            params![fingerprint, reason, suppress_until],
+        )
+        .map_err(backend)?;
+        Ok(())
+    }
+
+    fn is_suppressed(&self, fingerprint: &str, reason: &str, now: DateTime<Utc>) -> Result<bool> {
+        let conn = self.conn.lock().expect("poisoned");
+        let until: Option<DateTime<Utc>> = conn
+            .query_row(
+                "SELECT suppress_until FROM escalation_suppression
+                 WHERE fingerprint=? AND reason=?",
+                params![fingerprint, reason],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(backend)?;
+        Ok(until.is_some_and(|u| now < u))
+    }
+
+    fn clear(&self, fingerprint: &str, reason: &str) -> Result<()> {
+        let conn = self.conn.lock().expect("poisoned");
+        conn.execute(
+            "DELETE FROM escalation_suppression WHERE fingerprint=? AND reason=?",
+            params![fingerprint, reason],
+        )
+        .map_err(backend)?;
+        Ok(())
+    }
+}
+
 impl EventLog for SqliteTaskStore {
     fn append_event(&self, event: &Event) -> Result<()> {
         let conn = self.conn.lock().expect("poisoned");
@@ -1148,7 +1264,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn open_in_memory_initializes_schema_v1() {
+    fn open_in_memory_initializes_to_current_schema() {
         let store = SqliteTaskStore::open_in_memory().expect("open");
         let conn = store.conn.lock().unwrap();
         let v: String = conn
@@ -1158,7 +1274,24 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(v, "1");
+        assert_eq!(v, SCHEMA_VERSION.to_string());
+    }
+
+    #[test]
+    fn migrates_v1_db_to_current() {
+        // Simulate an older DB at V1: only V1 SQL applied. open() should
+        // upgrade by running V2 forward migrations.
+        let mut conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(V1_SQL).unwrap();
+        SqliteTaskStore::migrate(&mut conn).unwrap();
+        let v: String = conn
+            .query_row(
+                "SELECT value FROM meta WHERE key='schema_version'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(v, SCHEMA_VERSION.to_string());
     }
 
     #[test]
@@ -1174,7 +1307,7 @@ mod tests {
         match err {
             TaskStoreError::SchemaMismatch { found, expected } => {
                 assert_eq!(found, 999);
-                assert_eq!(expected, 1);
+                assert_eq!(expected, SCHEMA_VERSION);
             }
             other => panic!("expected SchemaMismatch, got {other:?}"),
         }

--- a/plugins/github-autopilot/cli/src/store/sqlite.rs
+++ b/plugins/github-autopilot/cli/src/store/sqlite.rs
@@ -1281,6 +1281,25 @@ mod tests {
     }
 
     #[test]
+    fn v2_lookup_indexes_are_present() {
+        let store = SqliteTaskStore::open_in_memory().expect("open");
+        let conn = store.conn.lock().unwrap();
+        let mut stmt = conn
+            .prepare(
+                "SELECT name FROM sqlite_master
+                  WHERE type='index' AND name IN ('idx_tasks_pr_number','idx_epics_active_spec')",
+            )
+            .unwrap();
+        let names: std::collections::HashSet<String> = stmt
+            .query_map([], |row| row.get::<_, String>(0))
+            .unwrap()
+            .collect::<rusqlite::Result<_>>()
+            .unwrap();
+        assert!(names.contains("idx_tasks_pr_number"));
+        assert!(names.contains("idx_epics_active_spec"));
+    }
+
+    #[test]
     fn migrates_v1_db_to_current() {
         // Simulate an older DB at V1: only V1 SQL applied. open() should
         // upgrade by running V2 forward migrations.

--- a/plugins/github-autopilot/cli/src/store/sqlite.rs
+++ b/plugins/github-autopilot/cli/src/store/sqlite.rs
@@ -292,7 +292,7 @@ impl EpicRepo for SqliteTaskStore {
         Ok(())
     }
 
-    fn find_active_by_spec_path(&self, spec_path: &std::path::Path) -> Result<Option<Epic>> {
+    fn find_active_by_spec_path(&self, spec_path: &Path) -> Result<Option<Epic>> {
         let conn = self.conn.lock().expect("poisoned");
         let path_str = spec_path.to_string_lossy().to_string();
         let mut stmt = conn
@@ -899,6 +899,9 @@ impl TaskRepo for SqliteTaskStore {
             .map_err(backend)?;
         let (epic_name, prev_status_str) =
             prev.ok_or_else(|| TaskStoreError::NotFound(format!("task '{id}'")))?;
+        let prev = TaskStatus::parse(&prev_status_str).ok_or_else(|| {
+            TaskStoreError::Backend(format!("invalid stored task status: {prev_status_str}"))
+        })?;
         conn.execute(
             "UPDATE tasks SET status=?, updated_at=? WHERE id=?",
             params![target.as_str(), now, id.as_str()],
@@ -910,7 +913,7 @@ impl TaskRepo for SqliteTaskStore {
             Some(&epic_name),
             Some(id),
             &serde_json::json!({
-                "from": prev_status_str,
+                "from": prev.as_str(),
                 "to": target.as_str(),
                 "reason": reason,
             }),

--- a/plugins/github-autopilot/cli/tests/store_conformance.rs
+++ b/plugins/github-autopilot/cli/tests/store_conformance.rs
@@ -152,12 +152,42 @@ fn body_claim_skips_tasks_with_unsatisfied_deps(store: Arc<dyn TaskStore>) {
     assert!(claimed_again.is_none());
 }
 
-fn body_claim_increments_attempts_on_each_call_after_revert(store: Arc<dyn TaskStore>) {
+fn body_release_claim_decrements_attempts(store: Arc<dyn TaskStore>) {
+    // claim → release_claim (UC-11 claim_lost) → claim should leave attempts at 1,
+    // not 2. release_claim cancels the bookkeeping +1 from claim so that lost
+    // claims do not consume an attempt budget.
     store
         .insert_epic_with_tasks(plan("e", vec![nt("A", "a")], vec![]), t0())
         .unwrap();
     let _ = store.claim_next_task("e", t0()).unwrap().unwrap();
-    store.revert_to_ready(&TaskId::from_raw("A"), t0()).unwrap();
+    store.release_claim(&TaskId::from_raw("A"), t0()).unwrap();
+    let claimed = store.claim_next_task("e", t0()).unwrap().unwrap();
+    assert_eq!(claimed.attempts, 1);
+}
+
+fn body_release_claim_rejects_non_wip(store: Arc<dyn TaskStore>) {
+    store
+        .insert_epic_with_tasks(plan("e", vec![nt("A", "a")], vec![]), t0())
+        .unwrap();
+    let err = store
+        .release_claim(&TaskId::from_raw("A"), t0())
+        .unwrap_err();
+    assert!(
+        format!("{err}").contains("illegal status transition"),
+        "expected illegal-transition, got: {err}"
+    );
+}
+
+fn body_mark_failed_preserves_attempts_for_retry(store: Arc<dyn TaskStore>) {
+    // Tried-and-failed should preserve the attempt count so that escalation
+    // counts toward max_attempts. Distinct from release_claim semantics.
+    store
+        .insert_epic_with_tasks(plan("e", vec![nt("A", "a")], vec![]), t0())
+        .unwrap();
+    let _ = store.claim_next_task("e", t0()).unwrap().unwrap();
+    let _ = store
+        .mark_task_failed(&TaskId::from_raw("A"), 3, t0())
+        .unwrap();
     let claimed = store.claim_next_task("e", t0()).unwrap().unwrap();
     assert_eq!(claimed.attempts, 2);
 }
@@ -403,6 +433,148 @@ fn body_upsert_watch_task_returns_duplicate_on_existing_fingerprint(store: Arc<d
     assert_eq!(tasks.len(), 1);
 }
 
+fn body_find_task_by_pr_returns_owning_task(store: Arc<dyn TaskStore>) {
+    store
+        .insert_epic_with_tasks(plan("e", vec![nt("A", "a"), nt("B", "b")], vec![]), t0())
+        .unwrap();
+    let _ = store.claim_next_task("e", t0()).unwrap().unwrap();
+    store
+        .complete_task_and_unblock(&TaskId::from_raw("A"), 42, t0())
+        .unwrap();
+    let found = store.find_task_by_pr(42).unwrap().unwrap();
+    assert_eq!(found.id.as_str(), "A");
+}
+
+fn body_find_task_by_pr_returns_none_when_unknown(store: Arc<dyn TaskStore>) {
+    assert!(store.find_task_by_pr(9999).unwrap().is_none());
+}
+
+fn body_find_active_by_spec_path_matches_active_only(store: Arc<dyn TaskStore>) {
+    store
+        .insert_epic_with_tasks(plan("e1", vec![], vec![]), t0())
+        .unwrap();
+    store
+        .insert_epic_with_tasks(plan("e2", vec![], vec![]), t0())
+        .unwrap();
+    store
+        .set_epic_status("e2", EpicStatus::Abandoned, t0() + Duration::seconds(1))
+        .unwrap();
+    let path = std::path::PathBuf::from("spec/e1.md");
+    let found = store.find_active_by_spec_path(&path).unwrap().unwrap();
+    assert_eq!(found.name, "e1");
+}
+
+fn body_find_active_by_spec_path_returns_none_when_no_match(store: Arc<dyn TaskStore>) {
+    store
+        .insert_epic_with_tasks(plan("e1", vec![], vec![]), t0())
+        .unwrap();
+    let path = std::path::PathBuf::from("spec/elsewhere.md");
+    assert!(store.find_active_by_spec_path(&path).unwrap().is_none());
+}
+
+fn body_force_status_bypasses_normal_transition(store: Arc<dyn TaskStore>) {
+    store
+        .insert_epic_with_tasks(plan("e", vec![nt("A", "a")], vec![]), t0())
+        .unwrap();
+    // Drive A into Escalated via the normal failure path, then jump straight
+    // back to Pending — a transition the normal graph would forbid.
+    for _ in 0..3 {
+        let _ = store.claim_next_task("e", t0()).unwrap().unwrap();
+        let _ = store
+            .mark_task_failed(&TaskId::from_raw("A"), 3, t0())
+            .unwrap();
+    }
+    store
+        .force_status(
+            &TaskId::from_raw("A"),
+            TaskStatus::Pending,
+            "manual reset",
+            t0(),
+        )
+        .unwrap();
+    let a = store.get_task(&TaskId::from_raw("A")).unwrap().unwrap();
+    assert_eq!(a.status, TaskStatus::Pending);
+}
+
+fn body_force_status_does_not_unblock_dependents(store: Arc<dyn TaskStore>) {
+    // After parent A is forced to Done, child B should remain Blocked —
+    // force_status is an operator override, not a normal completion.
+    store
+        .insert_epic_with_tasks(
+            plan("e", vec![nt("A", "a"), nt("B", "b")], vec![("B", "A")]),
+            t0(),
+        )
+        .unwrap();
+    for _ in 0..3 {
+        let _ = store.claim_next_task("e", t0()).unwrap().unwrap();
+        let _ = store
+            .mark_task_failed(&TaskId::from_raw("A"), 3, t0())
+            .unwrap();
+    }
+    let b_before = store.get_task(&TaskId::from_raw("B")).unwrap().unwrap();
+    assert_eq!(b_before.status, TaskStatus::Blocked);
+    store
+        .force_status(
+            &TaskId::from_raw("A"),
+            TaskStatus::Done,
+            "human fixed",
+            t0(),
+        )
+        .unwrap();
+    let b_after = store.get_task(&TaskId::from_raw("B")).unwrap().unwrap();
+    assert_eq!(b_after.status, TaskStatus::Blocked);
+}
+
+fn body_force_status_records_event_with_reason(store: Arc<dyn TaskStore>) {
+    store
+        .insert_epic_with_tasks(plan("e", vec![nt("A", "a")], vec![]), t0())
+        .unwrap();
+    store
+        .force_status(
+            &TaskId::from_raw("A"),
+            TaskStatus::Pending,
+            "rollback for repro",
+            t0(),
+        )
+        .unwrap();
+    let evs = store
+        .list_events(EventFilter {
+            kinds: vec![EventKind::TaskForceStatus],
+            ..Default::default()
+        })
+        .unwrap();
+    assert_eq!(evs.len(), 1);
+    assert_eq!(evs[0].payload["reason"], "rollback for repro");
+    assert_eq!(evs[0].payload["to"], "pending");
+}
+
+fn body_suppression_blocks_until_window_expires(store: Arc<dyn TaskStore>) {
+    let until = t0() + Duration::hours(1);
+    store.suppress("fp-1", "unmatched_watch", until).unwrap();
+    assert!(store
+        .is_suppressed("fp-1", "unmatched_watch", t0() + Duration::minutes(30))
+        .unwrap());
+    assert!(!store
+        .is_suppressed("fp-1", "unmatched_watch", t0() + Duration::hours(2))
+        .unwrap());
+}
+
+fn body_suppression_is_scoped_by_reason(store: Arc<dyn TaskStore>) {
+    store
+        .suppress("fp-1", "unmatched_watch", t0() + Duration::hours(1))
+        .unwrap();
+    assert!(!store
+        .is_suppressed("fp-1", "rejected_by_human", t0())
+        .unwrap());
+}
+
+fn body_suppression_clear_unblocks_immediately(store: Arc<dyn TaskStore>) {
+    let until = t0() + Duration::days(30);
+    store.suppress("fp-1", "r", until).unwrap();
+    store.clear("fp-1", "r").unwrap();
+    assert!(!store.is_suppressed("fp-1", "r", t0()).unwrap());
+}
+
 macro_rules! conformance_suite {
     ($($name:ident),* $(,)?) => {
         mod in_memory {
@@ -440,7 +612,9 @@ conformance_suite!(
     body_claim_returns_none_when_no_ready_task,
     body_claim_returns_oldest_ready_task,
     body_claim_skips_tasks_with_unsatisfied_deps,
-    body_claim_increments_attempts_on_each_call_after_revert,
+    body_release_claim_decrements_attempts,
+    body_release_claim_rejects_non_wip,
+    body_mark_failed_preserves_attempts_for_retry,
     body_claim_is_atomic_under_concurrent_callers,
     body_completing_a_task_unblocks_dependents_with_satisfied_deps,
     body_complete_rejects_when_status_not_wip,
@@ -451,6 +625,16 @@ conformance_suite!(
     body_reconcile_preserves_attempts_counter,
     body_upsert_watch_task_inserts_new_when_no_fingerprint_match,
     body_upsert_watch_task_returns_duplicate_on_existing_fingerprint,
+    body_find_task_by_pr_returns_owning_task,
+    body_find_task_by_pr_returns_none_when_unknown,
+    body_find_active_by_spec_path_matches_active_only,
+    body_find_active_by_spec_path_returns_none_when_no_match,
+    body_force_status_bypasses_normal_transition,
+    body_force_status_does_not_unblock_dependents,
+    body_force_status_records_event_with_reason,
+    body_suppression_blocks_until_window_expires,
+    body_suppression_is_scoped_by_reason,
+    body_suppression_clear_unblocks_immediately,
 );
 
 #[test]

--- a/plugins/github-autopilot/cli/tests/store_conformance.rs
+++ b/plugins/github-autopilot/cli/tests/store_conformance.rs
@@ -153,9 +153,6 @@ fn body_claim_skips_tasks_with_unsatisfied_deps(store: Arc<dyn TaskStore>) {
 }
 
 fn body_release_claim_decrements_attempts(store: Arc<dyn TaskStore>) {
-    // claim → release_claim (UC-11 claim_lost) → claim should leave attempts at 1,
-    // not 2. release_claim cancels the bookkeeping +1 from claim so that lost
-    // claims do not consume an attempt budget.
     store
         .insert_epic_with_tasks(plan("e", vec![nt("A", "a")], vec![]), t0())
         .unwrap();
@@ -179,8 +176,6 @@ fn body_release_claim_rejects_non_wip(store: Arc<dyn TaskStore>) {
 }
 
 fn body_mark_failed_preserves_attempts_for_retry(store: Arc<dyn TaskStore>) {
-    // Tried-and-failed should preserve the attempt count so that escalation
-    // counts toward max_attempts. Distinct from release_claim semantics.
     store
         .insert_epic_with_tasks(plan("e", vec![nt("A", "a")], vec![]), t0())
         .unwrap();
@@ -476,8 +471,6 @@ fn body_force_status_bypasses_normal_transition(store: Arc<dyn TaskStore>) {
     store
         .insert_epic_with_tasks(plan("e", vec![nt("A", "a")], vec![]), t0())
         .unwrap();
-    // Drive A into Escalated via the normal failure path, then jump straight
-    // back to Pending — a transition the normal graph would forbid.
     for _ in 0..3 {
         let _ = store.claim_next_task("e", t0()).unwrap().unwrap();
         let _ = store
@@ -497,8 +490,6 @@ fn body_force_status_bypasses_normal_transition(store: Arc<dyn TaskStore>) {
 }
 
 fn body_force_status_does_not_unblock_dependents(store: Arc<dyn TaskStore>) {
-    // After parent A is forced to Done, child B should remain Blocked —
-    // force_status is an operator override, not a normal completion.
     store
         .insert_epic_with_tasks(
             plan("e", vec![nt("A", "a"), nt("B", "b")], vec![("B", "A")]),

--- a/plugins/github-autopilot/cli/tests/store_conformance.rs
+++ b/plugins/github-autopilot/cli/tests/store_conformance.rs
@@ -467,6 +467,25 @@ fn body_find_active_by_spec_path_returns_none_when_no_match(store: Arc<dyn TaskS
     assert!(store.find_active_by_spec_path(&path).unwrap().is_none());
 }
 
+fn body_find_active_by_spec_path_rejects_invariant_violation(store: Arc<dyn TaskStore>) {
+    let shared = std::path::PathBuf::from("spec/shared.md");
+    let mk = |name: &str| Epic {
+        name: name.to_string(),
+        spec_path: shared.clone(),
+        branch: format!("epic/{name}"),
+        status: EpicStatus::Active,
+        created_at: t0(),
+        completed_at: None,
+    };
+    store.upsert_epic(&mk("e1")).unwrap();
+    store.upsert_epic(&mk("e2")).unwrap();
+    let err = store.find_active_by_spec_path(&shared).unwrap_err();
+    assert!(
+        format!("{err}").contains("inconsistency"),
+        "expected Inconsistency error, got: {err}"
+    );
+}
+
 fn body_force_status_bypasses_normal_transition(store: Arc<dyn TaskStore>) {
     store
         .insert_epic_with_tasks(plan("e", vec![nt("A", "a")], vec![]), t0())
@@ -620,6 +639,7 @@ conformance_suite!(
     body_find_task_by_pr_returns_none_when_unknown,
     body_find_active_by_spec_path_matches_active_only,
     body_find_active_by_spec_path_returns_none_when_no_match,
+    body_find_active_by_spec_path_rejects_invariant_violation,
     body_force_status_bypasses_normal_transition,
     body_force_status_does_not_unblock_dependents,
     body_force_status_records_event_with_reason,


### PR DESCRIPTION
## Summary
PR #648 의 spec 정제를 코드에 반영. 트레이트 시그니처/이름이 spec 과 1:1 정합되며 양쪽 어댑터 (in-memory, SQLite) 가 LSP 만족.

epic 브랜치 base. Round 2 PR-1a (3분할 중 첫 번째).

## 신규/변경 트레이트 메서드

### 추가
- `TaskRepo::find_task_by_pr(pr_number)` — MergeLoop 가 PR 머지 후 owner task 를 Done 으로 전이할 때 사용
- `EpicRepo::find_active_by_spec_path(path)` — WatchDispatcher 의 `epic_for_spec` 실체. invariant 위반 시 \`DomainError::Inconsistency\`
- `SuppressionRepo` 신규 trait — \`suppress\` / \`is_suppressed\` / \`clear\`. \`escalation_suppression\` 테이블 사용. \`TaskStore\` 슈퍼트레이트에 합쳐짐

### 의미 변경
- `revert_to_ready` → `release_claim`: status wip→ready **+ attempts -1**. UC-11 claim_lost 가 attempt budget 을 소비하지 않게 함. \`mark_task_failed\` 는 기존대로 attempts 보존
- `force_status` 시그니처: \`reason: &str\` 추가. \`TaskForceStatus\` 이벤트로 \`{from, to, reason}\` 기록. 자식 unblock 자동화 안 함 (운영자 override)

### 도메인
- `EventKind::TaskForceStatus`
- `DomainError::Inconsistency(String)`

## 스키마 V2

\`migrations/V2__lookup_indexes.sql\`:
- \`idx_tasks_pr_number\` partial index (pr_number IS NOT NULL)
- \`idx_epics_active_spec\` partial index (status='active')

V1 → V2 마이그레이션 경로 검증 (\`migrates_v1_db_to_current\` test).

## 테스트

Conformance suite 28 bodies × 2 stores = **56 LSP tests** + 1 standalone = 59. 모두 통과.

신규 시나리오:
- \`release_claim_decrements_attempts\` — claim → release_claim → claim 후 attempts==1 (2 아님)
- \`release_claim_rejects_non_wip\` — Wip 아닌 상태에서 호출 시 IllegalTransition
- \`mark_failed_preserves_attempts_for_retry\` — release_claim 과 의미 분리 검증
- \`find_task_by_pr_returns_owning_task\` / \`returns_none_when_unknown\`
- \`find_active_by_spec_path_matches_active_only\` / \`returns_none_when_no_match\`
- \`force_status_bypasses_normal_transition\`
- \`force_status_does_not_unblock_dependents\`
- \`force_status_records_event_with_reason\`
- \`suppression_blocks_until_window_expires\` / \`is_scoped_by_reason\` / \`clear_unblocks_immediately\`

## 영향 범위

- 외부 API: \`autopilot task force-status\` CLI 시그니처 동일 (내부에서 reason 추가 전달)
- DB 스키마: 새 인덱스만 추가 (기존 데이터 유지)
- 타 서브커맨드 (watch/build/issue 등): 영향 없음 (직접 트레이트 호출 안 함)

## 후속 PR
- **PR-1b**: 신규 포트 (GitClient, SpecDecomposer + Fake)
- **PR-1c**: EpicManager::start + cmd/epic start

## CI 검증
- \`cargo fmt --check\` ✓
- \`cargo clippy -- -D warnings\` ✓
- \`cargo check\` ✓
- \`cargo test\` (107 lib + 59 conformance + 91 integration) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)