### PR TITLE
feat(github-autopilot): add epic ledger CLI subcommands

### DIFF
--- a/plugins/github-autopilot/cli/src/cmd/epic.rs
+++ b/plugins/github-autopilot/cli/src/cmd/epic.rs
@@ -1,8 +1,8 @@
 //! Epic ledger subcommands.
 //!
-//! Pure ledger surface: every operation is a thin adapter over a `TaskStore`
-//! call. The agent owns spec decomposition, git, and GitHub interactions; this
-//! module only persists state and exposes audit-friendly output.
+//! Pure ledger surface: every operation is a thin adapter over `TaskStore`.
+//! Agents own spec decomposition, git, and GitHub; this module only
+//! persists state.
 
 use std::collections::BTreeMap;
 use std::io::{BufRead, BufReader, Write};
@@ -166,60 +166,51 @@ impl<'a> EpicService<'a> {
         let filter = status.and_then(EpicStatusFilter::to_status);
         let epics = self.store.list_epics(filter).context("listing epics")?;
         if json {
-            serde_json::to_writer(&mut *out, &epics)?;
-            writeln!(out)?;
-        } else if epics.is_empty() {
+            return write_json(out, &epics).map(|()| 0);
+        }
+        if epics.is_empty() {
             writeln!(out, "(no epics)")?;
-        } else {
+            return Ok(0);
+        }
+        writeln!(
+            out,
+            "NAME                STATUS      BRANCH                    SPEC"
+        )?;
+        for e in &epics {
             writeln!(
                 out,
-                "NAME                STATUS      BRANCH                    SPEC"
+                "{:<18}  {:<10}  {:<24}  {}",
+                e.name,
+                e.status.as_str(),
+                e.branch,
+                e.spec_path.display()
             )?;
-            for e in &epics {
-                writeln!(
-                    out,
-                    "{:<18}  {:<10}  {:<24}  {}",
-                    e.name,
-                    e.status.as_str(),
-                    e.branch,
-                    e.spec_path.display()
-                )?;
-            }
         }
         Ok(0)
     }
 
     pub fn get(&self, name: &str, json: bool, out: &mut dyn Write) -> Result<i32> {
-        let epic = self
+        let Some(epic) = self
             .store
             .get_epic(name)
-            .with_context(|| format!("fetching epic '{name}'"))?;
-        match epic {
-            Some(e) => {
-                if json {
-                    serde_json::to_writer(&mut *out, &e)?;
-                    writeln!(out)?;
-                } else {
-                    print_epic_human(&e, out)?;
-                }
-                Ok(0)
-            }
-            None => {
-                writeln!(out, "epic '{name}' not found")?;
-                Ok(1)
-            }
-        }
+            .with_context(|| format!("fetching epic '{name}'"))?
+        else {
+            writeln!(out, "epic '{name}' not found")?;
+            return Ok(1);
+        };
+        render_epic(&epic, json, out)?;
+        Ok(0)
     }
 
     pub fn status(&self, name: Option<&str>, json: bool, out: &mut dyn Write) -> Result<i32> {
         let epics: Vec<Epic> = match name {
-            Some(n) => match self.store.get_epic(n)? {
-                Some(e) => vec![e],
-                None => {
+            Some(n) => {
+                let Some(e) = self.store.get_epic(n)? else {
                     writeln!(out, "epic '{n}' not found")?;
                     return Ok(1);
-                }
-            },
+                };
+                vec![e]
+            }
             None => self.store.list_epics(Some(EpicStatus::Active))?,
         };
 
@@ -240,66 +231,62 @@ impl<'a> EpicService<'a> {
             reports.push(EpicStatusReport {
                 epic: e.name.clone(),
                 status: e.status,
+                total: tasks.len(),
                 counts,
-                total: tasks.len() as u32,
             });
         }
 
         if json {
-            serde_json::to_writer(&mut *out, &reports)?;
-            writeln!(out)?;
-        } else if reports.is_empty() {
+            return write_json(out, &reports).map(|()| 0);
+        }
+        if reports.is_empty() {
             writeln!(out, "(no active epics)")?;
-        } else {
+            return Ok(0);
+        }
+        writeln!(
+            out,
+            "EPIC               STATUS     PEND READY  WIP  BLK DONE  ESC TOTAL"
+        )?;
+        for r in &reports {
             writeln!(
                 out,
-                "EPIC               STATUS     PEND READY  WIP  BLK DONE  ESC TOTAL"
+                "{:<18} {:<10} {:>4} {:>5} {:>4} {:>4} {:>4} {:>4} {:>5}",
+                r.epic,
+                r.status.as_str(),
+                r.counts.pending,
+                r.counts.ready,
+                r.counts.wip,
+                r.counts.blocked,
+                r.counts.done,
+                r.counts.escalated,
+                r.total
             )?;
-            for r in &reports {
-                writeln!(
-                    out,
-                    "{:<18} {:<10} {:>4} {:>5} {:>4} {:>4} {:>4} {:>4} {:>5}",
-                    r.epic,
-                    r.status.as_str(),
-                    r.counts.pending,
-                    r.counts.ready,
-                    r.counts.wip,
-                    r.counts.blocked,
-                    r.counts.done,
-                    r.counts.escalated,
-                    r.total
-                )?;
-            }
         }
         Ok(0)
     }
 
     pub fn complete(&self, name: &str, out: &mut dyn Write) -> Result<i32> {
-        self.set_status(name, EpicStatus::Completed, "completed", out)
+        self.set_status(name, EpicStatus::Completed, out)
     }
 
     pub fn abandon(&self, name: &str, out: &mut dyn Write) -> Result<i32> {
-        self.set_status(name, EpicStatus::Abandoned, "abandoned", out)
+        self.set_status(name, EpicStatus::Abandoned, out)
     }
 
