### PR TITLE
docs(github-autopilot): rework spec for ledger model

### DIFF
--- a/plans/github-autopilot/00-concept.md
+++ b/plans/github-autopilot/00-concept.md
@@ -196,71 +196,111 @@ task_id = sha256(epic_name || ":" || section_path || ":" || requirement_slug)[:1
 
 ## 4. Reconciliation 프로토콜
 
-`epic-start` 또는 `epic-resume` 시 다음 절차로 로컬 DB 를 리모트와 동기화한다.
+Epic 재개 / DB 손실 복구 / 사람의 직접 push 인식 시 사용한다. **Agent 가 정보를 모아 autopilot CLI 에 한 번에 넘긴다** — autopilot 은 받은 plan 을 idempotent 하게 적용할 뿐 git/spec 을 직접 만지지 않는다.
 
 ```
-1. spec 분해 → 기대 task 목록 (결정적 ID 부여)
-2. git fetch origin
-3. 리모트 브랜치 스캔: "epic/<name>" 및 "epic/<name>/*"
-4. 머지된 PR 스캔: target = "epic/<name>"
-5. 매칭하여 status 결정:
-   - PR merged                    → done
-   - feature 브랜치 + open PR     → wip (검토중)
-   - feature 브랜치 + PR 없음    → wip (구현중) 또는 stale 후보
-   - 브랜치 없음                  → ready (deps 만족 시) 또는 pending
-6. 분해 결과에 없는데 DB 에만 남은 task → orphan 으로 표시 (사람 검토 대상)
-7. DB 에 신규 행 insert / 기존 행 update
+[Agent 측]
+  1. monitor 호출 → 기대 task 목록 + 의존성 (결정적 ID 부여)
+  2. git fetch origin
+  3. ls-remote: "epic/<name>" 및 "epic/<name>/*"
+  4. PR 스캔: target = "epic/<name>"
+  5. 매칭하여 RemoteTaskState 빌드:
+     - PR merged                    → done
+     - feature 브랜치 + open PR     → wip (검토중)
+     - feature 브랜치 + PR 없음    → wip (구현중) 또는 stale 후보
+     - 브랜치 없음                  → ready (deps 만족 시) 또는 pending
+  6. 분해 결과에 없는 epic/<name>/* 브랜치 목록 → orphan_branches 로 모음
+
+[Agent → Autopilot CLI]
+  autopilot epic reconcile --name <name> --plan <jsonl>
+    (또는 --tasks-from + --remote-state 분리 옵션)
+
+[Autopilot 측]
+  7. plan 검증 (cycle, 알 수 없는 deps, ...)
+  8. tasks upsert + deps 갱신 + status 적용 + reconciled 이벤트 기록
 ```
 
-이 절차는 **idempotent** 해야 한다. 동일 epic 에 대해 N번 reconcile 해도 결과가 같아야 하며, 재시도 안전하다.
+이 절차는 **idempotent** 해야 한다. 동일 plan 으로 N번 호출해도 결과가 같아야 하며, 재시도 안전하다. attempts 카운터는 보존된다 (DB 손실 시는 0 으로 초기화 — 허용 손실).
 
-## 5. 명령 / 에이전트 변화 매트릭스
+## 5. 책임 분리 — Ledger 모델
 
-### 5.1 신규
+autopilot 은 **상태 관리 + CLI 표면** 만 책임진다. 탐지 / 결정 / 구현은 **외부 에이전트 (Agent)** 가 수행하고, autopilot 은 그 에이전트가 호출하는 도구로 위치한다.
+
+```
+┌─ Agent (Claude Code 세션, GitHub Actions, autodev 등) ─┐
+│  - monitor 호출 (gap 탐지)                              │
+│  - autopilot CLI 호출 (task 적재 / claim / 결과 보고)   │
+│  - 직접 구현 + git/PR 조작                              │
+│  - escalation 이슈 발행 / 알림                          │
+└────────────────────────────────────────────────────────┘
+                        ↓ CLI
+┌─ Autopilot ────────────────────────────────────────────┐
+│  - state.db 관리 (epics / tasks / events / suppression)│
+│  - 결정적 상태 전이 (claim 원자성, deps 재평가, ...)   │
+│  - 헬퍼 명령 (worktree, label, issue, watch, ...)      │
+└────────────────────────────────────────────────────────┘
+```
+
+### 5.1 Autopilot 의 책임 표면
+
+**A. Ledger CLI** (신규 — Round 2 이후 추가)
+
+| 그룹 | 명령 (요지) | 역할 |
+|------|------------|------|
+| epic | `epic create / list / get / status / complete / abandon / reconcile` | epic 행 CRUD + 라이프사이클 전이 |
+| task | `task add / list / get / claim / release / complete / fail / escalate / force-status / find-by-pr` | task 행 CRUD + 상태 전이 (원자성 보장) |
+| suppress | `suppress add / check / clear` | escalation fingerprint 억제 |
+| events | `events list` | audit 로그 조회 |
+
+**B. 헬퍼 명령** (기존 유지 — 의사결정 없는 순수 도구)
 
 | 명령 | 역할 |
 |------|------|
-| `/github-autopilot:epic-start <spec-path>` | epic 브랜치 생성 + spec 분해 + task 적재 + 그 epic 스코프 루프 시작 |
-| `/github-autopilot:epic-resume <epic-name>` | 기존 epic 의 상태를 리모트 기준으로 reconcile 후 루프 재개 |
-| `/github-autopilot:epic-status [epic-name]` | epic / task 상태 대시보드 (사람용) |
-| `/github-autopilot:epic-stop <epic-name>` | 해당 epic 의 루프 종료 (수동) |
+| `worktree` | git worktree CRUD |
+| `simhash` | fingerprint 해싱 |
+| `labels` | GitHub 라벨 CRUD |
+| `issue`, `issue list` | GitHub 이슈 CRUD (gh wrapping) |
+| `preflight` | 환경 검증 |
+| `stats`, `check` | 읽기 전용 분석 |
+| `pipeline idle` | 라벨 기반 idle 판정 (count 기반) |
+| `watch run` | 외부 변화를 JSON 이벤트로 stdout 에 emit (long-poll, 의사결정 없음) |
 
-### 5.2 변경
+이 헬퍼들은 **에이전트의 도구** 로 분류한다. 에이전트가 필요할 때 호출하고, 출력을 보고 결정한다.
 
-| 명령 / 에이전트 | 변경점 |
-|----------------|--------|
-| `gap-watch` | 발견 시 활성 epic 매칭 → task append. 매칭 실패 시 HITL 이슈 escalate |
-| `qa-boost` | 동일 (활성 epic 매칭 → task append, 실패 시 escalate) |
-| `ci-watch` | epic 브랜치 / task 브랜치의 CI 실패는 해당 task 의 attempts 증가. main 의 CI 실패는 escalate |
-| `build-issues` → `build-tasks` | 입력 소스 변경: `:ready` 라벨 쿼리 → SQLite `WHERE status='ready'` |
-| `branch-promoter` | PR target: main → 해당 epic 브랜치 |
-| `analyze-issue` | HITL 이슈 분석 후 ready 판정 시: 이슈를 활성 epic 의 task 로 흡수 (이슈 번호를 task 메타에 기록) |
-| `merge-prs` | 동작 동일 (`:auto` 라벨 PR 머지). 단 머지 후 task status 업데이트 추가 |
+### 5.2 Agent 의 책임 (autopilot 외부)
 
-### 5.3 제거 / 폐기
+| 책임 | 설명 |
+|------|------|
+| **갭 탐지** | monitor (예: `gap-detector`, `qa-boost`) 호출. 결과를 autopilot CLI 로 task 화 |
+| **분해 정책** | spec-kit 재사용 / 자체 markdown 파서 / LLM prompt 등 — 에이전트 측 결정 |
+| **claim → 구현 → PR** | task claim 후 코드 작성 / 브랜치 push / PR 생성 |
+| **결과 보고** | 성공 시 `task complete --pr N`, push reject 시 `task release`, 실패 시 `task fail` |
+| **Escalation 발행** | `task fail` 결과가 `Escalated` 면 GitHub 이슈 발행 + `task escalate` |
+| **Escalation 해소 감지** | 주기적으로 escalated task 의 issue 상태 폴링 → close 시 `epic reconcile` 또는 `task force-status` |
+| **알림** | epic 완료 / escalation 시 사용자 알림 |
 
-- `:ready` 라벨 — task store 의 status 컬럼이 대체. autopilot 은 더 이상 라벨로 작업을 큐잉하지 않음.
-- `:wip` 라벨 — 동일 (status='wip' 가 대체)
-- `autopilot issue create` 의 watch-source 호출 경로 — task store insert 로 대체
+### 5.3 라벨 / 호환성
 
-`:auto`, `:ci-failure` 라벨은 PR / 사람 이슈에서 계속 의미를 가지므로 유지한다.
+- `:auto`, `:ci-failure` 라벨은 PR / 사람 이슈에서 그대로 의미를 가짐 (변경 없음)
+- `:ready`, `:wip` 라벨은 `tasks.status` 컬럼이 의미를 대체. **단 autopilot 자체는 라벨을 큐로 쓰지 않음** — 에이전트가 라벨 기반 흐름을 유지하고 싶으면 별도 매핑 가능
+- `autopilot issue create` 의 watch-source 호출 경로 → task store insert 로 대체
 
 ## 6. HITL Escalation
 
-### 6.1 Escalation 트리거
+### 6.1 Escalation 트리거 (모두 Agent 가 발행)
 
-| 조건 | 동작 |
-|------|------|
-| watch 가 발견했지만 활성 epic 에 매칭되지 않음 | "어느 epic 에 붙일지 결정해주세요" 이슈 발행 |
-| task 가 max_attempts 초과 | "구현 반복 실패, 검토 필요" 이슈 발행 |
-| task 의존성 사이클 또는 unresolvable | "의존성 문제 해결 필요" 이슈 발행 |
-| 충돌 자동 해결 실패 | 기존 충돌 알림 흐름 유지 |
+| 조건 | Agent 동작 |
+|------|----------|
+| 갭이 어떤 활성 epic 에도 매칭되지 않음 | autopilot `suppress check` 로 중복 차단 검사 → 신규면 이슈 발행 + `suppress add fingerprint reason="unmatched_watch"` |
+| `task fail` 결과가 `Escalated` | 이슈 발행 + `task escalate <id> --issue <n>` (의존 task 들은 autopilot 이 자동으로 `blocked`) |
+| 의존성 사이클 / unresolvable | epic 적재 시 autopilot 이 거부. agent 가 그 에러를 받고 이슈 발행 |
+| 충돌 자동 해결 실패 | agent 의 기존 충돌 알림 흐름 유지 |
 
 ### 6.2 Escalation 이슈 포맷
 
 ```yaml
 title: "[autopilot] <짧은 요약>"
-labels: ["autopilot:hitl-needed"]   # 새 라벨
+labels: ["autopilot:hitl-needed"]
 body: |
   <!-- autopilot-escalation -->
   <!-- epic: <epic-name or "none"> -->
@@ -270,29 +310,35 @@ body: |
   ## 상황
   ...
 
-  ## autopilot 이 시도한 것
+  ## Agent 가 시도한 것
   ...
 
   ## 사람이 결정해야 할 것
   - [ ] ...
 ```
 
-사람이 이 이슈를 처리하면 (close / 새 epic 시작 / 기존 epic 에 attach) autopilot 은 다음 cycle 에서 status 를 갱신한다.
+사람이 이 이슈를 close 하면, **agent 가 다음 cycle 에서 close 를 감지** 하여:
+- 사람이 직접 코드를 푸시했고 PR 머지된 경우 → `epic reconcile` 호출 → task 가 done 으로 인식
+- 그렇지 않으면 → `suppress add reason="rejected_by_human"` 로 동일 fingerprint 의 재 escalation 차단
 
 ## 7. Epic 라이프사이클
 
 ```
-[사람] /epic-start spec/auth.md
+[사람]  agent 에게 "spec/auth.md 로 epic 시작" 요청
   ↓
-[autopilot] epic 브랜치 생성 + spec 분해 + task 적재 + 루프 시작
+[Agent] monitor 호출 → spec 분해 결과 획득
+        autopilot epic create --name auth-token-refresh --spec spec/auth.md
+        autopilot task add --epic ... (각 task 별 또는 batch)
+        git checkout -b epic/auth-token-refresh && git push
   ↓
-[autopilot] task 단위 구현 → PR (target = epic 브랜치) → :auto 라벨 → merge
+[Agent] (cron / loop 마다 반복)
+        autopilot task claim --epic ...   → ready task 1건
+        구현 → push → PR 생성
+        autopilot task complete --id <id> --pr <n>   (또는 fail / release)
   ↓ (모든 task done)
-[autopilot] notification 설정대로 완료 알림 + 해당 epic 의 루프 종료
+[Agent] autopilot epic status 가 all-done 보고 → epic complete + 사용자 알림
   ↓
-[사람] epic 브랜치에서 추가 검증 / 수동 보완
-  ↓
-[사람] epic → main PR 직접 생성 (이 단계는 자동화하지 않음)
+[사람]  epic 브랜치 검증 + main 으로 PR 직접 생성 (자동화 안 함)
 ```
 
 main 으로의 promote 가 자동화되지 않는 이유: epic 단위는 큰 변경이라 사람의 최종 검토가 안전판으로 필요하다.
@@ -326,19 +372,23 @@ hitl_label: "autopilot:hitl-needed"
 
 ## 9. 미해결 / 후속 검토 항목
 
-설계 단계에서 명시적으로 결정을 미룬 사항. Phase 2 (REVIEW) 또는 구현 시 결정한다.
+설계 단계에서 명시적으로 결정을 미룬 사항.
 
-1. **Spec 분해 주체** — 기존 `spec-kit` 플러그인을 재사용할 것인지, github-autopilot 이 자체 분해 에이전트를 둘 것인지.
-2. **Stale 브랜치 정책** — feature 브랜치는 있으나 PR 도 없고 일정 시간 변경도 없는 task 를 어떻게 처리할지.
-3. **여러 epic 동시 활성** 시 자원 한도 — `max_parallel_agents` 가 epic 간에 어떻게 분배될지.
-4. **Schema 마이그레이션** — 향후 스키마 변경 시 사용자 로컬 DB 를 업데이트할 절차 (단순 버전 컬럼 + 마이그레이션 스크립트가 무난).
-5. **이벤트 로그 보존 기간** — `events` 테이블 무한 증가 방지 정책 (epic completed 후 N일 후 prune 등).
+1. **Stale 브랜치 정책** — feature 브랜치는 있으나 PR 도 없고 일정 시간 변경도 없는 task 를 어떻게 처리할지. (Agent 측 정책)
+2. **여러 epic 동시 활성** 시 자원 한도 — `max_parallel_agents` 같은 한도는 **agent 측** 의 결정. autopilot 은 임의 다중 epic 을 그냥 수용.
+3. **Schema 마이그레이션** — 향후 스키마 변경 시 사용자 로컬 DB 를 업데이트할 절차. V1→V2 자동 적용 패턴 채택 (이미 구현). 다운그레이드는 비지원.
+4. **이벤트 로그 보존 기간** — `events` 테이블 무한 증가 방지 정책 (단일 cron `DELETE` 로 N일 prune 권장).
+5. **`escalation_suppression` TTL 정리** — 만료된 행을 lazy 또는 주기적으로 cleanup.
+
+> **해소된 항목**: "spec 분해 주체" — Ledger 모델 채택으로 autopilot 의 결정 사항이 아님. Agent (또는 monitor) 가 자유롭게 선택.
 
 ## 10. 다음 단계
 
-- [ ] 본 문서 리뷰 (Phase 2)
-- [ ] 결정 사항 수렴 후 라운드별 구현 계획 (Phase 3 분할)
-  - Round 1: SQLite 스키마 + autopilot CLI 의 task store 명령 (DB 단독 동작)
-  - Round 2: `epic-start` / 분해 / reconcile
-  - Round 3: 기존 watch / build / promote 의 배선 변경
-  - Round 4: HITL escalation + epic 완료 알림 + 마이그레이션
+- [x] PR #646 — 도메인 타입 + 인메모리/SQLite 어댑터 골격
+- [x] PR #648 — spec 정제 1차 (트레이트 시그니처)
+- [x] PR #649 — TaskStore 트레이트 + V2 schema + conformance suite
+- [ ] **현재 PR** — Ledger 모델로 spec rework (orchestration 제거)
+- [ ] **Round 2-A**: `cmd/epic.rs` (epic CRUD CLI)
+- [ ] **Round 2-B**: `cmd/task.rs` 확장 (claim / complete / fail / escalate)
+- [ ] **Round 2-C**: `cmd/suppress.rs` + `cmd/events.rs` + `main.rs` wiring + autopilot.toml
+- [ ] **Round 3**: 기존 헬퍼 (`pipeline`, `watch`, ...) 와 새 ledger CLI 의 정합성 점검 / 필요 시 deprecate

--- a/plans/github-autopilot/01-use-cases.md
+++ b/plans/github-autopilot/01-use-cases.md
@@ -1,12 +1,12 @@
 # 01. Use Cases
 
-> Epic 기반 Task Store 가 만족해야 하는 시나리오를 페르소나 관점에서 정의한다. 본 문서는 02 (아키텍처) 와 03 (상세 스펙) 의 인터페이스 도출 출발점이며, 04 (테스트) 의 fixture 원본이 된다.
+> Epic 기반 Task Store 가 만족해야 하는 시나리오를 페르소나 관점에서 정의한다. Ledger 모델에서 autopilot 은 상태 관리만 담당하고, 탐지 / 결정 / 구현은 외부 **Agent** 가 한다. 본 문서는 그 책임 분리를 전제로 시나리오를 기술한다.
 >
 > 각 시나리오는 다음 항목으로 구성된다:
 >
 > - **트리거** — 시나리오를 시작시키는 외부 이벤트
 > - **선행 조건** — 시나리오 시작 시점의 시스템 상태
-> - **주 흐름** — 정상 경로의 단계
+> - **주 흐름** — 정상 경로의 단계 (Agent ↔ Autopilot CLI)
 > - **대안 흐름** — 분기 / 실패 경로
 > - **사후 조건** — 시나리오 종료 시점에 보장되어야 하는 상태
 > - **관찰 가능 결과** — 외부에서 검증 가능한 부수 효과 (DB 행, git ref, GitHub 이슈/PR)
@@ -15,268 +15,271 @@
 
 | 코드 | 이름 | 역할 |
 |------|------|------|
-| **OP** | 운영자 (Operator) | autopilot 을 호스트하고 epic 을 시작/감독하는 사람 |
-| **ML** | 메인 루프 (Main Loop) | epic 단위로 도는 부모 에이전트. DB 의 단일 writer |
-| **IM** | 구현자 (Implementer) | worktree 안에서 코드를 작성하고 push 하는 자식 에이전트 |
-| **CO** | 협업자 (Collaborator) | 같은 레포에서 일하는 다른 사람. autopilot 을 직접 다루지 않을 수도 있음 |
+| **OP** | 운영자 (Operator) | autopilot 을 호스트하고 Agent 를 트리거하는 사람 |
+| **AG** | 에이전트 (Agent) | Claude Code 세션 / autodev / GitHub Actions 등. monitor 호출 / autopilot CLI 호출 / 구현 / PR 을 직접 수행 |
+| **MN** | 모니터 (Monitor) | spec ↔ code 갭을 탐지하는 외부 도구 (예: gap-detector, qa-boost, ci-watch). Agent 가 호출 |
+| **AP** | 오토파일럿 (Autopilot) | ledger + CLI. CRUD + 결정적 상태 전이만 담당 |
+| **CO** | 협업자 (Collaborator) | 같은 레포에서 일하는 다른 사람 |
 | **RV** | 리뷰어 (Reviewer) | PR 을 검토하는 사람 |
 
-페르소나 간 직접 통신은 다음 경로로만 일어난다:
+페르소나 간 통신 경로:
 
 ```
-OP → ML : CLI 명령 (/github-autopilot:epic-start 등)
-ML → OP : escalation 이슈, 완료 알림
-ML → IM : task 사양 + 격리된 worktree
-IM → ML : 브랜치 push (성공/실패) — DB 는 직접 안 만짐
-ML ↔ git remote / GitHub : PR / 이슈 / branch
-CO → GitHub : 이슈, PR 코멘트
-CO ← ML : escalation 이슈 (CO 도 처리 가능)
+OP → AG : 자연어 요청 ("auth.md 로 epic 시작해줘")
+AG → MN : 도구 호출 (spec 분해 / 갭 탐지)
+AG → AP : CLI 호출 (epic create / task add / claim / complete / fail / ...)
+AP → AG : 종료 코드 + JSON 출력 (claim 한 task / fail 의 outcome / ...)
+AG ↔ git remote / GitHub : 직접 git 조작 + gh CLI / API
+AG → OP : 알림 (epic 완료 / escalation 필요)
+CO → GitHub : 이슈, PR 코멘트 (사람의 통상 흐름)
+CO ← AG : escalation 이슈
 ```
+
+**중요**: AP 는 git / GitHub 를 직접 만지지 않는다. MN 호출도 하지 않는다. 모든 외부 효과는 AG 의 책임.
 
 ## UC-1. Epic 시작
 
 > 운영자가 새 spec 으로부터 자율 작업 권한을 부여한다.
 
-- **트리거**: OP 가 `autopilot epic start --spec spec/auth.md --name auth-token-refresh` 실행
+- **트리거**: OP 가 AG 에게 "spec/auth.md 로 epic 시작" 요청
 - **선행 조건**:
-  - 현재 working tree 가 main 브랜치에 깨끗하게 위치
+  - 현재 working tree 가 깨끗 (default branch 위치)
   - `spec/auth.md` 파일이 존재
   - 같은 이름의 active epic 이 없음
 - **주 흐름**:
-  1. ML 이 `epic/auth-token-refresh` 브랜치를 main 에서 분기하여 push
-  2. spec 분해 결과로부터 결정적 task_id 들을 부여
-  3. tasks 테이블에 status=pending 으로 모두 insert
-  4. 의존성 그래프를 `task_deps` 에 insert
-  5. 진입점 task (deps 없음) 들의 status=ready 로 전이
-  6. epics 테이블에 (name, branch, status=active) insert
-  7. ML 이 epic 스코프 cron 루프를 시작
+  1. AG 가 MN 호출 → 결정적 task_id + 의존성 정보 획득
+  2. AG 가 git checkout -b epic/auth-token-refresh && git push
+  3. AG 가 `autopilot epic create --name auth-token-refresh --spec spec/auth.md --branch epic/auth-token-refresh`
+  4. AG 가 `autopilot task add-batch --epic auth-token-refresh --from <jsonl>` (task + deps 일괄 적재)
+  5. AP 가 의존성 검증 (cycle / unknown target) + 진입점 task 들의 status=ready 자동 승격
 - **대안 흐름**:
-  - 같은 이름 epic 이 active → 에러 종료, OP 에게 `epic-resume` 안내
-  - spec 분해 실패 → epic 행도 만들지 않고 에러 종료 (rollback)
-  - main 이 dirty → 에러 종료, OP 에게 정리 요청
+  - 같은 이름 epic 이 active → AP 가 `EpicAlreadyExists` 반환. AG 는 OP 에게 `epic resume` 안내
+  - 분해 실패 → AG 가 epic create 호출 전에 중단. AP 상태 변경 없음
+  - working tree dirty → AG 의 git 단계에서 실패. AG 가 OP 에게 정리 요청
+  - cycle 감지 → AP 의 `add-batch` 가 `DepCycle` 반환. AG 는 epic 을 abandon 하거나 사람에게 escalate
 - **사후 조건**:
   - 리모트에 `epic/<name>` 브랜치 존재
   - DB 에 epic 1개 + task N개 (≥1 ready) 존재
 - **관찰 가능 결과**:
   - `git ls-remote origin "refs/heads/epic/auth-token-refresh"` 결과 1줄
-  - `events` 테이블에 kind='epic_started' 1행
+  - `autopilot events list --epic auth-token-refresh --kind epic_started` 1행
 
 ## UC-2. Task 자동 구현 사이클
 
 > 활성 epic 에서 ready task 가 PR 머지까지 진행된다.
 
-- **트리거**: ML 의 `build-tasks` sub-loop tick
+- **트리거**: AG 의 build cycle tick (cron / loop / 수동)
 - **선행 조건**:
   - 활성 epic ≥1
   - 해당 epic 에 status=ready task ≥1
-  - 동시 구현 한도 (`max_parallel_agents`) 미만
+  - AG 가 자체 정한 동시 구현 한도 미만
 - **주 흐름**:
-  1. ML 이 `claim_next_task` 로 ready 한 task 1건을 원자적으로 wip 전환
-  2. ML 이 worktree 를 만들어 IM 을 띄움. task 사양 + 작업 브랜치명 (`epic/<name>/<task_id>`) 을 전달
-  3. IM 이 코드 작성 후 작업 브랜치 push
-  4. ML 이 `branch-promoter` 로 PR 생성 (target=epic 브랜치, `:auto` 라벨)
-  5. ML 이 `merge-prs` sub-loop 에서 CI 통과한 `:auto` PR 머지
-  6. 머지 성공 → ML 이 task.status=done, pr_number 기록
-  7. ML 이 이 task 에 의존하던 blocked/pending 들의 deps 를 재평가, ready 로 승격
+  1. AG 가 `autopilot task claim --epic <name> --json` → ready task 1건 (원자적 wip 전환)
+  2. AG 가 worktree 생성 + 코드 작성 + `epic/<name>/<task_id>` 브랜치 push
+  3. AG 가 PR 생성 (target=epic 브랜치, 라벨 자유)
+  4. AG 가 `autopilot task complete <id> --pr <n>` (또는 PR 머지 후 호출)
+  5. AP 가 task.status=done, pr_number 기록 + 의존하던 blocked/pending 의 deps 재평가하여 ready 승격
 - **대안 흐름**:
-  - claim 시 다른 sub-loop 가 먼저 가져감 → 다음 tick 까지 skip
-  - IM 이 push 실패 → ML 이 task.status=ready 로 되돌리고 attempts 증가 (UC-8 진입 가능)
-  - PR CI 실패 → 기존 `ci-watch` 흐름 적용, 일정 시도 후 escalation (UC-8)
+  - claim 시 동시에 다른 호출자가 가져감 → AP 가 None 반환, AG 는 다음 tick 으로 skip
+  - push 실패 (UC-11 reject) → AG 가 `autopilot task release <id>` (attempts 차감)
+  - 구현/CI 실패 → AG 가 `autopilot task fail <id>` → outcome=Retried 면 다시 ready, Escalated 면 UC-8
 - **사후 조건**: 해당 task.status=done, epic 브랜치에 코드 반영
 - **관찰 가능 결과**:
-  - `events`: claimed → started → completed
-  - GitHub PR closed-merged 상태
+  - `events`: task_claimed → task_completed (+ task_unblocked × N)
+  - GitHub PR closed-merged
 
 ## UC-3. 의존성 있는 Task
 
 > Task B 가 Task A 에 의존할 때, A 완료 전에는 B 가 claim 되지 않는다.
 
-- **트리거**: spec 분해 결과 deps 가 있음
+- **트리거**: 분해 결과 deps 가 있음
 - **선행 조건**: A.status=ready, B.status=pending, B → A 의존성 등록
 - **주 흐름**:
-  1. ML 이 ready 후보 조회 시 B 는 deps 미충족으로 제외 — A 만 claim 가능
-  2. A 가 done 으로 전이됨
-  3. ML 의 `unblock_dependents` 가 B 의 deps 를 재평가 → 모두 done 이면 B.status=ready
-  4. 다음 tick 에서 B claim 가능
+  1. AG 가 `task claim --epic <name>` → AP 가 deps 미충족인 B 는 후보에서 제외, A 만 반환
+  2. A 가 done 으로 전이됨 (UC-2)
+  3. AP 의 `complete_task_and_unblock` 이 B 의 deps 를 재평가 → 모두 done 이면 B.status=ready (자동, 같은 트랜잭션)
+  4. 다음 claim 에서 B 반환 가능
 - **대안 흐름**:
-  - A 가 escalated → B 는 blocked 로 전이 (사람 개입 대기)
-  - A → B → A 사이클 발견 → epic-start 시 검증 단계에서 거부 (UC-1 의 선행 조건 추가)
+  - A 가 escalated → AP 가 자동으로 B 를 blocked 로 전이 (mark_task_failed 의 escalate 분기에서 처리)
+  - A → B → A 사이클 발견 → AP 가 `add-batch` 시점에 `DepCycle` 반환
 - **사후 조건**: 모든 task 가 deps 순서대로만 wip 진입
-- **관찰 가능 결과**: `events` 의 시간순으로 A.completed 가 B.claimed 보다 먼저
+- **관찰 가능 결과**: `events` 의 시간순으로 task_completed(A) 가 task_claimed(B) 보다 먼저
 
 ## UC-4. Epic 이어받기 (다른 사람 / 다른 머신)
 
 > CO 가 OP 의 휴가 중에 같은 epic 을 이어서 진행한다.
 
-- **트리거**: CO 가 `autopilot epic resume auth-token-refresh` 실행
+- **트리거**: CO 의 AG 가 epic 재개를 시도
 - **선행 조건**:
   - 리모트에 `epic/auth-token-refresh` 브랜치 존재
   - CO 의 로컬 DB 에는 해당 epic 행이 없음 (또는 stale)
 - **주 흐름**:
-  1. ML 이 origin 에서 epic 브랜치 fetch
-  2. spec 을 epic 브랜치 시점 기준으로 다시 분해 → 동일한 결정적 task_id 도출
-  3. 리모트의 `epic/<name>/*` 브랜치 + 머지된 PR 을 스캔 (Reconciliation, 03 spec)
-  4. 매칭 결과로 DB 를 idempotent 하게 재구성:
+  1. AG 가 git fetch origin
+  2. AG 가 MN 호출 → 결정적 task_id 재도출 (= 동일 ID)
+  3. AG 가 ls-remote 로 `epic/<name>` + `epic/<name>/*` 브랜치 스캔
+  4. AG 가 PR 스캔 (target=epic 브랜치)
+  5. AG 가 plan.jsonl 작성: tasks + deps + remote_state + orphan_branches
+  6. AG 가 `autopilot epic reconcile --name auth-token-refresh --plan plan.jsonl`
+  7. AP 가 plan 을 idempotent 하게 적용:
      - PR merged → done
      - feature 브랜치 + open PR → wip
-     - feature 브랜치만 있고 PR 없음 → wip (stale 후보)
-     - 브랜치 없음 → ready (deps OK 시) / pending
-  5. epics 행을 active 로 upsert, ML 루프 시작
+     - feature 브랜치만 + PR 없음 → wip (stale 후보, events 기록)
+     - 브랜치 없음 → ready (deps 만족) / pending
 - **대안 흐름**:
-  - 분해 결과에 없는 task_id 의 브랜치/PR 이 발견됨 → orphan 으로 표시, OP/CO 에게 알림
-  - epic 브랜치 자체가 없음 → 에러 종료, `epic-start` 안내
+  - 분해 결과에 없는 task_id 의 브랜치 → orphan_branches 로 plan 에 포함, AP 가 reconciled.payload 에 기록
+  - epic 브랜치 자체가 없음 → AG 가 epic 시작 (UC-1) 안내
 - **사후 조건**: CO 의 로컬 DB 가 OP 의 직전 상태와 의미적으로 동일 (캐시 무손실 복구)
-- **관찰 가능 결과**: `epic-resume` 직후 `epic-status` 출력이 직전 OP 의 출력과 일치
+- **관찰 가능 결과**: `epic status` 출력이 OP 와 일치
 
 ## UC-5. 로컬 DB 손실 후 복구
 
 > OP 의 머신에서 `.autopilot/state.db` 가 삭제됐다.
 
-- **트리거**: DB 파일 부재 상태에서 다음 ML tick 또는 OP 가 `epic resume` 실행
+- **트리거**: DB 파일 부재 상태에서 AG 의 다음 tick
 - **선행 조건**: 리모트의 epic 브랜치/PR 은 그대로 존재
-- **주 흐름**: UC-4 와 동일 (`resume` 이 단일 진입점)
-- **사후 조건**: DB 가 재구성되어 ML 루프가 재개됨. 진행 중이던 task 의 attempts 카운터는 0 으로 초기화 (캐시 손실의 허용 손실)
+- **주 흐름**: UC-4 와 동일 (`epic reconcile` 이 단일 진입점)
+- **사후 조건**: DB 가 재구성. 진행 중이던 task 의 attempts 카운터는 0 으로 초기화 (캐시 손실의 허용 손실)
 - **관찰 가능 결과**: `events` 에 kind='reconciled' 1행, 직전 attempts 정보는 손실됨
 
-## UC-6. Watch 가 발견한 갭 (활성 epic 매칭 가능)
+## UC-6. 갭 발견 (활성 epic 매칭 가능)
 
-> `gap-watch` 가 spec ↔ 코드 갭을 발견했고, 그 spec 은 활성 epic 의 spec 과 일치한다.
+> AG 가 호출한 MN 이 spec ↔ 코드 갭을 발견했고, 그 spec 은 활성 epic 의 spec 과 일치.
 
-- **트리거**: `gap-watch` sub-loop 가 갭 1건 발견
+- **트리거**: AG 의 watch tick 에서 MN 호출
 - **선행 조건**: 발견된 갭의 spec 경로가 활성 epic 의 `spec_path` 와 일치
 - **주 흐름**:
-  1. ML 이 갭의 fingerprint 로 기존 task 중복 검사
-  2. 중복 없으면 새 task 행 (epic_name=매칭 epic, source='gap-watch', status=pending) insert
-  3. deps 가 없으면 즉시 ready 로 승격
+  1. AG 가 `autopilot epic find-by-spec-path <path>` → 매칭 epic 획득
+  2. AG 가 `autopilot task add --epic <name> --id <det_id> --fingerprint <fp> --source gap-watch ...`
+  3. AP 가 fingerprint 중복 검사 → 신규면 insert, 중복이면 `DuplicateFingerprint(existing_id)` 반환
 - **대안 흐름**:
-  - 동일 fingerprint task 가 이미 존재 → skip (멱등성)
-  - 갭의 spec 이 어떤 활성 epic 에도 매칭되지 않음 → UC-7 진입
-- **사후 조건**: 매칭 epic 산하 task 1건 추가
-- **관찰 가능 결과**: `tasks` 행 추가, GitHub 이슈는 발행되지 않음
+  - 동일 fingerprint task 존재 → AG 가 결과 보고 skip (멱등)
+  - spec 이 어떤 활성 epic 에도 매칭 안 됨 → UC-7
+- **사후 조건**: 매칭 epic 산하 task 1건 추가 (또는 멱등 skip)
+- **관찰 가능 결과**: `tasks` 행 추가, GitHub 이슈 미발행
 
-## UC-7. Watch 가 발견한 갭 (활성 epic 없음)
+## UC-7. 갭 발견 (활성 epic 없음)
 
 > 발견된 갭이 어떤 활성 epic 에도 속하지 않는다.
 
-- **트리거**: `gap-watch` / `qa-boost` / `ci-watch` 가 갭 1건 발견
-- **선행 조건**: 갭의 spec 경로가 활성 epic 의 `spec_path` 와 매칭 안 됨
+- **트리거**: AG 의 watch tick 에서 MN 호출
+- **선행 조건**: 갭의 spec 경로가 활성 epic 의 spec_path 와 매칭 안 됨
 - **주 흐름**:
-  1. ML 이 escalation 이슈 발행 (UC-9 의 후처리 대상)
-  2. 이슈 본문에 발견 컨텍스트 + 가능한 epic 후보 (있다면) 명시
-  3. tasks 테이블에는 행을 만들지 않음 — 에픽 미할당 task 는 존재할 수 없다
-- **대안 흐름**: 동일 fingerprint 의 escalation 이슈가 24h 이내 이미 발행됨 → 신규 발행 skip
-- **사후 조건**: GitHub 이슈 1건 신규 (label=`autopilot:hitl-needed`)
-- **관찰 가능 결과**: `events` 에 kind='escalated', target='unmatched_watch', issue_number 기록
+  1. AG 가 `autopilot suppress check --fingerprint <fp> --reason unmatched_watch`
+  2. exit 1 (미억제) 이면 AG 가 GitHub 이슈 발행 (`autopilot:hitl-needed` 라벨)
+  3. AG 가 `autopilot suppress add --fingerprint <fp> --reason unmatched_watch --until <now+24h>`
+  4. AP 는 task 생성 안 함 — epic 미할당 task 는 존재할 수 없다
+- **대안 흐름**: suppress check exit 0 (억제 중) → AG 가 이슈 발행 skip
+- **사후 조건**: GitHub 이슈 1건 신규, suppression 행 1건 신규
+- **관찰 가능 결과**: `events` 에 kind='escalated' (선택), GitHub 이슈 / suppression 테이블
 
 ## UC-8. Task 반복 실패 → Escalate
 
 > 한 task 가 max_attempts 까지 실패했다.
 
-- **트리거**: ML 이 IM 의 push 실패 / PR CI 실패를 N회 누적 관찰
+- **트리거**: AG 가 IM 의 push 실패 / PR CI 실패를 인지
 - **선행 조건**: task.attempts == max_attempts (직전 실패 처리 시점)
 - **주 흐름**:
-  1. ML 이 `mark_task_failed` 호출 → `TaskFailureOutcome::Escalated` 응답 받음
-  2. ML 이 escalation 이슈 발행 (task_id, 시도 로그 요약 포함)
-  3. task.status=escalated, escalated_issue=이슈번호 기록
-  4. 이 task 에 의존하던 다른 task 들은 blocked 로 전이
-- **대안 흐름**:
-  - attempts < max → status=ready 로 되돌리고 다음 cycle 재시도
-  - 동일 task 가 이미 escalated → 추가 이슈 발행 안 함
+  1. AG 가 `autopilot task fail <id>` → AP 가 outcome 결정:
+     - attempts < max → `Retried`. AP 가 status=ready 로 복귀, attempts 보존
+     - attempts ≥ max → `Escalated`. AP 가 status=escalated 로 전이 + 의존 task 들 자동 blocked
+  2. outcome=Escalated 면 AG 가 GitHub 이슈 발행
+  3. AG 가 `autopilot task escalate <id> --issue <n>` → AP 가 escalated_issue 기록 + event
+- **대안 흐름**: attempts < max → AG 는 다음 tick 에 재시도
 - **사후 조건**: task.status=escalated, 의존 task 들 blocked
-- **관찰 가능 결과**: `events`: failed → escalated, GitHub 이슈 1건
+- **관찰 가능 결과**: `events`: task_failed → task_escalated, GitHub 이슈 1건
 
 ## UC-9. 사람이 Escalation 이슈 처리
 
 > OP/CO 가 escalation 이슈를 받고 결정을 내린다.
 
-- **트리거**: 사람이 GitHub 에서 escalation 이슈에 결정 코멘트 또는 라벨 변경
+- **트리거**: 사람이 GitHub 에서 escalation 이슈를 close 또는 라벨 변경
 - **선행 조건**: 이슈 label=`autopilot:hitl-needed` + 본문에 epic/task 메타 포함
 - **주 흐름** (이슈 처리 패턴별):
-  - **(a) 새 epic 으로 승격**: 사람이 이슈에 `/autopilot epic-start <spec>` 코멘트 또는 운영자가 CLI 실행
-  - **(b) 기존 epic 에 흡수**: `analyze-issue` 가 이슈 본문에서 spec 매칭 후 task 행 신규 insert (UC-6 와 동일 흐름)
-  - **(c) 거부 / 무시**: 사람이 이슈 close → ML 은 더 이상 해당 fingerprint 를 escalate 하지 않도록 suppression 기록
-  - **(d) max-attempts 후 사람이 직접 수정**: 사람이 코드를 직접 작성하고 task 의 escalated_issue 이슈를 close → ML 은 reconcile 시 해당 task 가 done 으로 전이된 것으로 인식
+  - **(a) 새 epic 으로 승격**: 사람이 OP 에게 요청 → AG 가 UC-1 흐름. 기존 escalation 이슈는 사람이 close
+  - **(b) 기존 epic 에 흡수**: AG 가 issue 분석 후 spec 매칭 → `task add --source human` (UC-6 와 같은 흐름). 이슈 close + 코멘트
+  - **(c) 거부 / 무시**: 사람이 close → AG 의 다음 escalation polling 에서 close 감지:
+    - reconcile 시도 → status 변화 없음 → AG 가 `autopilot suppress add --reason rejected_by_human --until <now+30d>`
+  - **(d) 사람이 직접 코드 수정**: 사람이 코드 push + PR merge + escalation 이슈 close → AG 의 polling 이 close 감지 → `epic reconcile` 호출 → AP 가 task.status=done 으로 전이
 - **사후 조건**: 이슈 closed, 결과에 따라 새 task / 기존 task 상태 갱신
-- **관찰 가능 결과**: `events` 에 kind='escalation_resolved', resolution=(a|b|c|d)
+- **관찰 가능 결과**: `events` 에 kind='escalation_resolved', payload.resolution=(a|b|c|d 에 해당하는 값)
 
 ## UC-10. Epic 완료 → main 머지 (반자동)
 
 > 한 epic 의 모든 task 가 done 이 되었다.
 
-- **트리거**: 마지막 task 가 done 으로 전이된 직후 ML 의 cycle
-- **선행 조건**: epic 산하 task 의 status 가 모두 (done | escalated 중 사람이 close 한 것)
+- **트리거**: AG 의 cycle 에서 `autopilot epic status` 가 all-done 보고
+- **선행 조건**: epic 산하 task 의 status 가 모두 done (escalated 가 남아 있으면 UC-9 의 처리 후 done 또는 force-status 필요)
 - **주 흐름**:
-  1. ML 이 epic.status=completed, completed_at 기록
-  2. ML 의 epic 스코프 cron 루프 종료
-  3. 사용자 알림 발송 (notification 설정 사용)
-  4. **OP 가 직접** epic → main PR 생성 — 자동화하지 않음
+  1. AG 가 `autopilot epic complete <name>` → AP 가 status=completed, completed_at 기록
+  2. AG 가 사용자 알림 (notification 채널은 AG 의 책임)
+  3. **OP 가 직접** epic → main PR 생성 — 자동화 안 함
 - **대안 흐름**:
-  - 일부 task 가 escalated 인 채로 남아 있으나 사람이 모두 close → done 으로 reconcile 후 완료 처리
-- **사후 조건**: epic.status=completed, ML 의 해당 epic 루프 부재
-- **관찰 가능 결과**: `events`: epic_completed, 알림 송신 로그
+  - 일부 task 가 escalated 인 채로 남아 있고 사람이 close 만 했음 → AG 가 reconcile 또는 `task force-status <id> --to done --reason "rejected resolved"` 후 epic complete
+- **사후 조건**: epic.status=completed
+- **관찰 가능 결과**: `events`: epic_completed, AG 의 알림 송신 로그
 
 ## UC-11. 두 머신에서 같은 Epic 동시 진행 (충돌 자연 차단)
 
 > OP 와 CO 가 모르는 사이에 같은 epic 을 동시에 resume 하여 같은 task 를 구현하려 한다.
 
-- **트리거**: 두 머신에서 거의 동시에 동일 task_id 를 claim
+- **트리거**: 두 머신의 AG 가 거의 동시에 동일 task 를 claim
 - **선행 조건**: 둘 다 reconcile 후 동일 task 가 ready 로 보임
 - **주 흐름**:
-  1. 머신 A 의 IM 이 `epic/<name>/<task_id>` 브랜치 push 성공
-  2. 머신 B 의 IM 이 같은 이름 브랜치 push 시도 → non-fast-forward reject
-  3. 머신 B 의 ML 이 push 실패를 감지 → 해당 task.status=ready 로 되돌리고 다음 reconcile 에서 wip (다른 머신이 가져감) 으로 재인식
+  1. AP 의 `claim_next_task` 의 원자적 UPDATE 가 한 쪽만 winner — 다른 쪽은 None 반환 (같은 머신 내 race)
+  2. 다른 머신 케이스에선 둘 다 winner 처럼 보일 수 있음 → 하지만 git push 단계에서 한 쪽이 reject
+  3. reject 받은 머신의 AG 가 `autopilot task release <id>` 호출 (attempts 차감)
   4. 동일 task 의 PR 은 머신 A 의 것 1개만 존재
-- **대안 흐름**:
-  - 두 IM 의 코드가 다른 경우에도 git 차원에서 한 쪽만 살아남음. 머신 B 는 작업 결과 폐기
+- **대안 흐름**: 두 IM 의 코드가 다른 경우에도 git 차원에서 한 쪽만 살아남음. 머신 B 는 작업 결과 폐기
 - **사후 조건**: task 1건 = PR 1건. 중복 PR 없음
-- **관찰 가능 결과**: 머신 B 의 `events` 에 kind='claim_lost', upstream_existed=true
+- **관찰 가능 결과**: 머신 B 의 `events` 에 kind='claim_lost'
 
 ## UC-12. 운영자가 Epic 강제 중단
 
 > OP 가 진행 중 epic 을 더 이상 진행하지 않기로 결정한다.
 
-- **트리거**: OP 가 `autopilot epic stop <name>` 실행
+- **트리거**: OP → AG 에게 중단 요청
 - **선행 조건**: epic.status=active
 - **주 흐름**:
-  1. ML 이 epic.status=abandoned 로 전이
-  2. 진행 중이던 task 들 중 wip 상태는 그대로 둠 (현재 push 된 코드는 보존)
-  3. epic 스코프 ML 루프 종료
-  4. 새 task claim 중단
+  1. AG 가 `autopilot epic abandon <name>` → AP 가 status=abandoned 로 전이
+  2. AG 는 다음 cycle 부터 해당 epic 에 대해 task claim 시도 안 함
+  3. 진행 중이던 task 들 중 wip 상태는 그대로 둠 (현재 push 된 코드는 보존)
 - **대안 흐름**:
-  - `--purge-branches` 플래그가 주어지면 머지되지 않은 feature 브랜치 정리 옵션 (기본 OFF)
+  - OP 가 `--purge-branches` 같은 정책을 원하면 AG 가 ls-remote + `git push --delete` 직접 수행 (autopilot 은 git 미관여)
 - **사후 조건**: 해당 epic 의 새 작업이 진행되지 않음. 리모트의 코드는 보존
 - **관찰 가능 결과**: `events`: epic_abandoned
 
 ## UC-13. 라벨 기반 → DB 기반 마이그레이션
 
-> 기존 `:ready` 라벨 기반으로 운영하던 레포에서 epic 기반으로 전환한다.
+> 기존 `:ready` 라벨 기반으로 운영하던 레포에서 ledger 기반으로 전환한다.
 
-- **트리거**: OP 가 `epic_based: true` 설정 후 `autopilot migrate import-issue <#>` 실행
+- **트리거**: OP → AG 에게 마이그레이션 요청
 - **선행 조건**: 활성 epic ≥1, 대상 이슈가 `:ready` 상태
 - **주 흐름**:
-  1. ML 이 이슈 본문/제목에서 spec 매칭 시도
-  2. 매칭된 epic 의 task 로 신규 insert (source='human', body에 원래 이슈 번호 메타로 기록)
-  3. 이슈에는 자동으로 코멘트 추가: "task <id> 로 흡수됨, label `:ready` 제거"
-  4. 이슈에서 `:ready` 라벨 제거 (autopilot 이 더 이상 큐로 보지 않게)
+  1. AG 가 `gh issue view <#>` 로 본문 / 제목 분석
+  2. AG 가 spec 매칭 (어느 epic 에 속할지)
+  3. 매칭 epic 의 `task add --source human --body "<원본 issue #N>"`
+  4. AG 가 이슈에 코멘트 추가: "task <id> 로 흡수됨"
+  5. AG 가 `:ready` 라벨 제거
 - **대안 흐름**:
   - 매칭 실패 → UC-7 의 escalation 형태로 유지 또는 사람이 수동 mapping
 - **사후 조건**: 이슈는 살아 있되 라벨이 정리됨, 새 task 행 1건
-- **관찰 가능 결과**: `events`: kind='migrated_from_issue', issue_number 기록
+- **관찰 가능 결과**: 새 task 의 source='human', body 에 원본 이슈 번호 메타
 
-## 시나리오 ↔ 인터페이스 매핑 (요약)
+## 시나리오 ↔ Autopilot 트레이트 메서드 매핑 (요약)
 
-| UC | 도출되는 핵심 인터페이스 / 동작 |
-|----|------------------------------|
-| 1 | `EpicManager::start`, `TaskStore::insert_epic_with_tasks` (트랜잭션) |
-| 2 | `TaskStore::claim_next_task` (원자성), `TaskStore::mark_task_done` |
-| 3 | `TaskStore::list_ready_tasks` 의 deps 필터, `unblock_dependents` |
-| 4-5 | `Reconciler::reconcile_epic`, 결정적 `task_id` 함수 |
-| 6 | `TaskStore::find_by_fingerprint`, watch 측의 epic 매칭 함수 |
-| 7-9 | `Escalator::escalate`, suppression 기록, `analyze-issue` 의 흡수 경로 |
-| 8 | `mark_task_failed` → `TaskFailureOutcome` 분기 |
-| 10 | epic 완료 판정 + 알림. main 머지는 자동화 대상 아님 |
-| 11 | claim 의 원자성 + git push reject 자연 처리 |
-| 12 | `EpicManager::stop`, abandoned 상태 |
-| 13 | 마이그레이션 CLI + 이슈 → task 흡수 |
+| UC | Agent CLI 호출 | Autopilot 트레이트 메서드 |
+|----|--------------|------------------------|
+| 1 | `epic create`, `task add-batch` | `EpicRepo::upsert_epic`, `TaskRepo::insert_epic_with_tasks` |
+| 2 | `task claim`, `task complete \| fail \| release`, `task escalate` | `claim_next_task`, `complete_task_and_unblock`, `mark_task_failed`, `release_claim`, `escalate_task` |
+| 3 | (UC-2 와 동일) | `claim_next_task` 의 deps 필터, `complete_task_and_unblock` 의 unblock |
+| 4-5 | `epic reconcile --plan ...` | `apply_reconciliation` |
+| 6 | `epic find-by-spec-path`, `task add` | `find_active_by_spec_path`, `upsert_watch_task` |
+| 7 | `suppress check`, `suppress add` | `is_suppressed`, `suppress` |
+| 8 | `task fail`, `task escalate` | `mark_task_failed`, `escalate_task` |
+| 9 | `epic reconcile`, `suppress add`, `task force-status` | `apply_reconciliation`, `suppress`, `force_status` |
+| 10 | `epic status`, `epic complete` | `list_epics`, `set_epic_status` |
+| 11 | `task release` | `release_claim` |
+| 12 | `epic abandon` | `set_epic_status` |
+| 13 | `task add --source human` | `upsert_watch_task` (source=Human) |
 
-이 매핑은 02 (아키텍처) 의 모듈 경계와 03 (상세 스펙) 의 trait 시그니처가 충족해야 하는 최소 요구사항이다.
+이 매핑은 02 (아키텍처) 의 모듈 경계와 03 (상세 스펙) 의 trait 시그니처가 충족해야 하는 최소 요구사항이다. **Agent 측의 워크플로 통합 검증은 본 spec 의 책임이 아니다** — 04 §1 참조.

--- a/plans/github-autopilot/02-architecture.md
+++ b/plans/github-autopilot/02-architecture.md
@@ -6,112 +6,108 @@
 
 | 원칙 | 본 시스템에서의 의미 |
 |------|------------------|
-| **SRP** | 도메인 / 포트 / 어댑터 / 오케스트레이션 / CLI 레이어를 분리. 한 모듈은 하나의 변경 이유만 갖는다 |
-| **OCP** | 새 watch 종류, 새 알림 채널, 새 spec 분해기 추가 시 기존 코드 수정 없이 어댑터만 추가 |
+| **SRP** | autopilot 은 ledger + CLI 만 담당. 탐지 / 결정 / 구현은 외부 Agent |
+| **OCP** | 새 EventKind / 새 TaskStatus 추가 시 도메인 enum 확장만으로 흡수 |
 | **LSP** | 인메모리 TaskStore 와 SQLite TaskStore 가 동일 계약 (트랜잭션 의미 포함) 을 만족 |
-| **ISP** | 큰 단일 trait 대신 `EpicRepo`, `TaskRepo`, `EventLog` 등 역할별 분리. `TaskStore` 는 이들의 슈퍼트레이트 형태 |
-| **DIP** | 오케스트레이션은 포트(trait)에만 의존. CLI 진입점이 컴포지션 루트로서 어댑터를 wiring |
+| **ISP** | 큰 단일 trait 대신 `EpicRepo` / `TaskRepo` / `EventLog` / `SuppressionRepo` 로 분리. `TaskStore` 는 슈퍼트레이트 |
+| **DIP** | CLI 진입점은 trait 에만 의존. 어댑터는 컴포지션 루트에서 주입 |
 
 ## 2. 레이어와 의존성 방향
 
+autopilot 자체는 단일 프로세스 / 단일 책임이다. **Agent 는 외부** 요소로, autopilot 의 의존 그래프 밖에 있다.
+
 ```
+                 ┌────────────────────────────────────┐
+                 │  Agent (Claude Code 세션, autodev,  │
+                 │   GitHub Actions, ...)              │
+                 │  - monitor 호출 / 분해 / 구현 / PR │
+                 │  - escalation 이슈 발행            │
+                 └─────────────┬──────────────────────┘
+                               │ CLI 호출 (autopilot ...)
+                               ▼
 +--------------------------------------------------------+
-|                     cmd / CLI 진입점                    |  <- 컴포지션 루트
-|         (epic_start, epic_resume, watch, build, ...)   |
-+----------------------------+---------------------------+
-                             |
-+----------------------------v---------------------------+
-|                    Orchestration                       |
-|  EpicManager  BuildLoop  WatchDispatcher  Reconciler   |
-|  MergeLoop    Escalator  EscalationWatcher             |
+|                cmd / CLI 진입점                         |  <- 컴포지션 루트
+|  (epic, task, suppress, events, worktree, labels, ...) |
 +----------------------------+---------------------------+
                              |
 +----------------------------v---------------------------+
 |                       Ports (trait)                    |
-|  TaskStore  GitClient  GitHubClient  SpecDecomposer    |
-|             Notifier   Clock         IdGenerator       |
+|  TaskStore (= EpicRepo + TaskRepo + EventLog +         |
+|              SuppressionRepo)         Clock            |
 +----------------------------+---------------------------+
-                             |  (구현 의존성은 오직 한 방향)
+                             |
 +----------------------------v---------------------------+
 |                       Adapters                         |
-|  SqliteTaskStore  GitCli  GitHubMcpClient              |
-|                   SpecKitDecomposer  StdClock          |
+|  InMemoryTaskStore   SqliteTaskStore   StdClock        |
 +--------------------------------------------------------+
                              ^
                              |
 +----------------------------+---------------------------+
 |                   Domain (pure)                        |
 |  Epic  Task  TaskId  TaskStatus  TaskSource            |
-|  TaskFailureOutcome  Event  TaskGraph (deps)           |
+|  TaskFailureOutcome  Event  EventKind  TaskGraph       |
+|  DomainError                                           |
 +--------------------------------------------------------+
 ```
 
 엄격한 규칙:
 
-- **Domain 모듈은 어떤 외부 의존성도 갖지 않는다** — std + serde 만 허용
-- **Orchestration 은 어댑터를 직접 import 하지 않는다** — 오직 `ports` 의 trait 만
-- **Adapter 는 다른 adapter 를 직접 호출하지 않는다** — 필요하면 orchestration 으로 끌어올린다
-- **CLI cmd 는 orchestration 을 호출하지 직접 store/git 를 호출하지 않는다** — 단순 출력 변환과 wiring 만
+- **Domain 모듈은 어떤 외부 의존성도 갖지 않는다** — std + serde + chrono 만 허용
+- **CLI cmd 는 trait 만 호출** — adapter 를 직접 생성하지 않음 (`main.rs` 가 wiring)
+- **Adapter 는 다른 adapter 를 직접 호출하지 않는다**
+- **autopilot 코드는 git/github/Claude Code/spec-kit 을 직접 호출하지 않는다** — 그 책임은 agent 의 영역
+
+기존 헬퍼 명령 (`worktree`, `pipeline idle`, `watch run`, `issue`, `labels`, ...) 은 이 다이어그램의 **CLI 진입점** 에 함께 위치한다. 그들은 ledger 와 무관하게 자체 어댑터 (`GhOps`, `GitOps`, `FsOps`) 를 사용하며, agent 가 호출하는 도구 모음으로 분류된다.
 
 ## 3. 모듈 배치 (Rust)
 
-기존 `plugins/github-autopilot/cli/` 단일 crate 를 유지한다. 워크스페이스로 분할하지 않는 이유: 현재 외부 재사용 요구가 없고, 단일 crate 안에서 mod 경계만으로도 위 규칙을 강제할 수 있다.
-
 ```
 plugins/github-autopilot/cli/src/
-├── main.rs
-├── lib.rs                           # pub mod 선언만
+├── main.rs                          # 컴포지션 루트
+├── lib.rs                           # pub mod 선언
 │
-├── domain/                          # pure, no I/O
+├── domain/                          # pure
 │   ├── mod.rs
-│   ├── epic.rs                      # Epic, EpicStatus
-│   ├── task.rs                      # Task, TaskId, TaskStatus, TaskSource
-│   ├── task_id.rs                   # 결정적 ID 함수
-│   ├── deps.rs                      # TaskGraph, cycle detection
-│   └── event.rs                     # Event, EventKind
+│   ├── epic.rs
+│   ├── task.rs
+│   ├── task_id.rs
+│   ├── deps.rs
+│   ├── event.rs
+│   └── error.rs
 │
 ├── ports/                           # trait only
 │   ├── mod.rs
-│   ├── task_store.rs                # TaskStore (= EpicRepo + TaskRepo + EventLog)
-│   ├── git.rs                       # GitClient
-│   ├── github.rs                    # GitHubClient (이슈/PR)
-│   ├── decompose.rs                 # SpecDecomposer
-│   ├── notifier.rs                  # Notifier
-│   └── clock.rs                     # Clock
+│   ├── task_store.rs                # TaskStore = EpicRepo + TaskRepo
+│   │                                #             + EventLog + SuppressionRepo
+│   └── clock.rs
 │
 ├── store/
-│   └── sqlite.rs                    # SqliteTaskStore impl TaskStore
-│
-├── git.rs                           # (기존) GitCli impl GitClient
-├── github.rs                        # (기존) impl GitHubClient via gh
-├── gh.rs                            # (기존) gh CLI helper
-│
-├── decompose/
-│   └── speckit.rs                   # SpecKitDecomposer
-│
-├── orchestration/
 │   ├── mod.rs
-│   ├── epic_manager.rs              # start / resume / stop / status
-│   ├── build_loop.rs                # claim → IM 호출 → push 결과 처리
-│   ├── watch_dispatcher.rs          # watch 결과 → epic 매칭 / append / escalate
-│   ├── merge_loop.rs                # PR 머지 + task done 전이 + epic 완료 판정
-│   ├── reconciler.rs                # git remote ↔ DB
-│   ├── escalator.rs                 # escalation 이슈 + suppression
-│   └── escalation_watcher.rs        # escalated task 의 issue close 폴링 → reconcile
+│   ├── memory.rs                    # InMemoryTaskStore
+│   ├── sqlite.rs                    # SqliteTaskStore
+│   └── migrations/                  # V1, V2, ...
 │
-└── cmd/                             # CLI 핸들러 (clap subcommand 매핑)
-    ├── mod.rs
-    ├── epic.rs                      # start / resume / stop / status
-    ├── watch/                       # (기존, 일부 변경)
-    ├── pipeline.rs                  # (기존, build-tasks/merge-prs 진입)
-    └── ...
+├── cmd/
+│   ├── mod.rs
+│   ├── epic.rs                      # ledger CLI (신규)
+│   ├── task.rs                      # ledger CLI (확장)
+│   ├── suppress.rs                  # ledger CLI (신규)
+│   ├── events.rs                    # ledger CLI (신규)
+│   │
+│   ├── pipeline.rs                  # 기존 헬퍼 (idle 등 유지)
+│   ├── watch/                       # 기존 헬퍼 (이벤트 emitter)
+│   ├── worktree.rs                  # 기존 헬퍼
+│   ├── issue.rs, issue_list.rs      # 기존 헬퍼
+│   ├── labels.rs                    # 기존 헬퍼
+│   ├── preflight.rs, simhash.rs     # 기존 헬퍼
+│   ├── stats.rs, check/             # 기존 헬퍼
+│   └── ...
+│
+├── git.rs, github.rs, gh.rs, fs.rs  # 기존 헬퍼 어댑터 (GitOps/GhOps/...)
+└── ...
 ```
 
-기존 파일과의 관계:
-
-- `git.rs`, `github.rs`, `gh.rs` 는 그대로 두되, 새 `ports` 의 trait 을 구현하도록 시그니처를 정리한다 (어댑터화)
-- `cmd/issue.rs`, `cmd/issue_list.rs`, `cmd/labels.rs` 는 epic 기반 전환 후 일부 사용. 04 watch-integration 에서 다룸
-- `cmd/pipeline.rs` 의 build-issues 흐름은 build-tasks 흐름으로 대체 (UC-2 매핑)
+기존 `git.rs`, `github.rs`, `gh.rs`, `fs.rs` 와 `cmd/pipeline.rs`, `cmd/watch/`, `cmd/worktree.rs`, `cmd/issue*.rs`, `cmd/labels.rs`, `cmd/check/`, `cmd/preflight.rs`, `cmd/simhash.rs`, `cmd/stats.rs` 는 그대로 유지한다. **그들은 ledger 와 결합되지 않으며**, agent 가 자기 워크플로에서 자유롭게 호출한다.
 
 ## 4. 핵심 포트 (인터페이스 윤곽)
 
@@ -119,65 +115,47 @@ plugins/github-autopilot/cli/src/
 
 ### 4.1 TaskStore
 
-DB 의 epic / task / dep / event 행에 대한 CRUD + 상태 전이.
+DB 의 epic / task / dep / event / suppression 행에 대한 CRUD + 상태 전이.
 
-- **책임**: 원자적 상태 전이, 결정적 ID 보존, 이벤트 기록
-- **비책임**: spec 분해, git 호출, 이슈 발행
+- **책임**: 원자적 상태 전이, 결정적 ID 보존, 이벤트 기록, fingerprint 억제
+- **비책임**: spec 분해, git 호출, 이슈 발행, 알림, 의사결정
 - **분할 trait** (ISP):
-  - `EpicRepo`: epic 행
-  - `TaskRepo`: task 행 + deps + claim/done/fail
+  - `EpicRepo`: epic 행 + spec_path 매칭
+  - `TaskRepo`: task 행 + deps + claim/release/complete/fail/escalate/force-status + reconcile 적용
   - `EventLog`: event 행 append/query
-- 슈퍼트레이트 `TaskStore: EpicRepo + TaskRepo + EventLog` 로 통합
+  - `SuppressionRepo`: fingerprint × reason → until 매핑
+- 슈퍼트레이트 `TaskStore: EpicRepo + TaskRepo + EventLog + SuppressionRepo` 로 통합
 
-### 4.2 GitClient
+### 4.2 Clock
 
-git 명령어의 추상.
+테스트 격리용 시간 주입. autopilot 자체가 직접 의존하는 유일한 외부 포트.
 
-- **책임**: branch 생성/삭제/push/fetch, ls-remote 스캔, working tree 상태 조회
-- **비책임**: GitHub API (PR/이슈)
-- 구현체: `GitCli` (subprocess), 테스트용 `InMemoryGit`
+- 구현체: `StdClock`, `FixedClock` (테스트)
 
-### 4.3 GitHubClient
+### 4.3 외부 의존 도구 (autopilot 내부 포트가 아님)
 
-GitHub API 의 추상.
+다음은 **agent 의 책임 영역** 으로, autopilot 의 trait 시스템에 들어가지 않는다:
 
-- **책임**: PR / 이슈 / 라벨 / 코멘트
-- **비책임**: git 자체 동작
-- 구현체: `GitHubMcpClient` (MCP 도구 경유 / 또는 기존 `gh` CLI), 테스트용 `FakeGitHub`
+- spec 분해기 (spec-kit / 자체 markdown 파서 / LLM prompt — agent 가 채택)
+- git/GitHub 클라이언트 (agent 가 사용. autopilot 의 기존 헬퍼 명령은 그 위에서 동작)
+- 알림 (notification — agent 가 자기 알림 채널 사용)
+- 분해 결과 캐시 / artifact 저장 — agent 가 책임
 
-### 4.4 SpecDecomposer
-
-spec 마크다운을 task 후보 목록으로 분해.
-
-- **책임**: spec 파일 읽기 + 결정적 task_id 부여 + 의존성 추출
-- **비책임**: DB insert (호출자가 함)
-- 구현체: `SpecKitDecomposer` (기존 spec-kit 플러그인 호출), 테스트용 `FakeDecomposer`
-
-### 4.5 Notifier
-
-epic 완료 / escalation 등 사용자 알림.
-
-- **책임**: 메시지 송신
-- **비책임**: 메시지 내용 결정 (호출자가 정함)
-- 구현체: `NotificationConfigured` (기존 notification 설정 사용), `FakeNotifier`
-
-### 4.6 Clock / IdGenerator
-
-테스트 격리용 시간 / 외부 ID (escalation 시 fingerprint suppression key 등) 주입.
-
-- 구현체: `StdClock`, `FixedClock` (테스트), `Sha256IdGen` 등
+이 분리 덕분에 autopilot 은 단일 의존성 (SQLite + Clock) 만 가지며, 테스트 / 배포 / 마이그레이션이 단순하다.
 
 ## 5. 트랜잭션 경계
 
-DB 의 일관성 보장은 `TaskStore` 의 메서드 단위에서 보장된다. 호출자(orchestration)는 트랜잭션을 직접 열지 않는다.
+DB 의 일관성 보장은 `TaskStore` 의 메서드 단위에서 보장된다. 호출자(CLI)는 트랜잭션을 직접 열지 않는다.
 
 | 메서드 | 트랜잭션 범위 |
 |--------|------------|
 | `insert_epic_with_tasks` | epic + 모든 task + 모든 dep + 진입점 ready 승격을 한 tx |
 | `claim_next_task` | 후보 SELECT + UPDATE WHERE status='ready' + claimed event INSERT 한 tx (changes()==1 검증) |
 | `complete_task_and_unblock` | task done UPDATE + 이 task 에 의존하던 blocked 들의 deps 재평가 + ready 승격 + completed event 한 tx |
-| `mark_task_failed` | attempts 증가 + (재시도 가능이면) ready 복귀 / (max 도달이면) escalated 전이 + event 한 tx. 반환값으로 outcome 알림 |
-| `escalate_task` | escalated 전이 + escalated_issue 기록 + 의존 task 들 blocked 전이 + event 한 tx |
+| `mark_task_failed` | attempts 증가 + (재시도 가능이면) ready 복귀 / (max 도달이면) escalated 전이 + 의존 task 들 blocked + event 한 tx. 반환값으로 outcome 알림 |
+| `escalate_task` | escalated 전이 + escalated_issue 기록 + event 한 tx |
+| `release_claim` | wip → ready + attempts -1 한 tx |
+| `force_status` | 임의 상태 → target + force_status event 한 tx (자식 unblock 안 함) |
 | `apply_reconciliation` | reconcile 결과 (변경 행들) 을 한 tx 로 반영. orphan 처리 포함 |
 | `append_event` (단일) | 자동 commit |
 
@@ -185,11 +163,9 @@ DB 의 일관성 보장은 `TaskStore` 의 메서드 단위에서 보장된다. 
 
 ## 6. 동시성 정책
 
-### 6.1 단일 writer 가정
+### 6.1 단일 머신 — 다중 CLI 호출
 
-DB 는 메인 autopilot 프로세스 (ML) 만 쓴다. 같은 머신의 다른 프로세스가 DB 를 직접 만지지 않으며, 자식 IM 도 DB 미접근. 다른 머신은 `epic-resume` 으로 reconcile 후 자기 DB 를 가짐.
-
-이 가정 하에 동시 접근자는 메인 프로세스 안의 sub-loop 들 (`gap-watch`, `build-tasks`, `merge-prs`, `qa-boost`, `ci-watch`, `epic_manager`) 뿐이다.
+배포 모델은 **머신당 `.autopilot/state.db` 1개**. autopilot 은 **장수 데몬을 안 만든다**. 매 호출이 별도 프로세스 — cron tick 의 `autopilot task claim` 과 운영자의 `autopilot task force-status` 가 동시 실행될 수 있다.
 
 ### 6.2 SQLite 모드
 
@@ -201,18 +177,20 @@ PRAGMA foreign_keys = ON;
 ```
 
 - WAL: 다중 reader / 단일 writer 동시 동작
-- BUSY 5s: sub-loop 간 짧은 충돌 자연 해소
+- BUSY 5s: 짧은 충돌 자연 해소
 - FK: deps / events 의 무결성
 
-### 6.3 sub-loop 직렬화
+이 셋만으로 다중 프로세스 호출이 안전하다. 데이터 손상은 없다.
 
-Rust 차원에서는 단일 `Arc<dyn TaskStore>` 를 공유한다. SqliteTaskStore 내부에 `Mutex<Connection>` (단일 connection) 또는 `r2d2::Pool` (multi-conn + WAL) 중 후자를 선택한다. 사유: 읽기 다중 + 쓰기 BUSY 대기로 단순.
+### 6.3 Race window 와 정책
 
-쓰기 메서드는 짧게 유지하여 BUSY 충돌을 최소화한다 (특히 reconcile 같은 큰 작업은 staged commit 으로 분할 — 03 에서 다룸).
+상태 전이 메서드의 SELECT-then-UPDATE 가 별 트랜잭션이면 race 시 audit payload 에 약간의 부정확이 가능 (예: `force_status` 의 `from` 이 직전 값과 어긋남). 이 정도는 **운영 모델에서 수용** — autopilot 은 spec 의 단일 작가 가정 하에 잘 동작하며, multi-process 도 데이터 무결성 위반 없이 동작.
+
+`claim_next_task` 의 원자성 (단일 UPDATE WHERE) 만은 엄격히 보장한다 — task 가 두 caller 에 동시 할당되면 git push reject 로 자연 차단되긴 하나, DB 차원에서도 한 명만 winner 가 되도록 한다 (UC-11).
 
 ### 6.4 git push 차원의 동시성
 
-UC-11 의 두 머신 케이스는 git remote 에서 자연 차단된다 (non-fast-forward reject). orchestration 의 BuildLoop 는 IM 의 push 결과를 항상 검사하고 reject 시 task 를 ready 로 되돌린다.
+UC-11 (두 머신 / 두 프로세스가 같은 task 를 동시에 claim 후 push) 은 git remote 가 자연 차단 (non-fast-forward reject). agent 는 push 결과를 검사하고 reject 시 `autopilot task release` 호출.
 
 ## 7. 에러 처리 정책
 
@@ -220,51 +198,44 @@ UC-11 의 두 머신 케이스는 git remote 에서 자연 차단된다 (non-fas
 
 | 분류 | 예시 | 처리 |
 |------|------|------|
-| **Domain error** | invalid status transition, dep cycle | 호출자에게 `Result::Err`. 발생 시 작업 중단 |
-| **Storage error** | DB 락, 디스크 full | 재시도 (BUSY) → 그래도 실패 시 sub-loop 종료 + 알림 |
-| **Network error** | git fetch 실패, GitHub API 타임아웃 | exponential backoff 재시도 (4회). 그래도 실패 시 다음 cycle 까지 대기 |
-| **Configuration error** | 설정 누락 | 시작 시 검증, 즉시 에러 종료 |
-| **Inconsistency** | DB 와 git remote 가 모순 (예: DB 는 done 인데 PR 미존재) | reconcile 으로 자동 해소 / 해소 안 되면 escalation |
+| **Domain error** | invalid status transition, dep cycle, inconsistency | 호출자 (agent) 에게 `Result::Err`. CLI 가 사용자용 메시지 + non-zero exit code 로 변환 |
+| **Storage error** | DB 락, 디스크 full, schema mismatch | BUSY 재시도 후 실패 시 에러 종료. agent 가 retry 결정 |
+| **CLI usage error** | 잘못된 인자, 누락 옵션 | clap 이 처리. exit 1 |
+
+autopilot 자체는 네트워크 / git / GitHub 에러를 다루지 않는다 — agent 의 영역.
 
 ### 7.2 에러 타입
 
 `thiserror` 기반 enum 을 도메인 / 포트별로 분리:
 
-- `domain::DomainError`
-- `ports::TaskStoreError`, `GitError`, `GitHubError`, `DecomposeError`
-- orchestration 에서는 `OrchestrationError` 로 wrap
+- `domain::DomainError` (DepCycle, IllegalTransition, EpicAlreadyExists, UnknownDepTarget, DuplicateTaskId, Inconsistency)
+- `ports::TaskStoreError` (Busy, Backend, SchemaMismatch, NotFound, Domain)
 
 CLI 진입점에서 사용자용 메시지로 변환.
 
 ## 8. 설정 / 컴포지션 루트
 
-`AutopilotConfig` 가 모든 외부 입력을 한 곳에 모은다 (파일 + 환경변수 + CLI 플래그 우선순위 적용).
+`autopilot.toml` (기존 위치 유지) 의 ledger 관련 항목은 단순:
 
-```
+```toml
 [storage]
 db_path = ".autopilot/state.db"
 
 [epic]
-branch_prefix = "epic/"
-max_attempts = 3
-
-[hitl]
-label = "autopilot:hitl-needed"
-escalation_suppression_window_hours = 24
-
-[concurrency]
-max_parallel_agents = 4
+max_attempts = 3                        # task fail 시 escalate 임계
+hitl_label   = "autopilot:hitl-needed"  # 정보용; agent 가 사용
 ```
+
+기존 헬퍼 (gh / git / watch / pipeline ...) 의 설정은 별도 섹션이며 ledger 와 독립.
 
 `main.rs` 가 컴포지션 루트로서 다음을 수행:
 
 1. 설정 로드 + 검증
-2. SQLite 연결 + 마이그레이션 적용
-3. 어댑터들 인스턴스화 (SqliteTaskStore, GitCli, GitHubMcpClient, ...)
-4. orchestration 컴포넌트 인스턴스화 (포트 주입)
-5. clap 서브커맨드 디스패치
+2. SQLite 연결 + 마이그레이션 적용 (V1 → V2 → ...)
+3. `StdClock` 인스턴스화
+4. clap 서브커맨드 디스패치 (각 cmd 핸들러에 store + clock 주입)
 
-테스트는 4번에서 fake 어댑터를 주입한다.
+테스트는 4번에서 `InMemoryTaskStore` + `FixedClock` 주입.
 
 ## 9. 마이그레이션 정책
 
@@ -273,38 +244,38 @@ max_parallel_agents = 4
 ```
 src/store/migrations/
 ├── V1__initial.sql
-├── V2__...
+├── V2__lookup_indexes.sql
 └── ...
 ```
 
-`meta(key='schema_version')` 행으로 적용 상태 추적. 시작 시 누락된 버전 적용. 다운그레이드는 비지원 (사용자에게 DB 삭제 + resume 안내).
+`meta(key='schema_version')` 행으로 적용 상태 추적. 시작 시 누락된 버전 적용. 다운그레이드는 비지원 (사용자에게 DB 삭제 + reconcile 안내).
 
 ## 10. 인터페이스 ↔ UC 매핑
 
-본 문서의 포트가 01 의 시나리오를 어떻게 충족하는지:
+각 UC 의 핵심은 "agent 가 호출하는 CLI 시퀀스" 와 "autopilot 이 트리거하는 trait 메서드" 로 표현된다.
 
-| UC | 사용 포트 | 핵심 호출 경로 |
-|----|----------|--------------|
-| 1 | TaskStore + GitClient + SpecDecomposer | EpicManager::start → decompose → insert_epic_with_tasks → git push epic branch |
-| 2 | TaskStore + GitClient + GitHubClient | BuildLoop::tick → claim_next_task → IM 호출 → push 결과 → branch_promoter (PR) → MergeLoop::tick → complete_task_and_unblock |
-| 3 | TaskStore | claim 시 deps 필터, complete 시 unblock_dependents |
-| 4-5 | TaskStore + GitClient + SpecDecomposer + GitHubClient | Reconciler::reconcile_epic → fetch + ls-remote + PR 스캔 → apply_reconciliation |
-| 6 | TaskStore | WatchDispatcher::dispatch → epic 매칭 → upsert task |
-| 7-9 | GitHubClient + TaskStore | Escalator::escalate → 이슈 발행 + escalated_issue 기록. EscalationWatcher → 사람이 close 한 이슈 자동 인식 → reconcile |
-| 8 | TaskStore | mark_task_failed → outcome 분기 |
-| 10 | TaskStore + Notifier | MergeLoop::tick → all_tasks_done 판정 → notifier.send. escalated 잔류 시 EpicCompleted 미발송 (사람이 force-status 또는 코드 push 로 해소해야 함) |
-| 11 | GitClient | BuildLoop 의 push reject 처리 (DB 변경 없음) |
-| 12 | TaskStore | EpicManager::stop → epic.status=abandoned |
-| 13 | TaskStore + GitHubClient | MigrateCommand → import_issue → upsert task + 이슈 라벨 정리 |
+| UC | Agent CLI 호출 시퀀스 | Autopilot trait 메서드 |
+|----|--------------------|----------------------|
+| 1 (epic-start) | `epic create` → `task add` × N (또는 batch) → `git push` (헬퍼) | `EpicRepo::upsert_epic`, `TaskRepo::insert_epic_with_tasks` |
+| 2 (task 자동 구현) | `task claim` → 구현 → `task complete --pr N` (또는 fail / release) | `TaskRepo::claim_next_task`, `complete_task_and_unblock`, `mark_task_failed`, `release_claim` |
+| 3 (deps) | (UC-2 와 동일) | `claim_next_task` 의 deps 필터, `complete_task_and_unblock` 의 unblock 로직 |
+| 4-5 (resume / 복구) | monitor 호출 → git scan → `epic reconcile --plan ...` | `TaskRepo::apply_reconciliation` |
+| 6 (watch 매칭) | monitor 호출 → `epic find-by-spec-path` → `task add` | `EpicRepo::find_active_by_spec_path`, `TaskRepo::upsert_watch_task` |
+| 7 (watch 미매칭) | `suppress check` → 신규면 GitHub 이슈 발행 → `suppress add` | `SuppressionRepo::is_suppressed`, `suppress` |
+| 8 (반복 실패) | `task fail` → outcome=Escalated 면 GitHub 이슈 + `task escalate` | `TaskRepo::mark_task_failed`, `escalate_task` |
+| 9 (escalation 해소) | issue close 감지 → `epic reconcile` 또는 `suppress add reason='rejected_by_human'` | `apply_reconciliation`, `SuppressionRepo::suppress` |
+| 10 (epic 완료) | `epic status` 가 all-done → `epic complete` + 알림 | `EpicRepo::set_epic_status` |
+| 11 (동시 push 차단) | push reject 감지 → `task release` | `TaskRepo::release_claim` (attempts -1) |
+| 12 (epic 중단) | `epic abandon` | `EpicRepo::set_epic_status` |
+| 13 (마이그레이션) | 사람 이슈 본문 → spec 매칭 → `task add --source=human` + 라벨 정리 | `TaskRepo::upsert_watch_task` (source=Human) |
 
 ## 11. 테스트 가능성
 
 각 어댑터는 LSP 를 만족하는 인메모리 / fake 구현을 가진다:
 
-- `InMemoryTaskStore`: HashMap 기반, 동일 트랜잭션 의미 (단일 mutex)
-- `FakeGitClient`: 가상 ref 그래프 + push reject 시뮬레이션
-- `FakeGitHubClient`: 이슈/PR 가상 저장소
-- `FakeDecomposer`: 사전 정의된 task 목록 반환
-- `FakeNotifier`: 송신 메시지 캡처
+- `InMemoryTaskStore`: HashMap/BTreeMap 기반, 동일 트랜잭션 의미 (단일 mutex)
+- `FixedClock`: 테스트 시 시간 고정
 
-블랙박스 테스트는 orchestration 컴포넌트 단위로 fake 들을 wiring 하여 04 의 시나리오를 검증한다.
+orchestration 어댑터 (FakeGit, FakeGitHub, FakeDecomposer, FakeNotifier) 는 **본 spec 의 책임이 아니다** — agent 측에서 자기 워크플로에 맞춰 격리한다.
+
+블랙박스 테스트는 `TaskStore` 의 conformance suite 로 양 어댑터에 동일 검증을 적용 (04 §4).

--- a/plans/github-autopilot/03-detailed-spec.md
+++ b/plans/github-autopilot/03-detailed-spec.md
@@ -257,89 +257,7 @@ pub struct EventFilter {
 }
 ```
 
-### 2.2 GitClient
-
-```rust
-// ports/git.rs
-pub trait GitClient: Send + Sync {
-    fn current_branch(&self) -> Result<String>;
-    fn working_tree_clean(&self) -> Result<bool>;
-
-    fn fetch_origin(&self, refspec: Option<&str>) -> Result<()>;
-    fn ls_remote_branches(&self, prefix: &str) -> Result<Vec<String>>;
-    fn create_branch_from(&self, new_branch: &str, base: &str) -> Result<()>;
-    fn push_branch(&self, branch: &str) -> Result<PushOutcome>;
-    fn delete_remote_branch(&self, branch: &str) -> Result<()>;
-
-    fn rev_parse(&self, refname: &str) -> Result<Option<String>>;
-}
-
-pub enum PushOutcome { Created, FastForward, Rejected(String) }
-```
-
-### 2.3 GitHubClient
-
-```rust
-// ports/github.rs
-pub trait GitHubClient: Send + Sync {
-    fn create_issue(&self, req: CreateIssue) -> Result<u64>;
-    fn close_issue(&self, number: u64) -> Result<()>;
-    fn add_issue_comment(&self, number: u64, body: &str) -> Result<()>;
-    fn add_issue_labels(&self, number: u64, labels: &[String]) -> Result<()>;
-    fn remove_issue_labels(&self, number: u64, labels: &[String]) -> Result<()>;
-    fn list_issues(&self, filter: IssueFilter) -> Result<Vec<IssueRef>>;
-    fn get_issue(&self, number: u64) -> Result<Option<IssueRef>>;
-
-    fn create_pr(&self, req: CreatePr) -> Result<u64>;
-    fn merge_pr(&self, number: u64, method: MergeMethod) -> Result<()>;
-    fn list_prs_targeting(&self, base_branch: &str) -> Result<Vec<PrRef>>;
-    fn get_pr(&self, number: u64) -> Result<Option<PrRef>>;
-}
-
-pub struct CreateIssue { pub title: String, pub body: String, pub labels: Vec<String> }
-pub struct CreatePr { pub head: String, pub base: String, pub title: String, pub body: String, pub labels: Vec<String> }
-pub struct PrRef { pub number: u64, pub head: String, pub base: String, pub merged: bool, pub closed: bool, pub labels: Vec<String> }
-pub struct IssueRef {
-    pub number: u64,
-    pub title: String,
-    pub closed: bool,
-    pub labels: Vec<String>,
-    pub body_meta: Option<EscalationMeta>,
-}
-pub struct IssueFilter { pub labels: Vec<String>, pub state: IssueState }
-pub enum IssueState { Open, Closed, All }
-pub enum MergeMethod { Squash, Merge, Rebase }
-```
-
-### 2.4 SpecDecomposer
-
-```rust
-// ports/decompose.rs
-pub trait SpecDecomposer: Send + Sync {
-    fn decompose(&self, spec_path: &Path, epic_name: &str) -> Result<DecomposeOutput>;
-}
-
-pub struct DecomposeOutput {
-    pub tasks: Vec<NewTask>,            // id 는 결정적
-    pub deps: Vec<(TaskId, TaskId)>,
-}
-```
-
-### 2.5 Notifier
-
-```rust
-// ports/notifier.rs
-pub trait Notifier: Send + Sync {
-    fn send(&self, event: NotificationEvent) -> Result<()>;
-}
-
-pub enum NotificationEvent {
-    EpicCompleted { epic: String },
-    EscalationOpened { epic: Option<String>, task: Option<TaskId>, issue: u64 },
-}
-```
-
-### 2.6 Clock
+### 2.2 Clock
 
 ```rust
 // ports/clock.rs
@@ -609,151 +527,132 @@ fn apply_reconciliation(plan: ReconciliationPlan, now):
 
 idempotency: 동일 plan 으로 N번 호출해도 결과 동일. attempts 카운터는 보존되며 status 는 리모트 기준으로 권위적으로 재설정.
 
-### 5.6 WatchDispatcher (UC-6, UC-7)
+### 5.6 Agent 측 흐름 (의사코드, 참고용)
+
+본 §5 의 알고리즘은 모두 autopilot 내부 (TaskStore 메서드) 의 것이다. Agent 는 이들을 CLI 로
+호출하며 자기 흐름은 자유롭게 설계한다. 권장 패턴:
 
 ```
-fn dispatch_finding(finding: WatchFinding):
-  match task_store.find_active_by_spec_path(finding.spec_path):
-    Some(epic):
-      task_id = TaskId::new_deterministic(epic.name, finding.section, finding.requirement)
-      outcome = task_store.upsert_watch_task(NewWatchTask{
-        id: task_id,
-        epic_name: epic.name,
-        source: finding.source,
-        fingerprint: finding.fingerprint,
-        title: finding.title,
-        body: finding.body,
-      }, now)
-      log event accordingly
-    None:
-      if task_store.is_suppressed(finding.fingerprint, "unmatched_watch", now): return
-      issue_number = github.create_issue(escalation_template(finding))
-      task_store.append_event(kind='escalated', payload={...})
-      task_store.suppress(
-        finding.fingerprint,
-        reason="unmatched_watch",
-        suppress_until = now + Duration::hours(escalation_suppression_window_hours),
-      )
-```
+# Watch dispatch (UC-6, UC-7)
+fn agent_dispatch_finding(finding):
+  let epic = `autopilot epic find-by-spec-path <finding.spec_path>` (JSON)
+  if epic is Some:
+    `autopilot task add --epic <epic.name> --id <det_id>
+                       --section <finding.section> --requirement <finding.req>
+                       --fingerprint <finding.fp> --source gap-watch`
+    # autopilot 이 fingerprint 중복 시 DuplicateFingerprint 로 응답 → no-op
+  else:
+    if `autopilot suppress check --fingerprint <fp> --reason unmatched_watch`:
+      return
+    issue_n = `gh issue create --label autopilot:hitl-needed ...`
+    `autopilot suppress add --fingerprint <fp> --reason unmatched_watch --until <now+24h>`
 
-`upsert_watch_task` 는 fingerprint 충돌 시 `DuplicateFingerprint(existing_id)` 반환, orchestration 에서 이를 보고 신규 발행 skip.
+# Build cycle (UC-2, UC-11)
+fn agent_build_tick():
+  for epic in `autopilot epic list --status active` (JSON):
+    while parallel_count < max_parallel:
+      let task = `autopilot task claim --epic <epic.name>` or break
+      let branch = format!("epic/{}/{}", epic.name, task.id)
+      result = implement_and_push(branch, task)
+      match result:
+        PrCreated(n)   -> `autopilot task complete --id <task.id> --pr <n>`
+        PushRejected   -> `autopilot task release --id <task.id>`   # UC-11
+        OtherFailure   ->
+          let outcome = `autopilot task fail --id <task.id>`
+          if outcome == Escalated:
+            issue_n = `gh issue create --label autopilot:hitl-needed ...`
+            `autopilot task escalate --id <task.id> --issue <issue_n>`
 
-### 5.7 BuildLoop tick (UC-2, UC-11)
-
-```
-fn tick():
+# Escalation resolution polling (UC-9)
+fn agent_escalation_tick():
   for epic in active_epics:
-    while parallel_agents < max_parallel_agents:
-      task = task_store.claim_next_task(epic.name, now)
-      if task is None: break
-      branch = format!("{prefix}/{epic.name}/{task.id}", prefix=epic_branch_prefix)
-      spawn_implementer(epic, task, branch)
-        on_pr_created(pr_number) ->
-            -- PR 생성 성공. 머지는 MergeLoop 가 후속 처리.
-            task_store.append_event(kind='task_started', task=task.id, payload={pr: pr_number})
-        on_push_rejected         ->
-            -- UC-11: 다른 머신 / 다른 sub-loop 가 먼저 가져감. 시도 회복.
-            task_store.release_claim(task.id, now)
-            task_store.append_event(kind='claim_lost', task=task.id)
-        on_implementation_failed ->
-            -- 코드 작성 실패 / push 후 PR 생성 실패 / CI 실패 등. 시도는 보존.
-            outcome = task_store.mark_task_failed(task.id, max_attempts, now)
-            if Escalated: escalator.escalate(task)
-```
-
-`release_claim` 과 `mark_task_failed` 의 선택 기준: **시도조차 못 했으면** `release_claim`, **시도했으나 실패** 면 `mark_task_failed`.
-
-### 5.8 MergeLoop tick (UC-2, UC-10)
-
-```
-fn tick():
-  for epic in active_epics:
-    prs = github.list_prs_targeting(epic.branch, labels=[":auto"], state=open)
-    for pr in prs:
-      if pr 의 ci 상태 통과 + 충돌 없음:
-        github.merge_pr(pr.number, MergeMethod::Squash)
-        task = task_store.find_task_by_pr(pr.number)
-        if task is Some: task_store.complete_task_and_unblock(task.id, pr.number, now)
-
-    -- epic 완료 판정
-    -- "사람이 close 한 escalated" 의 자동 인식은 §5.9 EscalationWatcher 가 별도로 처리.
-    -- 본 루프에서는 task.status ∈ {done} 여부만 본다.
-    if all_tasks_done(epic):
-      epic_manager.complete(epic.name)
-      notifier.send(EpicCompleted { epic: epic.name })
-```
-
-### 5.9 EscalationWatcher tick (UC-9, UC-10)
-
-`EscalationWatcher` 는 escalated task 의 GitHub 이슈 close 를 주기 폴링하여 사람의 직접 해소를
-자동 인식한다. MergeLoop 와 분리한 이유: SRP — MergeLoop 는 PR 머지 흐름만, 본 루프는
-escalation 해소 흐름만 담당. 폴링 주기는 MergeLoop 보다 길게 (예: 5분).
-
-```
-fn tick():
-  for epic in active_epics:
-    escalated = task_store.list_tasks_by_epic(epic.name, status=Escalated)
-    for task in escalated:
+    for task in `autopilot task list --epic <epic.name> --status escalated`:
       if task.escalated_issue is None: continue
-      issue = github.get_issue(task.escalated_issue)
-      if issue is None or !issue.closed: continue
-
-      -- 사람이 issue 를 close 했음. 두 케이스:
-      -- (a) 사람이 직접 코드를 작성하여 epic 브랜치에 PR 머지 → reconcile 이 done 으로 인식
-      -- (b) 단순 거부 / 무시 close → suppression 등록 (해당 fingerprint 추가 escalate 차단)
-      reconciler.reconcile_epic(epic.name, now)
-      task_after = task_store.get_task(task.id)
-      if task_after.status != Done:
-        -- (b) 케이스. 사람이 코드 작업 없이 close 한 것으로 간주.
-        if task.fingerprint is Some:
-          task_store.suppress(
-            task.fingerprint, reason="rejected_by_human",
-            suppress_until = now + Duration::days(30),
-          )
-        task_store.append_event(kind='escalation_resolved',
-                                payload={resolution: 'rejected'}, task=task.id)
-      else:
-        task_store.append_event(kind='escalation_resolved',
-                                payload={resolution: 'human_fixed'}, task=task.id)
+      let issue = gh.get_issue(task.escalated_issue)
+      if not issue.closed: continue
+      # 사람이 close 했음. reconcile 시도 → done 이면 자연 흡수, 아니면 suppress 등록
+      let plan = build_reconcile_plan(epic, monitor, git)
+      `autopilot epic reconcile --name <epic.name> --plan <plan.jsonl>`
+      let task_after = `autopilot task get <task.id>`
+      if task_after.status != "done":
+        `autopilot suppress add --fingerprint <task.fingerprint>
+                                --reason rejected_by_human --until <now+30d>`
 ```
 
-**중요한 invariant**: 본 루프는 `force_status` 를 직접 호출하지 않는다. 상태 전이는 reconcile
-(idempotent) 또는 다른 정상 경로를 통해서만 일어난다.
+이 흐름은 단지 권장 구현일 뿐 — agent 는 자유롭게 구성할 수 있다. autopilot 의 트레이트 메서드
+계약 (§2, §5.1-§5.5) 만 만족하면 된다.
 
 ## 6. CLI 시그니처 (clap)
 
-`autopilot epic <subcommand>`:
+전 명령은 `--json` 출력 옵션을 지원하며, 기본은 사람용 요약. exit code: 0 정상 / 1 사용자 에러 / 2 일시적 시스템 에러 (재시도 가치 있음) / 3 영구적 시스템 에러.
+
+### 6.1 `autopilot epic` (Ledger CLI)
 
 ```
-autopilot epic start   --spec <PATH> --name <NAME> [--from-branch <REF>] [--dry-run]
-autopilot epic resume  <NAME> [--reset-attempts]
-autopilot epic stop    <NAME> [--purge-branches]
-autopilot epic status  [<NAME>] [--json]
-autopilot epic list    [--status active|completed|abandoned|all]
+autopilot epic create     --name <NAME> --spec <PATH> [--branch <REF>]
+                          [--from-branch <REF>]                              # branch 기본값: epic/<NAME>
+autopilot epic list       [--status active|completed|abandoned|all] [--json]
+autopilot epic get        <NAME> [--json]
+autopilot epic status     [<NAME>] [--json]                                  # task 상태 카운트
+autopilot epic complete   <NAME>                                             # status='completed' + 알림은 agent 책임
+autopilot epic abandon    <NAME>
+autopilot epic reconcile  --name <NAME> --plan <FILE>                        # JSONL: tasks + deps + remote_state + orphan_branches
+
+autopilot epic find-by-spec-path <PATH> [--json]                             # invariant 위반 시 exit 3 + Inconsistency 메시지
 ```
 
-`autopilot task <subcommand>` (운영자용 진단/오버라이드):
+### 6.2 `autopilot task` (Ledger CLI)
 
 ```
-autopilot task list    --epic <NAME> [--status <STATUS>] [--json]
-autopilot task show    <TASK_ID> [--json]
-autopilot task force-status <TASK_ID> --to <STATUS> [--reason <TEXT>]
+autopilot task add        --epic <NAME> --id <TASK_ID>
+                          [--section <PATH>] [--requirement <TEXT>]
+                          [--title <TEXT>] [--body <TEXT>]
+                          [--fingerprint <FP>]
+                          [--source decompose|gap-watch|qa-boost|ci-watch|human]
+autopilot task add-batch  --epic <NAME> --from <FILE>                        # JSONL: NewTask 한 줄에 1건
+autopilot task list       --epic <NAME> [--status <STATUS>] [--json]
+autopilot task get        <TASK_ID> [--json]
+autopilot task find-by-pr <PR_NUMBER> [--json]
+
+autopilot task claim      --epic <NAME> [--json]                             # 다음 ready task 원자적 wip 전환
+autopilot task release    <TASK_ID>                                          # UC-11 claim_lost (attempts -1)
+autopilot task complete   <TASK_ID> --pr <NUMBER>
+autopilot task fail       <TASK_ID>                                          # exit 0 + Retried | Escalated 출력
+autopilot task escalate   <TASK_ID> --issue <NUMBER>
+autopilot task force-status <TASK_ID> --to <STATUS> [--reason <TEXT>]        # 운영자 override
 ```
 
-`autopilot migrate <subcommand>`:
+### 6.3 `autopilot suppress` (Ledger CLI)
 
 ```
-autopilot migrate import-issue <ISSUE_NUMBER> [--epic <NAME>]
-autopilot migrate scan-issues  [--label <LABEL>=":ready"]      # 후보 목록만 출력
+autopilot suppress add    --fingerprint <FP> --reason <TEXT> --until <ISO8601>
+autopilot suppress check  --fingerprint <FP> --reason <TEXT>                 # exit 0=억제 중 / exit 1=아님
+autopilot suppress clear  --fingerprint <FP> --reason <TEXT>
 ```
 
-기존 명령 변화 (04 watch-integration 에서 자세히):
+### 6.4 `autopilot events` (Ledger CLI)
 
-- `autopilot pipeline build-tasks` (build-issues 대체)
-- `autopilot pipeline merge-prs` (의미 동일, task store 업데이트 추가)
-- `autopilot watch run` (gap/qa/ci 통합 진입, 기존 유지)
+```
+autopilot events list     [--epic <NAME>] [--task <TASK_ID>] [--kind <KIND>...]
+                          [--since <ISO8601>] [--limit <N>] [--json]
+```
 
-출력 포맷: 기본은 사람용 표/요약, `--json` 일 때 stable schema. exit code: 0 정상 / 1 사용자 에러 / 2 일시적 시스템 에러 (재시도 가치 있음) / 3 영구적 시스템 에러.
+### 6.5 기존 헬퍼 명령
+
+`watch run`, `pipeline idle`, `worktree`, `issue`, `issue list`, `labels`, `preflight`, `simhash`, `stats`, `check` 는 기존 시그니처 그대로. **ledger 와 결합되지 않음** — agent 가 자기 흐름에서 자유롭게 호출.
+
+### 6.6 입출력 형식 (JSONL)
+
+`epic reconcile --plan` 의 JSONL 한 줄 예시:
+
+```json
+{"kind":"task","id":"a1b2c3d4e5f6","title":"...","section":"## 인증","requirement":"토큰 갱신","fingerprint":null}
+{"kind":"dep","task":"b2c3d4e5f6a1","depends_on":"a1b2c3d4e5f6"}
+{"kind":"remote_state","task_id":"a1b2c3d4e5f6","branch_exists":true,"pr":{"number":42,"merged":true,"closed":true}}
+{"kind":"orphan_branch","ref":"epic/auth/old-task-id"}
+```
+
+`task add-batch --from` 의 JSONL: 각 줄이 NewTask (`id`, `title`, `body?`, `section?`, `requirement?`, `fingerprint?`, `source`).
 
 ## 7. 에러 타입
 
@@ -767,6 +666,10 @@ pub enum DomainError {
     IllegalTransition(TaskId, TaskStatus, TaskStatus),
     #[error("epic '{0}' already exists with status {1:?}")]
     EpicAlreadyExists(String, EpicStatus),
+    #[error("dep references unknown task: {0}")]
+    UnknownDepTarget(TaskId),
+    #[error("duplicate task id in plan: {0}")]
+    DuplicateTaskId(TaskId),
     /// 데이터 불변식 위반 (예: 동일 spec_path 의 active epic 이 2개 이상).
     /// 정상 흐름에서는 발생할 수 없으며, 발생 시 사람 개입 필요.
     #[error("inconsistency: {0}")]
@@ -780,52 +683,30 @@ pub enum TaskStoreError {
     #[error("storage backend: {0}")]        Backend(String),
     #[error("schema mismatch: at v{found}, expected v{expected}")]
     SchemaMismatch { found: u32, expected: u32 },
+    #[error("not found: {0}")]              NotFound(String),
     #[error(transparent)]                   Domain(#[from] DomainError),
-}
-
-// 동일 패턴으로:
-pub enum GitError      { NotARepo, FetchFailed(String), PushRejected(String), Other(String) }
-pub enum GitHubError   { Network(String), NotFound, Unauthorized, RateLimited, Other(String) }
-pub enum DecomposeError{ SpecNotFound(PathBuf), Parse(String), Other(String) }
-
-// orchestration/error.rs
-#[derive(Debug, thiserror::Error)]
-pub enum OrchestrationError {
-    #[error(transparent)] Store(#[from] TaskStoreError),
-    #[error(transparent)] Git(#[from] GitError),
-    #[error(transparent)] GitHub(#[from] GitHubError),
-    #[error(transparent)] Decompose(#[from] DecomposeError),
-    #[error(transparent)] Domain(#[from] DomainError),
-    #[error("inconsistency: {0}")] Inconsistency(String),
 }
 ```
 
-CLI 진입점은 `OrchestrationError` 를 받아 사용자 메시지 + exit code 매핑.
+git / GitHub / 분해 실패 / 알림 실패 등 외부 도구 에러는 **agent 의 영역** 으로 autopilot 의 트레이트 시스템에 들어가지 않는다. CLI 진입점은 `TaskStoreError` 를 사용자 메시지 + exit code 로 매핑한다.
 
 ## 8. 설정 스키마
 
-`autopilot.toml` (기본 위치는 기존 설정 컨벤션 유지):
+`autopilot.toml` (기본 위치는 기존 설정 컨벤션 유지). Ledger 관련 항목만 정의:
 
 ```toml
 [storage]
 db_path = ".autopilot/state.db"
 
 [epic]
-branch_prefix       = "epic/"
-max_attempts        = 3
-deps_cycle_check    = true
+max_attempts = 3                   # task fail → outcome=Escalated 임계
+hitl_label   = "autopilot:hitl-needed"   # 정보용; agent 측이 사용
 
-[hitl]
-label                                = "autopilot:hitl-needed"
-escalation_suppression_window_hours  = 24
-
-[concurrency]
-max_parallel_agents = 4
-sqlite_busy_timeout_ms = 5000
-
-[migration]
-epic_based = true                  # false 면 기존 라벨 기반 동작 유지 (06 spec)
+[suppression]
+default_window_hours = 24          # suppress add 의 --until 기본 (선택)
 ```
+
+다른 헬퍼 명령 (gh / git / watch / pipeline ...) 의 설정은 별도 섹션으로 유지되며 ledger 와 독립.
 
 설정 우선순위: CLI 플래그 > 환경변수 (`AUTOPILOT_*`) > 파일 > 기본값. 시작 시 유효성 검사 실패면 즉시 종료 (exit 1).
 

--- a/plans/github-autopilot/04-test-scenarios.md
+++ b/plans/github-autopilot/04-test-scenarios.md
@@ -4,38 +4,32 @@
 
 ## 1. 테스트 레이어와 격리
 
+Ledger 모델에서 autopilot 의 책임은 TaskStore + CLI 까지다. 그 위의 워크플로 (UC-1~13 의 시나리오 통합) 검증은 **agent 측의 책임** 이다 — 본 spec 의 범위 밖.
+
 | 레이어 | 대상 | 어댑터 | 격리 단위 |
 |--------|------|--------|----------|
 | **L1. Domain** | pure 함수 / 타입 (TaskId, TaskGraph, deps cycle) | 없음 | 함수별 단위 |
 | **L2. Store conformance** | TaskStore 의 트랜잭션 의미 (LSP) | `InMemoryTaskStore` + `SqliteTaskStore` 양쪽에 동일 suite 실행 | 메서드 + tx 경계 |
-| **L3. Orchestration** | EpicManager / BuildLoop / WatchDispatcher / MergeLoop / Reconciler / Escalator | 모든 포트는 fake (InMemoryTaskStore, FakeGit, FakeGitHub, FakeDecomposer, FakeNotifier, FixedClock) | UC 1건 = 1 시나리오 |
-| **L4. Property** | 결정적 ID 충돌, reconcile 멱등성, 동시 claim 의 원자성 | proptest 기반 임의 입력 | 불변식별 |
+| **L3. CLI 통합** | clap 진입점 ↔ TaskStore 연결, JSON 출력 / exit code | `InMemoryTaskStore` + `FixedClock` 주입 | 명령 1건 |
+| **L4. Property** | 결정적 ID 충돌, attempts 단조성, reconcile 멱등성, 동시 claim 원자성 | proptest 기반 임의 입력 | 불변식별 |
 
-CLI 진입점 / SQLite 어댑터의 실 SQL 동작은 L2 가 담당한다. 별도 e2e (실제 git/GitHub) 테스트는 본 문서 범위 밖 — CI 환경에서 수동 smoke 만 수행.
+E2E (실제 git / GitHub) 테스트와 agent 측 워크플로 통합은 본 문서 범위 밖.
 
 ## 2. 공통 fixture 형식
 
-각 시나리오는 다음 YAML-like 구조로 표기한다 (실제 구현에서는 builder 함수 권장):
+L2 / L3 / L4 모두 in-memory store 와 fixed clock 을 기본 fixture 로 사용. agent 와의 통합 fixture (FakeGit / FakeGitHub / FakeDecomposer / FakeNotifier) 는 더 이상 본 spec 의 책임이 아니다.
 
 ```yaml
 fixture:
   clock:
     now: "2026-04-28T09:00:00Z"
-  epic:
-    name: "auth-token-refresh"
-    spec_path: "spec/auth.md"
-    branch: "epic/auth-token-refresh"
-  decomposer:
-    tasks:
-      - { section: "## 인증", req: "토큰 갱신",   id: "<derived>" }
-      - { section: "## 인증", req: "401 재시도", id: "<derived>" }
-    deps: []
-  git:
-    initial_branches: ["main"]
-    push_rejects: []
-  github:
-    issues: []
-    prs: []
+  store: in-memory   # 또는 sqlite (conformance 비교)
+  epics:
+    - { name: "auth-token-refresh", spec_path: "spec/auth.md", status: "active" }
+  tasks:
+    - { id: "<derived>", epic: "auth-token-refresh", status: "ready", title: "..." }
+  deps: []
+  events: []
 ```
 
 `<derived>` 는 결정적 ID 함수의 결과 (테스트 setup 에서 계산하여 매칭).
@@ -318,282 +312,64 @@ test: sqlite_rejects_unknown_higher_version
   then:  Err(SchemaMismatch{found:999, expected:1})
 ```
 
-## 5. L3: Orchestration 시나리오 (UC ↔ 테스트)
 
-각 시나리오는 fake 어댑터로 wiring 한 orchestration 컴포넌트를 호출하고 외부 관찰점 (DB, FakeGit ref 그래프, FakeGitHub 이슈/PR, FakeNotifier 메시지) 으로 사후 조건을 검증한다.
+## 5. L3: CLI 통합
 
-### UC-1. Epic 시작
-
-```
-test: uc1_epic_start_creates_branch_and_seeds_tasks
-  fixture:
-    git: branches=[main], working_tree_clean=true
-    decomposer: tasks=[(s1,r1), (s2,r2)], deps=[]
-  when:  EpicManager::start({ name:"e", spec:"spec/auth.md" })
-  then:
-    git.branches contains "epic/e"
-    git.pushed contains "epic/e"
-    store.list_epics() == [Epic{name:"e", status='active', ...}]
-    store.list_tasks_by_epic("e") -> 2 tasks, 둘 다 status='ready'
-    store.events: epic_started + 2x task_inserted
-
-test: uc1_epic_start_rolls_back_on_decomposer_failure
-  fixture: decomposer.fail = SpecNotFound
-  when:  EpicManager::start({ name:"e", spec:"missing.md" })
-  then:  Err(_)
-         store.list_epics() empty
-         git.branches unchanged
-
-test: uc1_epic_start_rejects_dirty_working_tree
-  fixture: git.working_tree_clean=false
-  when:  EpicManager::start(...)
-  then:  Err(GitError::DirtyWorkingTree)
-
-test: uc1_epic_start_rejects_when_active_epic_with_same_name
-  fixture: store has epic "e" with status='active'
-  when:  EpicManager::start({ name:"e" })
-  then:  Err(EpicAlreadyExists)
-```
-
-### UC-2. Task 자동 구현 사이클
+CLI 진입점이 trait 메서드를 올바르게 디스패치하고 JSON 출력 / exit code 가 안정적인지 검증한다. `InMemoryTaskStore` + `FixedClock` 을 직접 주입하고 `assert_cmd` 또는 동등 도구로 stdout / exit code 를 검사한다.
 
 ```
-test: uc2_full_cycle_claim_to_merged
-  fixture:
-    epic "e" with 1 ready task A
-    fake_implementer: on_invoke push branch successfully
-    github: empty
-  when:
-    BuildLoop::tick()           -> claim A, IM push, branch_promoter create PR #100
-    MergeLoop::tick()           -> CI ok 가정, merge PR #100
-  then:
-    A.status == 'done'
-    A.pr_number == 100
-    events sequence: task_claimed, task_started, task_completed
-    github.prs[100].merged == true
+test: cli_epic_create_persists_and_emits_event
+  given: empty store
+  when:  `autopilot epic create --name e --spec spec/e.md`
+  then:  exit 0
+         store.list_epics() == [Epic{name="e", status=active, ...}]
+         events: epic_started
 
-test: uc2_push_failure_returns_task_to_ready
-  fixture: fake_implementer pushes successfully but branch_promoter fails to create PR
-  when:  BuildLoop::tick()
-  then:  A.status == 'ready'
-         events: task_failed (non-final)
+test: cli_task_claim_outputs_next_ready_task_as_json
+  given: epic e with task A(ready)
+  when:  `autopilot task claim --epic e --json`
+  then:  exit 0
+         stdout JSON: {"id":"...A...","status":"wip","attempts":1,...}
+         get_task(A).status == Wip
+
+test: cli_task_claim_signals_no_ready_via_exit_code
+  given: epic e with no ready task
+  when:  `autopilot task claim --epic e`
+  then:  exit 1   # "no ready task" 신호 (사용자 에러 아님)
+
+test: cli_task_complete_updates_pr_and_unblocks
+  given: A(wip), B(pending, deps=[A])
+  when:  `autopilot task complete <A.id> --pr 42`
+  then:  A.status == Done, A.pr_number == 42
+         B.status == Ready
+
+test: cli_task_fail_reports_outcome
+  given: A(wip, attempts=2), max_attempts=3
+  when:  `autopilot task fail <A.id>`
+  then:  exit 0
+         stdout JSON: {"outcome":"retried","attempts":2}
+         A.status == Ready
+
+  when (한번 더 claim → fail): 동일 호출
+  then:  stdout JSON: {"outcome":"escalated","attempts":3}
+         A.status == Escalated
+
+test: cli_suppress_check_returns_proper_exit_code
+  given: suppress(fp="x", reason="r", until=t0+1h)
+  when:  `autopilot suppress check --fingerprint x --reason r`
+  then:  exit 0   # 억제 중
+
+  when (window 만료 후): 동일 호출
+  then:  exit 1   # 억제 안 됨
+
+test: cli_epic_reconcile_applies_plan_idempotently
+  given: empty store
+  when:  `autopilot epic reconcile --name e --plan <plan.jsonl>` 두 번
+  then:  두 번째 호출 후 store 상태 == 첫 번째 호출 후 상태
+         events 에 reconciled 가 2건
 ```
 
-### UC-3. 의존성 있는 Task
-
-```
-test: uc3_dependent_task_not_claimed_until_parent_done
-  fixture: tasks A(ready), B(pending, deps=[A])
-  when:
-    claim_next_task -> A
-    complete_task_and_unblock(A, pr=1)
-    claim_next_task -> ?
-  then:  세 번째 결과는 Some(B)
-         events: A.completed before B.claimed
-
-test: uc3_escalated_parent_blocks_child
-  fixture: A(wip, attempts=max), B(pending, deps=[A])
-  when:  mark_task_failed(A, max_attempts) → Escalated
-  then:  B.status == 'blocked'
-```
-
-### UC-4. Epic 이어받기
-
-```
-test: uc4_resume_reconstructs_state_from_remote
-  fixture:
-    store: empty (다른 머신 또는 DB 손실 가정)
-    git.remote_branches: ["epic/e", "epic/e/<idA>", "epic/e/<idB>"]
-    github.prs: [{head:"epic/e/<idA>", base:"epic/e", merged:true, number:10}]
-    decomposer: tasks=[A,B,C]   # idA,idB,idC 결정적
-  when:  EpicManager::resume("e")
-  then:
-    A.status == 'done', A.pr_number == 10
-    B.status == 'wip'           # 브랜치만 있고 PR 없음
-    C.status == 'ready'         # 브랜치 없음, deps 만족
-    events: kind='reconciled'
-
-test: uc4_resume_reports_orphan_branch
-  fixture: remote has "epic/e/<unknown_id>"
-  when:  EpicManager::resume("e")
-  then:  events 에 reconciled.payload.orphan_branch=="epic/e/<unknown_id>" 1건
-```
-
-### UC-5. DB 손실 후 복구
-
-```
-test: uc5_lost_db_recovers_via_resume
-  fixture: 같은 fixture 를 두 번 실행 — 첫 번째는 실 DB, 두 번째는 DB 파일 삭제 후 resume
-  then:  두 번째 실행 후 store 상태가 첫 번째의 의미적 상태와 일치
-         단, attempts 카운터는 0 으로 재설정 (허용 손실)
-```
-
-### UC-6. Watch 매칭 task append
-
-```
-test: uc6_gap_watch_appends_task_when_spec_matches_active_epic
-  fixture: active epic "e" with spec_path="spec/auth.md"
-  when:  WatchDispatcher::dispatch(GapFinding {
-           spec_path:"spec/auth.md",
-           section:"## 인증", req:"새로운 갭",
-           fingerprint:"fp-1"
-         })
-  then:  store.list_tasks_by_epic("e") 가 1건 증가
-         새 task.source == 'gap-watch'
-         github.issues empty   # 매칭됐으므로 이슈 발행 없음
-
-test: uc6_duplicate_fingerprint_is_no_op
-  fixture: epic "e" 에 이미 fingerprint="fp-1" 인 task
-  when:  WatchDispatcher::dispatch(finding with fp-1)
-  then:  store.tasks count unchanged
-         events kind='watch_duplicate' 1건
-```
-
-### UC-7. Watch 미매칭 escalation
-
-```
-test: uc7_unmatched_watch_creates_escalation_issue
-  fixture: 활성 epic 의 spec_path 와 다른 path
-  when:  WatchDispatcher::dispatch(finding)
-  then:  github.issues count == 1
-         issue.labels contains "autopilot:hitl-needed"
-         store.tasks unchanged (미매칭 watch 는 task 미생성)
-         escalation_suppression 에 fingerprint 기록
-
-test: uc7_suppressed_fingerprint_skips_issue
-  fixture: escalation_suppression 에 fp 가 활성 (now < suppress_until)
-  when:  WatchDispatcher::dispatch(finding with fp)
-  then:  github.issues count unchanged
-```
-
-### UC-8. 반복 실패 escalation
-
-```
-test: uc8_max_attempts_creates_escalation_issue
-  fixture: A(wip, attempts=2), max_attempts=3
-  when:
-    mark_task_failed(A, max=3)        # → Retried{attempts:2}
-    re-claim → mark_task_failed(A, max=3)   # 이제 attempts=3 → Escalated
-    Escalator::escalate(A)             # GitHub 이슈 발행
-  then:  github.issues count == 1
-         A.escalated_issue == issue.number
-         A.status == 'escalated'
-```
-
-### UC-9. 사람이 escalation 처리
-
-```
-test: uc9a_resolved_by_starting_new_epic
-  fixture: open escalation issue with epic="none"
-  when:  사람이 EpicManager::start(...) 로 새 epic 시작
-  then:  새 epic 활성화. 기존 escalation 이슈는 사람이 close 해야 닫힘 (자동 close 안함)
-
-test: uc9b_resolved_by_absorbing_into_existing_epic
-  fixture: 활성 epic "e" + open escalation issue
-  when:  analyze-issue 가 이슈 본문 → spec 매칭 후 task append
-  then:  store 에 새 task 1건, source='human', body 에 issue_number 메타
-         이슈는 코멘트 추가 후 close
-
-test: uc9d_human_fixed_directly_marks_done_on_resume
-  fixture: A.status='escalated', 사람이 직접 코드 push 후 PR merged
-  when:  EpicManager::resume(...)
-  then:  reconcile 로 A.status='done' 으로 전이
-
-test: uc9_escalation_watcher_picks_up_human_close_without_resume
-  fixture:
-    epic "e" active, A.status='escalated', A.escalated_issue=#42
-    github.issues[42].closed = true
-    git.remote: PR head=epic/e/<A_id> base=epic/e merged=true
-    decomposer: tasks 에 A 포함
-  when:  EscalationWatcher::tick()
-  then:  A.status == 'done'
-         events kind='escalation_resolved', payload.resolution=='human_fixed'
-         # resume 호출 없이 자동 인식
-
-test: uc9_escalation_watcher_records_rejection_on_close_without_code
-  fixture:
-    epic "e" active, A.status='escalated', A.escalated_issue=#42, fingerprint='fp-A'
-    github.issues[42].closed = true
-    git.remote: 해당 task 의 feature 브랜치 / PR 없음
-  when:  EscalationWatcher::tick()
-  then:  A.status == 'escalated' 유지   # reconcile 결과 done 아님
-         suppression(fp='fp-A', reason='rejected_by_human') 활성
-         events kind='escalation_resolved', payload.resolution=='rejected'
-```
-
-### UC-10. Epic 완료
-
-```
-test: uc10_all_tasks_done_completes_epic_and_notifies
-  fixture: epic "e" 의 마지막 task A 가 wip → done 으로 전이 직후
-  when:  MergeLoop::tick() 가 마지막 PR 머지 후 epic 완료 판정
-  then:  epic.status == 'completed'
-         notifier.sent contains EpicCompleted{ epic:"e" }
-         no automatic main-merge PR 생성  # main 머지는 사람의 몫
-
-test: uc10_does_not_complete_with_open_escalations
-  fixture: epic 의 task 들 중 하나가 escalated 이고 issue 가 open
-  when:  MergeLoop::tick()
-  then:  epic.status == 'active' 유지
-         notifier.sent 에 EpicCompleted 없음
-```
-
-### UC-11. 동시 진행 자연 차단
-
-```
-test: uc11_push_reject_releases_claim_without_attempt_charge
-  fixture: BuildLoop 가 task A 를 claim, IM 이 push 시도하나 git.push_rejects 로 reject
-  when:  IM 결과 처리
-  then:  A.status == 'ready'
-         events kind='claim_lost'
-         A.attempts == 0   # release_claim 으로 차감되어 다음 cycle 에서 새 시도
-
-test: uc11_concurrent_claim_yields_one_winner
-  given: store 에 ready task A 1건
-  when:  두 BuildLoop 인스턴스가 동시에 claim
-  then:  한 쪽만 Some(A), 다른 쪽 None
-         tasks.attempts == 1
-         events kind='task_claimed' 1건
-```
-
-### UC-12. Epic 강제 중단
-
-```
-test: uc12_stop_marks_abandoned_and_keeps_branches
-  fixture: epic "e" with task A(wip)
-  when:  EpicManager::stop("e", purge_branches=false)
-  then:  epic.status == 'abandoned'
-         A.status == 'wip' (보존)
-         git.remote_branches contains "epic/e" (삭제 안 함)
-
-test: uc12_stop_with_purge_deletes_unmerged_branches
-  fixture: epic with feature branches, 일부 PR merged
-  when:  EpicManager::stop("e", purge_branches=true)
-  then:  머지된 PR 의 feature 브랜치만 삭제
-         미머지 feature 브랜치는 보존 (작업 손실 방지)
-```
-
-### UC-13. 마이그레이션
-
-```
-test: uc13_import_issue_creates_task_and_strips_label
-  fixture:
-    epic "e" active, spec_path="spec/auth.md"
-    github.issues = [{ number:5, title:"...", labels:[":ready"], body:"...spec/auth.md..." }]
-  when:  MigrateCommand::import_issue(5)
-  then:
-    store.list_tasks_by_epic("e") 1건 증가
-    new_task.source == 'human'
-    new_task.body contains "issue #5"
-    github.issues[5].labels does NOT contain ":ready"
-    github.issues[5].comments contains "task <id> 로 흡수됨"
-
-test: uc13_unmatched_issue_falls_back_to_escalation
-  fixture: 이슈의 spec 매칭 실패
-  when:  MigrateCommand::import_issue(5)
-  then:  task 생성 안 됨
-         이슈는 그대로 유지 (사람이 수동 처리)
-```
+L3 의 의도는 **CLI 인자 파싱 / 트레이트 디스패치 / JSON 출력** 의 안정성. 비즈니스 로직 검증은 L2 가 담당하므로 L3 는 가벼운 분량으로 유지.
 
 ## 6. L4: Property 테스트
 
@@ -602,10 +378,13 @@ proptest: deterministic_task_id_no_collision_in_realistic_corpus
   generator: 1000개 spec section/requirement 쌍 (Korean+English mix, 길이 1..200)
   property: { TaskId(...) } 가 모두 unique 하거나 입력이 정규화 후 동일
 
-proptest: claim_invariant_attempts_monotonic
-  for any sequence of (claim → mark_failed | revert) operations:
-    task.attempts 는 단조 증가 (감소하지 않음)
-    final status ∈ {ready, wip, escalated, done}
+proptest: attempts_bounded_by_real_attempts
+  for any sequence of operations from {claim, mark_failed, release_claim, complete}:
+    let real_attempts =
+        (# of claim) - (# of release_claim immediately following the matching claim)
+    final task.attempts == real_attempts
+    final task.attempts 는 결코 0 미만이 되지 않음 (saturating_sub 보장)
+    final status ∈ {Ready, Wip, Escalated, Done, Pending, Blocked}
 
 proptest: reconcile_idempotent_under_arbitrary_remote_state
   generator: 임의 remote_state (브랜치 + PR 조합)
@@ -624,42 +403,40 @@ proptest: dep_graph_topological_order_respects_constraints
 
 | Fake | 보장 동작 |
 |------|----------|
-| `InMemoryTaskStore` | 단일 `Mutex<State>` 로 모든 메서드 atomic. SqliteTaskStore 와 같은 트랜잭션 의미 |
-| `FakeGitClient` | 가상 ref 그래프. `push_rejects` 리스트에 등록된 브랜치는 항상 `Rejected` 반환. push 성공 시 ref 추가 |
-| `FakeGitHubClient` | 이슈/PR 의 in-memory store. PR.merged 는 명시적 `merge_pr` 호출 시에만 true |
-| `FakeDecomposer` | fixture 의 tasks/deps 를 그대로 반환. `fail` 옵션 시 지정된 에러 반환 |
-| `FakeNotifier` | 호출 시 메시지를 `sent: Vec<NotificationEvent>` 에 누적 |
+| `InMemoryTaskStore` | 단일 `Mutex<State>` 로 모든 메서드 atomic. `SqliteTaskStore` 와 같은 트랜잭션 의미 |
 | `FixedClock` | `now()` 가 고정. 테스트가 명시적으로 advance 가능 |
+
+git / github / decompose / notifier 의 fake 는 **본 spec 의 책임이 아니다** — agent 측에서 자기 워크플로 통합 테스트에 필요할 때 만든다.
 
 ### 7.2 Builder 함수 (예)
 
 ```rust
-let world = TestWorld::new()
-    .with_clock_at("2026-04-28T09:00:00Z")
-    .with_active_epic("e", spec="spec/auth.md")
-    .with_tasks(&["A", "B"])
-    .with_deps(&[("B", "A")])
-    .with_remote_branches(&["epic/e", "epic/e/<A_id>"])
-    .with_merged_pr(number=10, head="epic/e/<A_id>", base="epic/e");
+let store = Arc::new(InMemoryTaskStore::new()) as Arc<dyn TaskStore>;
+let clock = FixedClock::at("2026-04-28T09:00:00Z");
 
-let outcome = world.epic_manager().resume("e")?;
-world.assert_task_status("A", TaskStatus::Done);
-world.assert_task_status("B", TaskStatus::Wip);
+store.insert_epic_with_tasks(plan("e", vec![nt("A","a"), nt("B","b")],
+                                  vec![("B","A")]), clock.now())?;
+store.claim_next_task("e", clock.now())?;       // A → Wip
+store.complete_task_and_unblock(&id("A"), 42, clock.now())?;
+assert_eq!(store.get_task(&id("A"))?.unwrap().status, TaskStatus::Done);
+assert_eq!(store.get_task(&id("B"))?.unwrap().status, TaskStatus::Ready);
 ```
 
-빌더는 03 의 도메인 타입 + 결정적 ID 함수를 사용하여 fixture 의 `<A_id>` 를 자동 계산한다.
+빌더는 03 의 도메인 타입 + 결정적 ID 함수를 사용한다. CLI L3 테스트에서는 `assert_cmd::Command` 같은 도구로 실행 + stdout / exit code 검사.
 
 ## 8. 카버리지 목표
 
 - L1: 100% (pure 함수 — 작성 즉시 모두 다룰 수 있음)
 - L2: TaskStore trait 의 모든 public 메서드에 ≥1 시나리오 + LSP suite 전체 양 구현체 통과
-- L3: 01 의 13개 UC 마다 ≥1 happy path + ≥1 대안 흐름
+- L3: 03 §6 의 ledger CLI 명령마다 ≥1 happy path 시나리오. 에러 / 빈 결과 / JSON 형식 검증 포함
 - L4: 본 문서에 명시된 4개 property 모두 통과
 
 CI 게이트: 위 목표 미달 시 PR 차단.
 
+UC-1~13 시나리오 (01 의 사용자 흐름 통합 검증) 는 **agent 측의 책임** — 본 문서의 카버리지 항목 아님.
+
 ## 9. 본 문서의 변경 정책
 
-- UC 가 추가/변경되면 (01 갱신) 본 문서의 L3 시나리오도 함께 추가
-- 03 의 시그니처가 변경되면 본 문서의 코드 단편도 함께 갱신
-- 신규 시나리오는 가능한 한 기존 fixture builder 를 재사용
+- 03 의 시그니처가 변경되면 본 문서의 L2 / L3 / L4 코드 단편도 함께 갱신
+- ledger CLI 명령이 추가되면 L3 에 happy path 시나리오 추가
+- 신규 property 가 도출되면 L4 에 추가


### PR DESCRIPTION
## Summary
Spec 시리즈 (00-04) 를 **Ledger 모델** 로 재정리. autopilot 의 책임을 \`상태 관리 + CLI\` 로 좁히고, 탐지 / 결정 / 구현 / git·PR 조작은 외부 **Agent** 의 책임으로 이전.

epic 브랜치 base. 코드 변경 없음 (문서만).

## 배경

이전 spec (PR #648 까지) 은 autopilot 안에 BuildLoop / MergeLoop / WatchDispatcher / EscalationWatcher / Reconciler 등의 orchestration 레이어 + GitClient / SpecDecomposer / Notifier 포트를 두고 자체 sub-loop 로 도는 구조였음. 그러나:

- gap-detector 가 이미 spec 파싱 + 갭 탐지를 통합 수행 (autopilot 안에 같은 로직을 또 두는 건 redundant)
- Claude Code / autodev 같은 외부 에이전트가 자연스럽게 \`/loop\` / cron 으로 orchestrate 가능
- spec 분해 정책 (00 §9 #1) 같은 미해결 사항이 autopilot 의 결정사항으로 묶이는 게 부자연스러움
- 결과적으로 만들어야 할 코드 ~3-5K LOC 가 phantom 디자인이었음

## 새 모델

\`\`\`
┌─ Agent (Claude Code / autodev / GitHub Actions / ...) ─┐
│  monitor 호출 / 분해 / 구현 / PR / escalation 발행      │
└────────────────────┬───────────────────────────────────┘
                     │ CLI
┌────────────────────▼───────────────────────────────────┐
│  Autopilot — ledger + CLI                              │
│  TaskStore (epics / tasks / events / suppression)      │
│  결정적 상태 전이 + 헬퍼 명령 (worktree / labels / ...)│
└────────────────────────────────────────────────────────┘
\`\`\`

## 파일별 변경 (각 commit 단위)

| commit | 파일 | 핵심 |
|---|---|---|
| 1 | 00-concept | §5 명령/에이전트 매트릭스 → 책임 분리 표. §6 HITL → agent 발행. §9 #1 해소 |
| 2 | 02-architecture | orchestration 레이어 제거, ports 단일화 (TaskStore + Clock), 모듈 트리 단순화, UC↔CLI 매핑 |
| 3 | 03-detailed-spec | §2 외부 포트 (Git/GitHub/Decompose/Notifier) 삭제, §5.6-9 의사코드 → "Agent 측 흐름" 으로 압축, §6 ledger CLI 전체 표면 명세 (epic / task / suppress / events 약 25개 명령) |
| 4 | 04-test-scenarios | L3 "orchestration" → L3 "CLI 통합" 으로 교체 (UC 통합 시나리오는 agent 책임), L4 attempts property 가 release_claim 의미에 맞게 갱신 |
| 5 | 01-use-cases | ML → AG/AP 페르소나 분리, UC-1~13 재기술 (agent 의 CLI 호출 시퀀스 + autopilot 의 트레이트 부수효과) |

## 영향

- **코드 영향 없음** — PR #649 의 트레이트/어댑터/V2 schema/conformance 모두 새 모델에 정합
- **만들 필요 없어짐**: BuildLoop, MergeLoop, WatchDispatcher, Escalator, EscalationWatcher, Reconciler 모듈, GitClient/SpecDecomposer/Notifier 포트 + 어댑터 + Fake. 약 3-5K LOC unwritten 절약
- **만들 것**: \`cmd/epic.rs\` / \`cmd/task.rs\` 확장 / \`cmd/suppress.rs\` / \`cmd/events.rs\` + \`main.rs\` wiring. 대부분 trait → CLI thin wrapping

## 통계
- 5 files / +598 / -916 (전체 약 -318 라인 net, spec 더 짧고 명료)
- 5 commits (파일별 분리해서 리뷰 시 추적 가능)

## 후속 PR (이전 PR-1b/c 대신)
- **PR-A**: \`cmd/epic.rs\` (epic CRUD + reconcile)
- **PR-B**: \`cmd/task.rs\` 확장 (claim / complete / fail / escalate / release)
- **PR-C**: \`cmd/suppress.rs\` + \`cmd/events.rs\` + \`main.rs\` wiring + autopilot.toml [storage]/[epic]/[suppression]
- **PR-D** (선택): 기존 헬퍼 (pipeline / watch / ...) 정합성 점검 및 deprecate 결정

## Test plan
- [ ] 5 spec 파일 cross-reference 정합 확인 (UC ↔ trait ↔ CLI 매핑)
- [ ] 03 §6 의 CLI 명령이 03 §2 의 트레이트 메서드로 1:1 디스패치되는지 점검
- [ ] 04 §5 L3 시나리오와 03 §6 명령이 1:1 매칭되는지 점검
- [ ] PR #649 의 trait 시그니처가 본 spec 의 모든 의존을 만족하는지 (불일치 시 후속 PR 로 보정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)