### PR TITLE
fix(git-utils): detect default branch dynamically in prioritize-issues

### DIFF
--- a/plugins/git-utils/commands/prioritize-issues.md
+++ b/plugins/git-utils/commands/prioritize-issues.md
@@ -185,7 +185,12 @@ git log --since='3 months ago' --name-only --pretty=format: \
 현재 브랜치의 변경 영역과 issue 관련 경로를 교차하여 연관성을 평가합니다.
 
 ```bash
-git diff main...HEAD --name-only
+# default 브랜치 동적 조회 — main 외 (master/develop 등) 레포 대응
+DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null \
+  | sed 's@^refs/remotes/origin/@@' \
+  || echo main)
+
+git diff "${DEFAULT_BRANCH}...HEAD" --name-only
 ```
 
 issue 관련 경로와 위 결과의 교집합이 있으면 "현재 작업과 연속성 있는 issue"로 가산점.


### PR DESCRIPTION
## Summary

PR #651 후속. Step 3 (4) "현재 작업과의 교차 분석" 단계는 `git diff main...HEAD`로 base를 하드코딩했다. default 브랜치가 `master`, `develop` 등 `main`이 아닌 레포에서는 silent 실패. generic 슬래시 커맨드 취지에 맞춰 default 브랜치를 동적으로 조회한다.

## Change

`refs/remotes/origin/HEAD` symbolic ref 에서 default 브랜치명을 추출하고, 미설정 시 `main` 으로 폴백.

```diff
+# default 브랜치 동적 조회 — main 외 (master/develop 등) 레포 대응
+DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null \
+  | sed 's@^refs/remotes/origin/@@' \
+  || echo main)
+
-git diff main...HEAD --name-only
+git diff "${DEFAULT_BRANCH}...HEAD" --name-only
```

## Base

Stacked on `feat/prioritize-issues-improvements` (#651). #651 머지 시 자동으로 main 기준 diff가 됩니다. PR #653(regex escape) 와는 동일 base 위 독립 브랜치.

## Test plan

- [ ] default 브랜치가 `main` 인 레포에서 기존 동작과 동일한지 회귀 검증
- [ ] default 브랜치가 `master` 인 레포에서도 정상 동작 확인
- [ ] `origin/HEAD` 미설정 환경(`git remote set-head origin --delete` 후)에서 폴백 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)