-    fn set_status(
-        &self,
-        name: &str,
-        target: EpicStatus,
-        verb: &str,
-        out: &mut dyn Write,
-    ) -> Result<i32> {
+    fn set_status(&self, name: &str, target: EpicStatus, out: &mut dyn Write) -> Result<i32> {
         let now = self.clock.now();
         match self.store.set_epic_status(name, target, now) {
             Ok(()) => {
-                writeln!(out, "epic '{name}' {verb}")?;
+                writeln!(out, "epic '{name}' {}", target.as_str())?;
                 Ok(0)
             }
             Err(TaskStoreError::NotFound(_)) => {
                 writeln!(out, "epic '{name}' not found")?;
                 Ok(1)
             }
-            Err(e) => Err(e).with_context(|| format!("setting epic '{name}' to {verb}")),
+            Err(e) => {
+                Err(e).with_context(|| format!("setting epic '{name}' to {}", target.as_str()))
+            }
         }
     }
 
@@ -311,12 +298,7 @@ impl<'a> EpicService<'a> {
     ) -> Result<i32> {
         match self.store.find_active_by_spec_path(spec_path) {
             Ok(Some(e)) => {
-                if json {
-                    serde_json::to_writer(&mut *out, &e)?;
-                    writeln!(out)?;
-                } else {
-                    print_epic_human(&e, out)?;
-                }
+                render_epic(&e, json, out)?;
                 Ok(0)
             }
             Ok(None) => {
@@ -378,11 +360,14 @@ struct StatusCounts {
 struct EpicStatusReport {
     epic: String,
     status: EpicStatus,
+    total: usize,
     counts: StatusCounts,
-    total: u32,
 }
 
-fn print_epic_human(e: &Epic, out: &mut dyn Write) -> Result<()> {
+fn render_epic(e: &Epic, json: bool, out: &mut dyn Write) -> Result<()> {
+    if json {
+        return write_json(out, e);
+    }
     writeln!(out, "name:         {}", e.name)?;
     writeln!(out, "status:       {}", e.status.as_str())?;
     writeln!(out, "branch:       {}", e.branch)?;
@@ -391,6 +376,12 @@ fn print_epic_human(e: &Epic, out: &mut dyn Write) -> Result<()> {
     if let Some(ts) = e.completed_at {
         writeln!(out, "completed_at: {}", ts.to_rfc3339())?;
     }
+    Ok(())
+}
+
+fn write_json<T: Serialize>(out: &mut dyn Write, value: &T) -> Result<()> {
+    serde_json::to_writer(&mut *out, value)?;
+    writeln!(out)?;
     Ok(())
 }
 
@@ -474,7 +465,9 @@ fn parse_reconcile_jsonl(plan_path: &Path, existing: Epic) -> Result<Reconciliat
                     title,
                     body,
                 };
-                tasks.insert(id, nt);
+                if tasks.insert(id.clone(), nt).is_some() {
+                    anyhow::bail!("duplicate task id '{id}' on line {}", lineno + 1);
+                }
             }
             PlanLine::Dep { task, depends_on } => {
                 deps.push((TaskId::from_raw(&task), TaskId::from_raw(&depends_on)));

--- a/plugins/github-autopilot/cli/src/cmd/epic.rs
+++ b/plugins/github-autopilot/cli/src/cmd/epic.rs
@@ -1,0 +1,517 @@
+//! Epic ledger subcommands.
+//!
+//! Pure ledger surface: every operation is a thin adapter over a `TaskStore`
+//! call. The agent owns spec decomposition, git, and GitHub interactions; this
+//! module only persists state and exposes audit-friendly output.
+
+use std::collections::BTreeMap;
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use clap::{Args, Subcommand, ValueEnum};
+use serde::{Deserialize, Serialize};
+
+use crate::domain::{DomainError, Epic, EpicStatus, TaskId, TaskSource, TaskStatus};
+use crate::ports::clock::Clock;
+use crate::ports::task_store::{
+    EpicPlan, NewTask, ReconciliationPlan, RemotePrState, RemoteTaskState, TaskStore,
+    TaskStoreError,
+};
+
+#[derive(Subcommand)]
+pub enum EpicCommands {
+    /// Begin tracking a new epic
+    Create(CreateArgs),
+    /// List epics
+    List(ListArgs),
+    /// Show a single epic
+    Get(GetArgs),
+    /// Task status counts for an epic (or all active epics)
+    Status(StatusArgs),
+    /// Mark epic as completed
+    Complete(NameArg),
+    /// Mark epic as abandoned
+    Abandon(NameArg),
+    /// Apply a reconciliation plan (JSONL on disk) to an epic
+    Reconcile(ReconcileArgs),
+    /// Look up the active epic owning a spec path
+    FindBySpecPath(FindBySpecPathArgs),
+}
+
+#[derive(Args)]
+pub struct CreateArgs {
+    #[arg(long)]
+    pub name: String,
+    #[arg(long)]
+    pub spec: PathBuf,
+    /// Defaults to `epic/<NAME>` when omitted.
+    #[arg(long)]
+    pub branch: Option<String>,
+}
+
+#[derive(Args)]
+pub struct ListArgs {
+    #[arg(long)]
+    pub status: Option<EpicStatusFilter>,
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Args)]
+pub struct GetArgs {
+    pub name: String,
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Args)]
+pub struct StatusArgs {
+    pub name: Option<String>,
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Args)]
+pub struct NameArg {
+    pub name: String,
+}
+
+#[derive(Args)]
+pub struct ReconcileArgs {
+    #[arg(long)]
+    pub name: String,
+    #[arg(long)]
+    pub plan: PathBuf,
+}
+
+#[derive(Args)]
+pub struct FindBySpecPathArgs {
+    pub spec: PathBuf,
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum, PartialEq, Eq)]
+pub enum EpicStatusFilter {
+    Active,
+    Completed,
+    Abandoned,
+    All,
+}
+
+impl EpicStatusFilter {
+    pub fn to_status(self) -> Option<EpicStatus> {
+        match self {
+            Self::Active => Some(EpicStatus::Active),
+            Self::Completed => Some(EpicStatus::Completed),
+            Self::Abandoned => Some(EpicStatus::Abandoned),
+            Self::All => None,
+        }
+    }
+}
+
+pub struct EpicService<'a> {
+    store: &'a dyn TaskStore,
+    clock: &'a dyn Clock,
+}
+
+impl<'a> EpicService<'a> {
+    pub fn new(store: &'a dyn TaskStore, clock: &'a dyn Clock) -> Self {
+        Self { store, clock }
+    }
+
+    pub fn create(
+        &self,
+        name: &str,
+        spec_path: &Path,
+        branch: Option<&str>,
+        out: &mut dyn Write,
+    ) -> Result<i32> {
+        let now = self.clock.now();
+        let epic = Epic {
+            name: name.to_string(),
+            spec_path: spec_path.to_path_buf(),
+            branch: branch
+                .map(str::to_string)
+                .unwrap_or_else(|| format!("epic/{name}")),
+            status: EpicStatus::Active,
+            created_at: now,
+            completed_at: None,
+        };
+        let plan = EpicPlan {
+            epic,
+            tasks: vec![],
+            deps: vec![],
+        };
+        match self.store.insert_epic_with_tasks(plan, now) {
+            Ok(()) => {
+                writeln!(out, "epic '{name}' created")?;
+                Ok(0)
+            }
+            Err(TaskStoreError::Domain(DomainError::EpicAlreadyExists(n, st))) => {
+                writeln!(out, "epic '{n}' already exists ({})", st.as_str())?;
+                Ok(1)
+            }
+            Err(e) => Err(e).with_context(|| format!("creating epic '{name}'")),
+        }
+    }
+
+    pub fn list(
+        &self,
+        status: Option<EpicStatusFilter>,
+        json: bool,
+        out: &mut dyn Write,
+    ) -> Result<i32> {
+        let filter = status.and_then(EpicStatusFilter::to_status);
+        let epics = self.store.list_epics(filter).context("listing epics")?;
+        if json {
+            serde_json::to_writer(&mut *out, &epics)?;
+            writeln!(out)?;
+        } else if epics.is_empty() {
+            writeln!(out, "(no epics)")?;
+        } else {
+            writeln!(
+                out,
+                "NAME                STATUS      BRANCH                    SPEC"
+            )?;
+            for e in &epics {
+                writeln!(
+                    out,
+                    "{:<18}  {:<10}  {:<24}  {}",
+                    e.name,
+                    e.status.as_str(),
+                    e.branch,
+                    e.spec_path.display()
+                )?;
+            }
+        }
+        Ok(0)
+    }
+
+    pub fn get(&self, name: &str, json: bool, out: &mut dyn Write) -> Result<i32> {
+        let epic = self
+            .store
+            .get_epic(name)
+            .with_context(|| format!("fetching epic '{name}'"))?;
+        match epic {
+            Some(e) => {
+                if json {
+                    serde_json::to_writer(&mut *out, &e)?;
+                    writeln!(out)?;
+                } else {
+                    print_epic_human(&e, out)?;
+                }
+                Ok(0)
+            }
+            None => {
+                writeln!(out, "epic '{name}' not found")?;
+                Ok(1)
+            }
+        }
+    }
+
+    pub fn status(&self, name: Option<&str>, json: bool, out: &mut dyn Write) -> Result<i32> {
+        let epics: Vec<Epic> = match name {
+            Some(n) => match self.store.get_epic(n)? {
+                Some(e) => vec![e],
+                None => {
+                    writeln!(out, "epic '{n}' not found")?;
+                    return Ok(1);
+                }
+            },
+            None => self.store.list_epics(Some(EpicStatus::Active))?,
+        };
+
+        let mut reports: Vec<EpicStatusReport> = Vec::with_capacity(epics.len());
+        for e in &epics {
+            let tasks = self.store.list_tasks_by_epic(&e.name, None)?;
+            let mut counts = StatusCounts::default();
+            for t in &tasks {
+                match t.status {
+                    TaskStatus::Pending => counts.pending += 1,
+                    TaskStatus::Ready => counts.ready += 1,
+                    TaskStatus::Wip => counts.wip += 1,
+                    TaskStatus::Blocked => counts.blocked += 1,
+                    TaskStatus::Done => counts.done += 1,
+                    TaskStatus::Escalated => counts.escalated += 1,
+                }
+            }
+            reports.push(EpicStatusReport {
+                epic: e.name.clone(),
+                status: e.status,
+                counts,
+                total: tasks.len() as u32,
+            });
+        }
+
+        if json {
+            serde_json::to_writer(&mut *out, &reports)?;
+            writeln!(out)?;
+        } else if reports.is_empty() {
+            writeln!(out, "(no active epics)")?;
+        } else {
+            writeln!(
+                out,
+                "EPIC               STATUS     PEND READY  WIP  BLK DONE  ESC TOTAL"
+            )?;
+            for r in &reports {
+                writeln!(
+                    out,
+                    "{:<18} {:<10} {:>4} {:>5} {:>4} {:>4} {:>4} {:>4} {:>5}",
+                    r.epic,
+                    r.status.as_str(),
+                    r.counts.pending,
+                    r.counts.ready,
+                    r.counts.wip,
+                    r.counts.blocked,
+                    r.counts.done,
+                    r.counts.escalated,
+                    r.total
+                )?;
+            }
+        }
+        Ok(0)
+    }
+
+    pub fn complete(&self, name: &str, out: &mut dyn Write) -> Result<i32> {
+        self.set_status(name, EpicStatus::Completed, "completed", out)
+    }
+
+    pub fn abandon(&self, name: &str, out: &mut dyn Write) -> Result<i32> {
+        self.set_status(name, EpicStatus::Abandoned, "abandoned", out)
+    }
+
+    fn set_status(
+        &self,
+        name: &str,
+        target: EpicStatus,
+        verb: &str,
+        out: &mut dyn Write,
+    ) -> Result<i32> {
+        let now = self.clock.now();
+        match self.store.set_epic_status(name, target, now) {
+            Ok(()) => {
+                writeln!(out, "epic '{name}' {verb}")?;
+                Ok(0)
+            }
+            Err(TaskStoreError::NotFound(_)) => {
+                writeln!(out, "epic '{name}' not found")?;
+                Ok(1)
+            }
+            Err(e) => Err(e).with_context(|| format!("setting epic '{name}' to {verb}")),
+        }
+    }
+
+    pub fn find_by_spec_path(
+        &self,
+        spec_path: &Path,
+        json: bool,
+        out: &mut dyn Write,
+    ) -> Result<i32> {
+        match self.store.find_active_by_spec_path(spec_path) {
+            Ok(Some(e)) => {
+                if json {
+                    serde_json::to_writer(&mut *out, &e)?;
+                    writeln!(out)?;
+                } else {
+                    print_epic_human(&e, out)?;
+                }
+                Ok(0)
+            }
+            Ok(None) => {
+                writeln!(out, "(no active epic for {})", spec_path.display())?;
+                Ok(1)
+            }
+            Err(TaskStoreError::Domain(DomainError::Inconsistency(msg))) => {
+                writeln!(out, "inconsistency: {msg}")?;
+                Ok(3)
+            }
+            Err(e) => Err(e)
+                .with_context(|| format!("finding active epic for spec '{}'", spec_path.display())),
+        }
+    }
+
+    pub fn reconcile(&self, name: &str, plan_path: &Path, out: &mut dyn Write) -> Result<i32> {
+        let now = self.clock.now();
+        let existing = match self
+            .store
+            .get_epic(name)
+            .with_context(|| format!("fetching epic '{name}' for reconcile"))?
+        {
+            Some(e) => e,
+            None => {
+                writeln!(
+                    out,
+                    "epic '{name}' not found — run `autopilot epic create` first"
+                )?;
+                return Ok(1);
+            }
+        };
+        let plan = parse_reconcile_jsonl(plan_path, existing)
+            .with_context(|| format!("parsing reconcile plan {}", plan_path.display()))?;
+        match self.store.apply_reconciliation(plan, now) {
+            Ok(()) => {
+                writeln!(out, "epic '{name}' reconciled")?;
+                Ok(0)
+            }
+            Err(TaskStoreError::Domain(DomainError::DepCycle(cycle))) => {
+                writeln!(out, "dependency cycle: {cycle:?}")?;
+                Ok(1)
+            }
+            Err(e) => Err(e).with_context(|| format!("reconciling epic '{name}'")),
+        }
+    }
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize)]
+struct StatusCounts {
+    pending: u32,
+    ready: u32,
+    wip: u32,
+    blocked: u32,
+    done: u32,
+    escalated: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct EpicStatusReport {
+    epic: String,
+    status: EpicStatus,
+    counts: StatusCounts,
+    total: u32,
+}
+
+fn print_epic_human(e: &Epic, out: &mut dyn Write) -> Result<()> {
+    writeln!(out, "name:         {}", e.name)?;
+    writeln!(out, "status:       {}", e.status.as_str())?;
+    writeln!(out, "branch:       {}", e.branch)?;
+    writeln!(out, "spec_path:    {}", e.spec_path.display())?;
+    writeln!(out, "created_at:   {}", e.created_at.to_rfc3339())?;
+    if let Some(ts) = e.completed_at {
+        writeln!(out, "completed_at: {}", ts.to_rfc3339())?;
+    }
+    Ok(())
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum PlanLine {
+    Task {
+        id: String,
+        title: String,
+        #[serde(default)]
+        body: Option<String>,
+        #[serde(default)]
+        fingerprint: Option<String>,
+        #[serde(default)]
+        source: Option<String>,
+    },
+    Dep {
+        task: String,
+        depends_on: String,
+    },
+    RemoteState {
+        task_id: String,
+        branch_exists: bool,
+        #[serde(default)]
+        pr: Option<PlanPr>,
+    },
+    OrphanBranch {
+        #[serde(rename = "ref")]
+        branch_ref: String,
+    },
+}
+
+#[derive(Debug, Deserialize)]
+struct PlanPr {
+    number: u64,
+    #[serde(default)]
+    merged: bool,
+    #[serde(default)]
+    closed: bool,
+}
+
+fn parse_reconcile_jsonl(plan_path: &Path, existing: Epic) -> Result<ReconciliationPlan> {
+    let file = std::fs::File::open(plan_path)
+        .with_context(|| format!("opening {}", plan_path.display()))?;
+    let reader = BufReader::new(file);
+
+    let mut tasks: BTreeMap<String, NewTask> = BTreeMap::new();
+    let mut deps: Vec<(TaskId, TaskId)> = Vec::new();
+    let mut remote_state: Vec<RemoteTaskState> = Vec::new();
+    let mut orphan_branches: Vec<String> = Vec::new();
+
+    for (lineno, line) in reader.lines().enumerate() {
+        let line = line.with_context(|| format!("reading line {}", lineno + 1))?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        let parsed: PlanLine = serde_json::from_str(trimmed)
+            .with_context(|| format!("parsing line {}: {trimmed}", lineno + 1))?;
+        match parsed {
+            PlanLine::Task {
+                id,
+                title,
+                body,
+                fingerprint,
+                source,
+            } => {
+                let source = source
+                    .as_deref()
+                    .map(|s| {
+                        TaskSource::parse(s).ok_or_else(|| {
+                            anyhow::anyhow!("unknown source '{s}' on line {}", lineno + 1)
+                        })
+                    })
+                    .transpose()?
+                    .unwrap_or(TaskSource::Decompose);
+                let nt = NewTask {
+                    id: TaskId::from_raw(&id),
+                    source,
+                    fingerprint,
+                    title,
+                    body,
+                };
+                tasks.insert(id, nt);
+            }
+            PlanLine::Dep { task, depends_on } => {
+                deps.push((TaskId::from_raw(&task), TaskId::from_raw(&depends_on)));
+            }
+            PlanLine::RemoteState {
+                task_id,
+                branch_exists,
+                pr,
+            } => {
+                remote_state.push(RemoteTaskState {
+                    task_id: TaskId::from_raw(&task_id),
+                    branch_exists,
+                    pr: pr.map(|p| RemotePrState {
+                        number: p.number,
+                        merged: p.merged,
+                        closed: p.closed,
+                    }),
+                });
+            }
+            PlanLine::OrphanBranch { branch_ref } => {
+                orphan_branches.push(branch_ref);
+            }
+        }
+    }
+
+    Ok(ReconciliationPlan {
+        epic: Epic {
+            status: EpicStatus::Active,
+            ..existing
+        },
+        tasks: tasks.into_values().collect(),
+        deps,
+        remote_state,
+        orphan_branches,
+    })
+}
+
+pub fn epic_service<'a>(store: &'a dyn TaskStore, clock: &'a dyn Clock) -> EpicService<'a> {
+    EpicService::new(store, clock)
+}

--- a/plugins/github-autopilot/cli/src/cmd/mod.rs
+++ b/plugins/github-autopilot/cli/src/cmd/mod.rs
@@ -1,4 +1,5 @@
 pub mod check;
+pub mod epic;
 pub mod issue;
 pub mod issue_list;
 pub mod labels;
@@ -58,6 +59,11 @@ pub enum Commands {
     Task {
         #[command(subcommand)]
         command: TaskCommands,
+    },
+    /// Epic ledger operations
+    Epic {
+        #[command(subcommand)]
+        command: epic::EpicCommands,
     },
 }
 

--- a/plugins/github-autopilot/cli/src/main.rs
+++ b/plugins/github-autopilot/cli/src/main.rs
@@ -173,6 +173,37 @@ fn main() {
                 } => svc.force_status(&task_id, to, reason.as_deref(), &mut out),
             }
         }
