### PR TITLE
fix(git-utils): escape regex metachars in prioritize-issues ROOTS

### DIFF
--- a/plugins/git-utils/commands/prioritize-issues.md
+++ b/plugins/git-utils/commands/prioritize-issues.md
@@ -149,8 +149,10 @@ issue 내용과 현재 코드베이스의 연관성을 다음 4단계 절차로 
 issue body에서 코드 경로처럼 보이는 토큰을 추출합니다. 디렉토리 후보는 레포의 실제 최상위 디렉토리에서 동적으로 수집해 다양한 레이아웃에 대응합니다.
 
 ```bash
-# 레포 최상위 디렉토리를 정규식 OR 그룹으로 변환
-ROOTS=$(ls -d */ 2>/dev/null | tr -d '/' | paste -sd '|' -)
+# 디렉토리명에 정규식 메타문자가 있으면 grep -E 패턴이 깨지므로 사전 escape
+ROOTS=$(ls -d */ 2>/dev/null | tr -d '/' \
+  | sed 's/[][\\.^$*+?()|]/\\&/g' \
+  | paste -sd '|' -)
 
 echo "$BODY" | grep -oE "(${ROOTS})/[A-Za-z0-9_./-]+" | sort -u
 ```


### PR DESCRIPTION
## Summary

PR #651 후속. Step 3 (1) 의 `ROOTS` 빌드 단계는 `ls -d */` 결과를 그대로 `paste -sd '|'`로 묶어 `grep -E` alternation 그룹으로 사용한다. 디렉토리명에 정규식 메타문자(`.`, `(`, `+`, `*`, `?`, `|`, `[`, `]`, `^`, `$`, `\`)가 들어 있으면 패턴이 깨지거나 의도치 않게 매칭된다.

본 레포 디렉토리는 모두 알파벳뿐이라 당장 영향은 없지만, generic 슬래시 커맨드로 다양한 레포에서 쓰이는 것이 본 커맨드의 취지이므로 사전 escape를 추가한다.

## Change

`paste` 직전에 `sed 's/[][\\.^$*+?()|]/\\&/g'` 한 단계를 추가해 regex 메타문자를 escape.

```diff
-ROOTS=$(ls -d */ 2>/dev/null | tr -d '/' | paste -sd '|' -)
+ROOTS=$(ls -d */ 2>/dev/null | tr -d '/' \
+  | sed 's/[][\\.^$*+?()|]/\\&/g' \
+  | paste -sd '|' -)
```

## Base

Stacked on `feat/prioritize-issues-improvements` (#651). #651 머지 시 자동으로 main 기준 diff가 됩니다.

## Test plan

- [ ] 디렉토리명에 메타문자가 들어간 가상 환경에서 `ROOTS` 가 올바르게 escape 되는지 검증
- [ ] 본 레포(메타문자 없는 디렉토리만)에서 동작이 변하지 않는지 회귀 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)