+        Commands::Epic { command } => {
+            let db_path = task_store_db_path();
+            let store = match SqliteTaskStore::open(&db_path) {
+                Ok(s) => s,
+                Err(e) => {
+                    eprintln!("failed to open task store at {}: {e}", db_path.display());
+                    std::process::exit(2);
+                }
+            };
+            let clock = cmd::task::default_clock();
+            let svc = cmd::epic::epic_service(&store, &clock);
+            let mut out = stdout();
+            match command {
+                cmd::epic::EpicCommands::Create(args) => {
+                    svc.create(&args.name, &args.spec, args.branch.as_deref(), &mut out)
+                }
+                cmd::epic::EpicCommands::List(args) => svc.list(args.status, args.json, &mut out),
+                cmd::epic::EpicCommands::Get(args) => svc.get(&args.name, args.json, &mut out),
+                cmd::epic::EpicCommands::Status(args) => {
+                    svc.status(args.name.as_deref(), args.json, &mut out)
+                }
+                cmd::epic::EpicCommands::Complete(args) => svc.complete(&args.name, &mut out),
+                cmd::epic::EpicCommands::Abandon(args) => svc.abandon(&args.name, &mut out),
+                cmd::epic::EpicCommands::Reconcile(args) => {
+                    svc.reconcile(&args.name, &args.plan, &mut out)
+                }
+                cmd::epic::EpicCommands::FindBySpecPath(args) => {
+                    svc.find_by_spec_path(&args.spec, args.json, &mut out)
+                }
+            }
+        }
     };
 
     match result {

--- a/plugins/github-autopilot/cli/tests/epic_tests.rs
+++ b/plugins/github-autopilot/cli/tests/epic_tests.rs
@@ -1,15 +1,10 @@
-//! L3 CLI integration tests for `autopilot epic` subcommands.
-//!
-//! Drives `EpicService` directly with `InMemoryTaskStore` + `FixedClock`
-//! and checks stdout / exit-code stability per spec §5 (04-test-scenarios).
-
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use autopilot::cmd::epic::{EpicService, EpicStatusFilter};
 use autopilot::domain::{Epic, EpicStatus, EventKind, TaskId, TaskStatus};
-use autopilot::ports::clock::FixedClock;
+use autopilot::ports::clock::{Clock, FixedClock};
 use autopilot::ports::task_store::{EpicPlan, EventFilter, NewTask, TaskStore};
 use autopilot::store::InMemoryTaskStore;
 use chrono::{TimeZone, Utc};
@@ -81,7 +76,7 @@ fn list_filters_by_status_and_renders_json() {
     let _ = capture(|w| svc.create("a", Path::new("spec/a.md"), None, w));
     let _ = capture(|w| svc.create("b", Path::new("spec/b.md"), None, w));
     store
-        .set_epic_status("b", EpicStatus::Completed, clock_now(&clock))
+        .set_epic_status("b", EpicStatus::Completed, clock.now())
         .unwrap();
 
     let (code, out) = capture(|w| svc.list(Some(EpicStatusFilter::Active), true, w));
@@ -109,8 +104,7 @@ fn status_groups_tasks_by_state() {
     let (store, clock) = fixture();
     let svc = EpicService::new(store.as_ref(), &clock);
 
-    // Insert epic with two tasks; one promoted to ready, one pending behind a dep
-    let now = clock_now(&clock);
+    let now = clock.now();
     store
         .insert_epic_with_tasks(
             EpicPlan {
@@ -219,10 +213,9 @@ fn find_by_spec_path_returns_exit_1_when_no_match() {
 
 #[test]
 fn find_by_spec_path_returns_exit_3_on_inconsistency() {
-    // Two active epics share a spec_path → invariant violation.
     let store: Arc<dyn TaskStore> = Arc::new(InMemoryTaskStore::new());
     let clock = FixedClock::new(Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap());
-    let now = clock_now(&clock);
+    let now = clock.now();
     for name in ["a", "b"] {
         store
             .insert_epic_with_tasks(
@@ -267,7 +260,6 @@ fn reconcile_applies_jsonl_plan_and_is_idempotent() {
         }
     }
 
-    // First call: tasks created, dependent stays pending
     let (code1, _) = capture(|w| svc.reconcile("e", plan.path(), w));
     assert_eq!(code1, 0);
     let tasks = store.list_tasks_by_epic("e", None).unwrap();
@@ -278,7 +270,6 @@ fn reconcile_applies_jsonl_plan_and_is_idempotent() {
 
     let snapshot1 = store.list_tasks_by_epic("e", None).unwrap();
 
-    // Second call: store state unchanged (events accumulate, tasks stable)
     let (code2, _) = capture(|w| svc.reconcile("e", plan.path(), w));
     assert_eq!(code2, 0);
     let snapshot2 = store.list_tasks_by_epic("e", None).unwrap();
@@ -310,9 +301,4 @@ fn reconcile_returns_exit_1_when_epic_missing() {
     let (code, out) = capture(|w| svc.reconcile("ghost", plan.path(), w));
     assert_eq!(code, 1);
     assert!(out.contains("not found"));
-}
-
-fn clock_now(c: &FixedClock) -> chrono::DateTime<Utc> {
-    use autopilot::ports::clock::Clock;
-    c.now()
 }

--- a/plugins/github-autopilot/cli/tests/epic_tests.rs
+++ b/plugins/github-autopilot/cli/tests/epic_tests.rs
@@ -25,6 +25,28 @@ where
     (code, String::from_utf8(buf).expect("utf-8"))
 }
 
+fn expect_err<F>(f: F) -> String
+where
+    F: FnOnce(&mut Vec<u8>) -> anyhow::Result<i32>,
+{
+    let mut buf: Vec<u8> = Vec::new();
+    format!("{:#}", f(&mut buf).unwrap_err())
+}
+
+fn seed_epic(svc: &EpicService, name: &str) {
+    let path = format!("spec/{name}.md");
+    let _ = capture(|w| svc.create(name, Path::new(&path), None, w));
+}
+
+fn write_plan_jsonl(lines: &[&str]) -> NamedTempFile {
+    let f = NamedTempFile::new().unwrap();
+    let mut h = std::fs::File::create(f.path()).unwrap();
+    for l in lines {
+        writeln!(h, "{l}").unwrap();
+    }
+    f
+}
+
 #[test]
 fn create_persists_epic_and_emits_started_event() {
     let (store, clock) = fixture();
@@ -307,23 +329,14 @@ fn reconcile_returns_exit_1_when_epic_missing() {
 fn reconcile_rejects_duplicate_task_id_in_plan() {
     let (store, clock) = fixture();
     let svc = EpicService::new(store.as_ref(), &clock);
-    let _ = capture(|w| svc.create("e", Path::new("spec/e.md"), None, w));
+    seed_epic(&svc, "e");
 
-    let plan = NamedTempFile::new().unwrap();
-    let lines = [
+    let plan = write_plan_jsonl(&[
         r#"{"kind":"task","id":"aaaaaaaaaaaa","title":"first"}"#,
         r#"{"kind":"task","id":"aaaaaaaaaaaa","title":"duplicate"}"#,
-    ];
-    {
-        let mut f = std::fs::File::create(plan.path()).unwrap();
-        for l in &lines {
-            writeln!(f, "{l}").unwrap();
-        }
-    }
+    ]);
 
-    let mut buf: Vec<u8> = Vec::new();
-    let err = svc.reconcile("e", plan.path(), &mut buf).unwrap_err();
-    let msg = format!("{err:#}");
+    let msg = expect_err(|w| svc.reconcile("e", plan.path(), w));
     assert!(
         msg.contains("duplicate task id 'aaaaaaaaaaaa'"),
         "error: {msg}"
@@ -335,50 +348,45 @@ fn reconcile_rejects_duplicate_task_id_in_plan() {
 fn reconcile_rejects_unknown_task_source() {
     let (store, clock) = fixture();
     let svc = EpicService::new(store.as_ref(), &clock);
-    let _ = capture(|w| svc.create("e", Path::new("spec/e.md"), None, w));
+    seed_epic(&svc, "e");
 
-    let plan = NamedTempFile::new().unwrap();
-    {
-        let mut f = std::fs::File::create(plan.path()).unwrap();
-        writeln!(
-            f,
-            r#"{{"kind":"task","id":"aaaaaaaaaaaa","title":"x","source":"telepathy"}}"#
-        )
-        .unwrap();
-    }
-    let mut buf: Vec<u8> = Vec::new();
-    let err = svc.reconcile("e", plan.path(), &mut buf).unwrap_err();
-    assert!(format!("{err:#}").contains("unknown source 'telepathy'"));
+    let plan = write_plan_jsonl(&[
+        r#"{"kind":"task","id":"aaaaaaaaaaaa","title":"x","source":"telepathy"}"#,
+    ]);
+    let msg = expect_err(|w| svc.reconcile("e", plan.path(), w));
+    assert!(msg.contains("unknown source 'telepathy'"), "error: {msg}");
+    // No partial write on parse error.
+    assert!(store.list_tasks_by_epic("e", None).unwrap().is_empty());
 }
 
 #[test]
 fn reconcile_skips_blank_and_comment_lines() {
     let (store, clock) = fixture();
     let svc = EpicService::new(store.as_ref(), &clock);
-    let _ = capture(|w| svc.create("e", Path::new("spec/e.md"), None, w));
+    seed_epic(&svc, "e");
 
-    let plan = NamedTempFile::new().unwrap();
-    {
-        let mut f = std::fs::File::create(plan.path()).unwrap();
-        writeln!(f, "# leading comment").unwrap();
-        writeln!(f).unwrap();
-        writeln!(
-            f,
-            r#"{{"kind":"task","id":"aaaaaaaaaaaa","title":"first"}}"#
-        )
-        .unwrap();
-        writeln!(f, "   ").unwrap();
-    }
+    // The `#`-prefixed line is itself valid JSON; if the parser stripped `#`
+    // *after* trying to deserialize it would either error or insert task
+    // `cccccccccccc`. Asserting only `aaaa...` is created proves `#` is
+    // recognized as a comment marker before parse.
+    let plan = write_plan_jsonl(&[
+        r#"# {"kind":"task","id":"cccccccccccc","title":"comment"}"#,
+        "",
+        r#"{"kind":"task","id":"aaaaaaaaaaaa","title":"first"}"#,
+        "   ",
+    ]);
     let (code, _) = capture(|w| svc.reconcile("e", plan.path(), w));
     assert_eq!(code, 0);
-    assert_eq!(store.list_tasks_by_epic("e", None).unwrap().len(), 1);
+    let tasks = store.list_tasks_by_epic("e", None).unwrap();
+    assert_eq!(tasks.len(), 1);
+    assert_eq!(tasks[0].id.as_str(), "aaaaaaaaaaaa");
 }
 
 #[test]
 fn list_renders_human_table_when_not_json() {
     let (store, clock) = fixture();
     let svc = EpicService::new(store.as_ref(), &clock);
-    let _ = capture(|w| svc.create("alpha", Path::new("spec/a.md"), None, w));
+    seed_epic(&svc, "alpha");
     let (code, out) = capture(|w| svc.list(None, false, w));
     assert_eq!(code, 0);
     assert!(out.contains("alpha"));

--- a/plugins/github-autopilot/cli/tests/epic_tests.rs
+++ b/plugins/github-autopilot/cli/tests/epic_tests.rs
@@ -1,0 +1,318 @@
+//! L3 CLI integration tests for `autopilot epic` subcommands.
+//!
+//! Drives `EpicService` directly with `InMemoryTaskStore` + `FixedClock`
+//! and checks stdout / exit-code stability per spec §5 (04-test-scenarios).
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use autopilot::cmd::epic::{EpicService, EpicStatusFilter};
+use autopilot::domain::{Epic, EpicStatus, EventKind, TaskId, TaskStatus};
+use autopilot::ports::clock::FixedClock;
+use autopilot::ports::task_store::{EpicPlan, EventFilter, NewTask, TaskStore};
+use autopilot::store::InMemoryTaskStore;
+use chrono::{TimeZone, Utc};
+use tempfile::NamedTempFile;
+
+fn fixture() -> (Arc<dyn TaskStore>, FixedClock) {
+    let store: Arc<dyn TaskStore> = Arc::new(InMemoryTaskStore::new());
+    let clock = FixedClock::new(Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap());
+    (store, clock)
+}
+
+fn capture<F>(f: F) -> (i32, String)
+where
+    F: FnOnce(&mut Vec<u8>) -> anyhow::Result<i32>,
+{
+    let mut buf: Vec<u8> = Vec::new();
+    let code = f(&mut buf).expect("service call");
+    (code, String::from_utf8(buf).expect("utf-8"))
+}
+
+#[test]
+fn create_persists_epic_and_emits_started_event() {
+    let (store, clock) = fixture();
+    let svc = EpicService::new(store.as_ref(), &clock);
+
+    let (code, out) = capture(|w| svc.create("e", Path::new("spec/e.md"), None, w));
+    assert_eq!(code, 0, "stdout: {out}");
+
+    let epics = store.list_epics(None).unwrap();
+    assert_eq!(epics.len(), 1);
+    assert_eq!(epics[0].name, "e");
+    assert_eq!(epics[0].status, EpicStatus::Active);
+    assert_eq!(epics[0].branch, "epic/e");
+    assert_eq!(epics[0].spec_path, PathBuf::from("spec/e.md"));
+
+    let events = store
+        .list_events(EventFilter {
+            kinds: vec![EventKind::EpicStarted],
+            ..Default::default()
+        })
+        .unwrap();
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].epic_name.as_deref(), Some("e"));
+}
+
+#[test]
+fn create_uses_explicit_branch_override() {
+    let (store, clock) = fixture();
+    let svc = EpicService::new(store.as_ref(), &clock);
+    let (_code, _) = capture(|w| svc.create("e", Path::new("spec/e.md"), Some("custom/x"), w));
+    let e = store.get_epic("e").unwrap().unwrap();
+    assert_eq!(e.branch, "custom/x");
+}
+
+#[test]
+fn create_returns_exit_1_when_epic_already_exists() {
+    let (store, clock) = fixture();
+    let svc = EpicService::new(store.as_ref(), &clock);
+    let _ = capture(|w| svc.create("e", Path::new("spec/e.md"), None, w));
+    let (code, out) = capture(|w| svc.create("e", Path::new("spec/e.md"), None, w));
+    assert_eq!(code, 1);
+    assert!(out.contains("already exists"), "stdout: {out}");
+}
+
+#[test]
+fn list_filters_by_status_and_renders_json() {
+    let (store, clock) = fixture();
+    let svc = EpicService::new(store.as_ref(), &clock);
+    let _ = capture(|w| svc.create("a", Path::new("spec/a.md"), None, w));
+    let _ = capture(|w| svc.create("b", Path::new("spec/b.md"), None, w));
+    store
+        .set_epic_status("b", EpicStatus::Completed, clock_now(&clock))
+        .unwrap();
+
+    let (code, out) = capture(|w| svc.list(Some(EpicStatusFilter::Active), true, w));
+    assert_eq!(code, 0);
+    let v: serde_json::Value = serde_json::from_str(out.trim()).unwrap();
+    let arr = v.as_array().unwrap();
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["name"], "a");
+
+    let (_, out_all) = capture(|w| svc.list(Some(EpicStatusFilter::All), true, w));
+    let v: serde_json::Value = serde_json::from_str(out_all.trim()).unwrap();
+    assert_eq!(v.as_array().unwrap().len(), 2);
+}
+
+#[test]
+fn get_returns_exit_1_when_missing() {
+    let (store, clock) = fixture();
+    let svc = EpicService::new(store.as_ref(), &clock);
+    let (code, _) = capture(|w| svc.get("ghost", false, w));
+    assert_eq!(code, 1);
+}
+
+#[test]
+fn status_groups_tasks_by_state() {
+    let (store, clock) = fixture();
+    let svc = EpicService::new(store.as_ref(), &clock);
+
+    // Insert epic with two tasks; one promoted to ready, one pending behind a dep
+    let now = clock_now(&clock);
+    store
+        .insert_epic_with_tasks(
+            EpicPlan {
+                epic: Epic {
+                    name: "e".into(),
+                    spec_path: PathBuf::from("spec/e.md"),
+                    branch: "epic/e".into(),
+                    status: EpicStatus::Active,
+                    created_at: now,
+                    completed_at: None,
+                },
+                tasks: vec![
+                    NewTask {
+                        id: TaskId::from_raw("aaaaaaaaaaaa"),
+                        source: autopilot::domain::TaskSource::Decompose,
+                        fingerprint: None,
+                        title: "first".into(),
+                        body: None,
+                    },
+                    NewTask {
+                        id: TaskId::from_raw("bbbbbbbbbbbb"),
+                        source: autopilot::domain::TaskSource::Decompose,
+                        fingerprint: None,
+                        title: "second".into(),
+                        body: None,
+                    },
+                ],
+                deps: vec![(
+                    TaskId::from_raw("bbbbbbbbbbbb"),
+                    TaskId::from_raw("aaaaaaaaaaaa"),
+                )],
+            },
+            now,
+        )
+        .unwrap();
+
+    let (code, out) = capture(|w| svc.status(Some("e"), true, w));
+    assert_eq!(code, 0, "stdout: {out}");
+    let v: serde_json::Value = serde_json::from_str(out.trim()).unwrap();
+    let r = &v.as_array().unwrap()[0];
+    assert_eq!(r["epic"], "e");
+    assert_eq!(r["counts"]["ready"], 1);
+    assert_eq!(r["counts"]["pending"], 1);
+    assert_eq!(r["total"], 2);
+}
+
+#[test]
+fn complete_marks_epic_completed_and_records_event() {
+    let (store, clock) = fixture();
+    let svc = EpicService::new(store.as_ref(), &clock);
+    let _ = capture(|w| svc.create("e", Path::new("spec/e.md"), None, w));
+
+    let (code, _) = capture(|w| svc.complete("e", w));
+    assert_eq!(code, 0);
+    let e = store.get_epic("e").unwrap().unwrap();
+    assert_eq!(e.status, EpicStatus::Completed);
+    let events = store
+        .list_events(EventFilter {
+            kinds: vec![EventKind::EpicCompleted],
+            ..Default::default()
+        })
+        .unwrap();
+    assert_eq!(events.len(), 1);
+}
+
+#[test]
+fn complete_returns_exit_1_when_epic_missing() {
+    let (store, clock) = fixture();
+    let svc = EpicService::new(store.as_ref(), &clock);
+    let (code, out) = capture(|w| svc.complete("ghost", w));
+    assert_eq!(code, 1);
+    assert!(out.contains("not found"));
+}
+
+#[test]
+fn abandon_marks_epic_abandoned() {
+    let (store, clock) = fixture();
+    let svc = EpicService::new(store.as_ref(), &clock);
+    let _ = capture(|w| svc.create("e", Path::new("spec/e.md"), None, w));
+    let (code, _) = capture(|w| svc.abandon("e", w));
+    assert_eq!(code, 0);
+    assert_eq!(
+        store.get_epic("e").unwrap().unwrap().status,
+        EpicStatus::Abandoned
+    );
+}
+
+#[test]
+fn find_by_spec_path_matches_active_epic() {
+    let (store, clock) = fixture();
+    let svc = EpicService::new(store.as_ref(), &clock);
+    let _ = capture(|w| svc.create("e", Path::new("spec/e.md"), None, w));
+    let (code, out) = capture(|w| svc.find_by_spec_path(Path::new("spec/e.md"), true, w));
+    assert_eq!(code, 0);
+    let v: serde_json::Value = serde_json::from_str(out.trim()).unwrap();
+    assert_eq!(v["name"], "e");
+}
+
+#[test]
+fn find_by_spec_path_returns_exit_1_when_no_match() {
+    let (store, clock) = fixture();
+    let svc = EpicService::new(store.as_ref(), &clock);
+    let (code, _) = capture(|w| svc.find_by_spec_path(Path::new("spec/none.md"), false, w));
+    assert_eq!(code, 1);
+}
+
+#[test]
+fn find_by_spec_path_returns_exit_3_on_inconsistency() {
+    // Two active epics share a spec_path → invariant violation.
+    let store: Arc<dyn TaskStore> = Arc::new(InMemoryTaskStore::new());
+    let clock = FixedClock::new(Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap());
+    let now = clock_now(&clock);
+    for name in ["a", "b"] {
+        store
+            .insert_epic_with_tasks(
+                EpicPlan {
+                    epic: Epic {
+                        name: name.into(),
+                        spec_path: PathBuf::from("spec/shared.md"),
+                        branch: format!("epic/{name}"),
+                        status: EpicStatus::Active,
+                        created_at: now,
+                        completed_at: None,
+                    },
+                    tasks: vec![],
+                    deps: vec![],
+                },
+                now,
+            )
+            .unwrap();
+    }
+    let svc = EpicService::new(store.as_ref(), &clock);
+    let (code, out) = capture(|w| svc.find_by_spec_path(Path::new("spec/shared.md"), false, w));
+    assert_eq!(code, 3);
+    assert!(out.contains("inconsistency"), "stdout: {out}");
+}
+
+#[test]
+fn reconcile_applies_jsonl_plan_and_is_idempotent() {
+    let (store, clock) = fixture();
+    let svc = EpicService::new(store.as_ref(), &clock);
+    let _ = capture(|w| svc.create("e", Path::new("spec/e.md"), None, w));
+
+    let plan = NamedTempFile::new().unwrap();
+    let lines = [
+        r#"{"kind":"task","id":"aaaaaaaaaaaa","title":"first","fingerprint":null,"source":"decompose"}"#,
+        r#"{"kind":"task","id":"bbbbbbbbbbbb","title":"second"}"#,
+        r#"{"kind":"dep","task":"bbbbbbbbbbbb","depends_on":"aaaaaaaaaaaa"}"#,
+    ];
+    {
+        let mut f = std::fs::File::create(plan.path()).unwrap();
+        for l in &lines {
+            writeln!(f, "{l}").unwrap();
+        }
+    }
+
+    // First call: tasks created, dependent stays pending
+    let (code1, _) = capture(|w| svc.reconcile("e", plan.path(), w));
+    assert_eq!(code1, 0);
+    let tasks = store.list_tasks_by_epic("e", None).unwrap();
+    assert_eq!(tasks.len(), 2);
+    let by_id = |id: &str| tasks.iter().find(|t| t.id.as_str() == id).cloned().unwrap();
+    assert_eq!(by_id("aaaaaaaaaaaa").status, TaskStatus::Ready);
+    assert_eq!(by_id("bbbbbbbbbbbb").status, TaskStatus::Pending);
+
+    let snapshot1 = store.list_tasks_by_epic("e", None).unwrap();
+
+    // Second call: store state unchanged (events accumulate, tasks stable)
+    let (code2, _) = capture(|w| svc.reconcile("e", plan.path(), w));
+    assert_eq!(code2, 0);
+    let snapshot2 = store.list_tasks_by_epic("e", None).unwrap();
+    assert_eq!(
+        snapshot1
+            .iter()
+            .map(|t| (&t.id, t.status))
+            .collect::<Vec<_>>(),
+        snapshot2
+            .iter()
+            .map(|t| (&t.id, t.status))
+            .collect::<Vec<_>>()
+    );
+
+    let reconciled_events = store
+        .list_events(EventFilter {
+            kinds: vec![EventKind::Reconciled],
+            ..Default::default()
+        })
+        .unwrap();
+    assert_eq!(reconciled_events.len(), 2);
+}
+
+#[test]
+fn reconcile_returns_exit_1_when_epic_missing() {
+    let (store, clock) = fixture();
+    let svc = EpicService::new(store.as_ref(), &clock);
+    let plan = NamedTempFile::new().unwrap();
+    let (code, out) = capture(|w| svc.reconcile("ghost", plan.path(), w));
+    assert_eq!(code, 1);
+    assert!(out.contains("not found"));
+}
+
+fn clock_now(c: &FixedClock) -> chrono::DateTime<Utc> {
+    use autopilot::ports::clock::Clock;
+    c.now()
+}

--- a/plugins/github-autopilot/cli/tests/epic_tests.rs
+++ b/plugins/github-autopilot/cli/tests/epic_tests.rs
@@ -302,3 +302,95 @@ fn reconcile_returns_exit_1_when_epic_missing() {
     assert_eq!(code, 1);
     assert!(out.contains("not found"));
 }
+
+#[test]
+fn reconcile_rejects_duplicate_task_id_in_plan() {
+    let (store, clock) = fixture();
+    let svc = EpicService::new(store.as_ref(), &clock);
+    let _ = capture(|w| svc.create("e", Path::new("spec/e.md"), None, w));
+
+    let plan = NamedTempFile::new().unwrap();
+    let lines = [
+        r#"{"kind":"task","id":"aaaaaaaaaaaa","title":"first"}"#,
+        r#"{"kind":"task","id":"aaaaaaaaaaaa","title":"duplicate"}"#,
+    ];
+    {
+        let mut f = std::fs::File::create(plan.path()).unwrap();
+        for l in &lines {
+            writeln!(f, "{l}").unwrap();
+        }
+    }
+
+    let mut buf: Vec<u8> = Vec::new();
+    let err = svc.reconcile("e", plan.path(), &mut buf).unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("duplicate task id 'aaaaaaaaaaaa'"),
+        "error: {msg}"
+    );
+    assert!(store.list_tasks_by_epic("e", None).unwrap().is_empty());
+}
+
+#[test]
+fn reconcile_rejects_unknown_task_source() {
+    let (store, clock) = fixture();
+    let svc = EpicService::new(store.as_ref(), &clock);
+    let _ = capture(|w| svc.create("e", Path::new("spec/e.md"), None, w));
+
+    let plan = NamedTempFile::new().unwrap();
+    {
+        let mut f = std::fs::File::create(plan.path()).unwrap();
+        writeln!(
+            f,
+            r#"{{"kind":"task","id":"aaaaaaaaaaaa","title":"x","source":"telepathy"}}"#
+        )
+        .unwrap();
+    }
+    let mut buf: Vec<u8> = Vec::new();
+    let err = svc.reconcile("e", plan.path(), &mut buf).unwrap_err();
+    assert!(format!("{err:#}").contains("unknown source 'telepathy'"));
+}
+
+#[test]
+fn reconcile_skips_blank_and_comment_lines() {
+    let (store, clock) = fixture();
+    let svc = EpicService::new(store.as_ref(), &clock);
+    let _ = capture(|w| svc.create("e", Path::new("spec/e.md"), None, w));
+
+    let plan = NamedTempFile::new().unwrap();
+    {
+        let mut f = std::fs::File::create(plan.path()).unwrap();
+        writeln!(f, "# leading comment").unwrap();
+        writeln!(f).unwrap();
+        writeln!(
+            f,
+            r#"{{"kind":"task","id":"aaaaaaaaaaaa","title":"first"}}"#
+        )
+        .unwrap();
+        writeln!(f, "   ").unwrap();
+    }
+    let (code, _) = capture(|w| svc.reconcile("e", plan.path(), w));
+    assert_eq!(code, 0);
+    assert_eq!(store.list_tasks_by_epic("e", None).unwrap().len(), 1);
+}
+
+#[test]
+fn list_renders_human_table_when_not_json() {
+    let (store, clock) = fixture();
+    let svc = EpicService::new(store.as_ref(), &clock);
+    let _ = capture(|w| svc.create("alpha", Path::new("spec/a.md"), None, w));
+    let (code, out) = capture(|w| svc.list(None, false, w));
+    assert_eq!(code, 0);
+    assert!(out.contains("alpha"));
+    assert!(out.contains("epic/alpha"));
+    assert!(out.contains("active"));
+}
+
+#[test]
+fn list_emits_placeholder_when_empty() {
+    let (store, clock) = fixture();
+    let svc = EpicService::new(store.as_ref(), &clock);
+    let (code, out) = capture(|w| svc.list(None, false, w));
+    assert_eq!(code, 0);
+    assert!(out.contains("(no epics)"));
+}


### PR DESCRIPTION
## Summary
- `cmd/epic.rs`: `EpicService` exposes 8 ledger subcommands — create, list, get, status, complete, abandon, find-by-spec-path, reconcile — as thin adapters over `TaskStore`.
- `find-by-spec-path` maps `DomainError::Inconsistency` to exit 3 per spec; `not found` cases use exit 1.
- `epic reconcile` parses JSONL (`task` / `dep` / `remote_state` / `orphan_branch` lines) into `ReconciliationPlan` and delegates to `apply_reconciliation`. Requires the epic to exist (created via `epic create`) so spec_path metadata is preserved.
- Wired `Commands::Epic { command }` into clap + `main.rs` dispatching.

## Test plan
- [x] `cargo fmt --check` ✓
- [x] `cargo clippy --lib --bins -- -D warnings` ✓ (matches CI hook scope)
- [x] `cargo check` ✓
- [x] `cargo test` — 14 new L3 tests in `tests/epic_tests.rs` covering: persist+event emission, branch override, duplicate-name exit 1, status filter + JSON, get not-found, status counts, complete/abandon, find-by-spec-path (match / none / inconsistency exit 3), reconcile idempotency + missing-epic exit 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)