### PR TITLE
docs(spec-kit): plan 2-layer grounded extraction redesign

### DIFF
--- a/plans/spec-kit-redesign/00-concept.md
+++ b/plans/spec-kit-redesign/00-concept.md
@@ -1,0 +1,110 @@
+# spec-kit 재설계 — 2-layer Grounded Extraction
+
+## 배경
+
+현재 spec-kit 은 다음 6개 에이전트로 구성되어 있다:
+
+| 에이전트 | 역할 |
+|----------|------|
+| `spec-parser` | spec 마크다운 → 구조화 JSON |
+| `cross-reference-checker` | spec ↔ spec 일관성 (D1-D5) |
+| `spec-quality-checker` | spec 자체 품질 (A/B/C) |
+| `gap-analyzer` | spec ↔ code gap |
+| `reverse-gap-analyzer` | code ↔ spec reverse gap |
+| `structure-mapper` | code 구조 매핑 |
+
+이 구조의 핵심 문제는 **spec-parser 가 N개 파일을 종합 요약** 한다는 것이다. 종합 = 해석 = 환각 진입점.
+
+## 트리거 사건 (#639)
+
+`/spec-kit:spec-review` 실행 중 `cross-reference-checker` 가:
+
+1. 실제 Read 도구를 호출하지 않고 텍스트로 `<tool_call>` / `<tool_response>` 블록 생성
+2. 가짜 본문 생성 (`content_type ENUM('json','multipart','form')` — 실제는 `VARCHAR(255)`)
+3. 이를 다른 spec 의 실제 내용과 대조해 "불일치 6건" 보고
+
+근본 원인은 **에이전트가 종합 요약된 입력만 보고 결론을 내려야 하는 구조** 자체에 있다. 입력에 없는 내용을 만들어 내도 검증할 메커니즘이 없다.
+
+## 임시 처치 (#650)
+
+prompt-level 강제 조항을 추가했다:
+
+- "전달받은 구조화 입력에만 근거하여 검증한다"
+- "`<tool_call>` / `<tool_response>` 같은 가짜 블록을 출력하지 않는다"
+
+부정형 지시("거짓말 하지 마라")는 LLM 이 어기기 쉽다. 같은 환각이 다른 형태로 재발할 수 있다.
+
+## 새 설계 방향
+
+### 핵심 원칙
+
+1. **종합 요약 단계 제거** — spec-parser 처럼 "여러 파일을 한번에 요약하는" 에이전트 없음
+2. **하나의 에이전트는 하나의 파일만** — 발언권의 범위 = 자기 파일
+3. **인용 by construction** — 각 에이전트는 직접 Read 한 파일의 라인을 인용. 인용 없으면 발언 불가
+4. **Code 를 외부 ground truth 로 활용** — spec 만 보지 말고 code 와 대조. "spec 의 모호함" 이 "code 와의 불일치" 라는 객관적 증거로 드러남
+
+### 2-Layer 구조
+
+```
+[Layer 1] file-pair-observer  (Haiku × N, 병렬)
+  Input  : spec 파일 1개 + 관련 code 영역
+  Output : 사실 나열만 (인용 필수)
+           - Spec Claims        : "이 라인에 이렇게 쓰여 있다"
+           - Code Observations  : "이 라인에 이렇게 구현돼 있다"
+           - Mismatches         : 둘이 다른 곳 (판단 없이 병치)
+           - Gaps               : 한쪽에만 있는 것
+  특성   : 종합/추론 금지. 적시만. 인용은 file:line 범위 + 발췌
+
+         ↓ N개 markdown 리포트
+
+[Layer 2] gap-analyzer  (Sonnet/Opus, 1개)
+  Input  : L1 리포트 전체 (raw 파일 안 봄)
+  Output :
+    A. code ↔ spec gaps  : 구현 불일치/누락
+    B. spec ↔ spec gaps  : 여러 L1 리포트가 같은 code 를 다른 spec 주장으로
+                            가리킬 때 자동 발견
+  특성   : 새 사실 만들지 않음. L1 인용을 그대로 통과시키며 패턴 매칭 + 우선순위
+```
+
+### 환각 면적 비교
+
+| 단계 | 기존 구조 | 새 구조 |
+|------|-----------|---------|
+| 입력 종합 | spec-parser 가 N 파일 종합 → JSON (환각 진입점) | 없음 |
+| Per-file 처리 | 없음 | L1 (Haiku, 자기 파일만, 인용 필수) |
+| Cross-file 검증 | 6개 checker 가 JSON 종합 결론 (환각 surface 큼) | L2 (Sonnet, L1 인용만 처리) |
+| 인용 가능성 | 약함 (JSON 경로 인용은 사용자 친화 X) | 강함 (file:line + excerpt, 클릭 가능) |
+| 검증 메커니즘 | 없음 | L1: 인용 라인이 실파일에 존재하는지 확인. L2: 인용된 L1 리포트 항목이 실재하는지 확인 |
+
+### 모델 선택 근거
+
+- **L1 = Haiku**: 사실 적시 작업. 종합 욕심을 부리는 강한 모델은 오히려 위험. Haiku 의 "literal" 성향이 적합. N개 병렬 → 비용도 낮음.
+- **L2 = Sonnet/Opus**: 패턴 매칭, 우선순위, 종합 판단. 새 사실은 만들지 않지만 cross-report 추론 필요. 한 번만 호출.
+
+### 기존 6개 에이전트 흡수 매핑
+
+| 기존 | 새 구조 | 비고 |
+|------|---------|------|
+| `spec-parser` | **삭제** | 종합 요약 단계가 없어짐 |
+| `cross-reference-checker` | **L2 흡수** | spec ↔ spec gap 이 L2 의 자연스런 결과 |
+| `spec-quality-checker` | **L2 흡수** | spec 모호함이 code 와의 불일치로 드러남 |
+| `gap-analyzer` | **L1 + L2 분산** | per-file 관찰은 L1, 종합 판단은 L2 |
+| `reverse-gap-analyzer` | **L1 + L2 분산** | 양방향 관찰을 L1 이 한꺼번에 |
+| `structure-mapper` | **L1 보조** | 각 L1 에이전트가 자기 영역 매핑 → L2 가 합침 |
+
+6 → 2 단순화.
+
+## #650 의 처리
+
+이 재설계가 합의되면 #650 은 **임시방편으로 머지** 한다:
+
+- 새 구조 구현/마이그레이션은 다중 단계 작업이라 시간이 걸림
+- 그 사이에도 #639 같은 환각이 재발할 수 있으므로 약한 가드라도 있는 게 낫다
+- 새 구조가 안정화되면 cross-reference-checker / spec-quality-checker 자체가 사라지므로 자연스레 함께 제거됨
+
+## 다음 단계
+
+- `01-use-cases.md`: D1-D5, A/B/C, gap, reverse-gap, #639 시나리오가 새 구조에서 어떻게 풀리는지
+- `02-architecture.md`: L1/L2 인터페이스, 입력 결정, 호출자 변경
+- `03-detailed-spec.md`: 출력 스키마, 인용 형식, 검증 규칙
+- `04-test-scenarios.md`: 환각 회귀, 마이그레이션 호환성, 정확도 측정

--- a/plans/spec-kit-redesign/01-use-cases.md
+++ b/plans/spec-kit-redesign/01-use-cases.md
@@ -1,0 +1,247 @@
+# Use Cases — 새 구조에서 기존 검증 시나리오 처리
+
+기존 spec-kit 의 검증 분류(D1-D5, A/B/C, gap, reverse-gap)와 트리거 사건(#639) 이 새 2-layer 구조에서 어떻게 처리되는지 시나리오 기반으로 검증한다.
+
+## U1. D1 — 용어 일관성
+
+### 기존 처리
+`cross-reference-checker` 가 `spec-parser` 의 `glossary` JSON 을 받아 용어별 정의 충돌을 탐색.
+
+### 새 처리
+
+**L1 출력 예** (`database.md` 담당 에이전트):
+
+```markdown
+## Spec Claims
+- [S3] `database.md:80-85` — "Tool: 외부 시스템과의 통합 단위. ID 는 namespace + name 으로 식별"
+```
+
+**L1 출력 예** (`proxy.md` 담당 에이전트):
+
+```markdown
+## Spec Claims
+- [S2] `proxy.md:40-44` — "Tool: 사용자가 호출 가능한 단일 엔드포인트. ID 는 UUID"
+```
+
+**L2 가 발견**:
+
+```markdown
+### [HIGH] 용어 "Tool" 의 정의 충돌
+- 증거: database.md report [S3] vs proxy.md report [S2]
+- 양쪽 모두 동일 code 영역(`internal/types/tool.go`)을 가리키지만 서로 다른 식별 방식 주장
+- 둘 중 하나(또는 둘 다)는 실 구현과 불일치
+```
+
+**핵심**: D1 을 위한 별도 검증 로직 불필요. L2 가 L1 리포트들에서 같은 항목에 대한 다른 주장을 발견하면 자동으로 표면화.
+
+## U2. D2 — 요구사항 ↔ 컴포넌트 매핑
+
+### 기존 처리
+`cross-reference-checker` 가 `requirements[].component` 와 `components[]` 리스트를 cross-check.
+
+### 새 처리
+
+**L1 출력**:
+
+```markdown
+## Spec Claims
+- [R1] `auth.md:120` — "Auth 모듈은 JWT 토큰 검증을 수행"
+
+## Code Observations
+- [C1] `internal/auth/jwt.go:50` — `func ValidateToken(token string) error`
+
+## Mismatches
+- [R1] vs [C1] — 일치
+```
+
+**Orphan requirement (구현 누락)**:
+
+```markdown
+## Gaps
+- [G1] spec `auth.md:200` "Refresh token 회전" 언급 → 해당 영역 code 없음
+```
+
+**Orphan code (spec 누락)**:
+
+```markdown
+## Gaps
+- [G2] code `internal/auth/session.go:30` "session expiry tracking" → spec 미언급
+```
+
+**L2 종합**:
+
+```markdown
+### [MEDIUM] Auth 모듈 요구사항 누락
+- 증거: auth.md report [G1]
+- spec 만 있고 code 없음. 우선순위 협의 필요
+```
+
+## U3. D5 — 인터페이스 일치
+
+### 기존 처리
+`cross-reference-checker` 가 spec 들이 선언한 인터페이스 시그니처를 cross-check.
+
+### 새 처리
+
+**L1 출력 (proxy.md 담당)**:
+
+```markdown
+## Spec Claims
+- [S1] `proxy.md:60-70` — "GET /tools/{name} → ToolInfo { id, name, version }"
+
+## Code Observations
+- [C1] `internal/handler/tool.go:40` — `r.GET("/tools/:name", getToolInfo)` returns `ToolInfo { ID, Name, Version, Deprecated }`
+
+## Mismatches
+- [S1] vs [C1] — 응답에 `Deprecated` 필드 추가 (spec 미언급)
+```
+
+**L1 출력 (api.md 담당)**:
+
+```markdown
+## Spec Claims
+- [S2] `api.md:30` — "ToolInfo 응답: { id, name, version, deprecated_at? }"
+```
+
+**L2 종합**:
+
+```markdown
+### [HIGH] ToolInfo 응답 스키마 충돌
+- 증거: proxy.md report [S1, C1] vs api.md report [S2]
+- proxy.md 는 deprecated 필드 미언급, api.md 는 `deprecated_at` 명시
+- code 는 `Deprecated` (boolean) 사용 → 두 spec 과 다름
+```
+
+## U4. A/B/C — Spec Quality
+
+### 기존 처리
+`spec-quality-checker` 가 spec 자체를 읽고 모호성, 누락, 검증 불가 항목을 식별.
+
+### 새 처리
+
+기존 처리는 "spec 만 보고" 모호성을 판단하려 했다. 새 구조에서는 **code 와의 대조 결과** 가 모호성을 드러내는 객관적 증거가 된다.
+
+**Mode A. 직접 모호 (기존과 유사)**
+
+여전히 일부 모호함은 spec 만 봐도 보임. L1 이 다음과 같이 표시:
+
+```markdown
+## Notes
+- [N1] `auth.md:150` — "적절한 시점에 토큰 갱신" 시점 미명시 (모호)
+```
+
+**Mode B. Code 와의 대조로 드러나는 모호함 (새 능력)**
+
+```markdown
+## L1 from auth.md
+- [S5] `auth.md:200` — "사용자는 권한에 따라 접근 제한"
+
+## L1 from rbac.md
+- [S2] `rbac.md:80` — "역할 기반 접근 제어"
+```
+
+**L2 발견**:
+
+```markdown
+### [MEDIUM] auth.md "권한" 정의 부재
+- 증거: auth.md report [S5] (권한 언급) + rbac.md report [S2] (역할 정의)
+- auth.md 는 "권한" 의 의미를 정의하지 않음. rbac.md 는 별개 개념인 "역할" 만 다룸
+- code 는 두 개념을 모두 사용 (`internal/auth/permission.go`, `internal/rbac/role.go`)
+- spec 에 "권한 vs 역할" 정의 누락
+```
+
+이것이 "**code 를 외부 ground truth 로 활용**" 의 실제 효과. 기존 spec-only 검증이 잡지 못하는 모호함이 드러남.
+
+## U5. Spec ↔ Code Gap (gap-analyzer 의 일)
+
+### 기존 처리
+`gap-analyzer` 가 spec 의 요구사항 리스트와 code 를 대조해 미구현 항목 식별.
+
+### 새 처리
+
+L1 의 `## Gaps` 섹션이 그대로 이 역할. L2 가 우선순위만 부여.
+
+**L1 출력**:
+
+```markdown
+## Gaps
+- [G1] `auth.md:300` "rate limiting" → 해당 영역 code 없음
+- [G2] `auth.md:250` "audit logging" → `internal/audit/log.go` 존재하지만 auth 호출처 없음 (부분 구현)
+```
+
+**L2**:
+
+```markdown
+### [HIGH] Rate limiting 완전 미구현
+- 증거: auth.md report [G1]
+
+### [MEDIUM] Audit logging 부분 구현
+- 증거: auth.md report [G2]
+- 모듈은 있으나 auth 영역에서 호출 없음
+```
+
+## U6. Code ↔ Spec Reverse Gap (reverse-gap-analyzer 의 일)
+
+### 기존 처리
+`reverse-gap-analyzer` 가 code 에 있는데 spec 에 없는 것을 식별.
+
+### 새 처리
+
+L1 이 양방향을 동시에 본다. `## Gaps` 의 다른 방향:
+
+```markdown
+## Gaps
+- [G3] `internal/auth/api_key.go:20` "API key 인증" → spec 미언급
+```
+
+L2 종합 시 reverse gap 으로 분류:
+
+```markdown
+### [LOW] API key 인증 spec 누락
+- 증거: auth.md report [G3]
+- code 는 있으나 spec 어디에도 정의 없음
+- 결정 필요: spec 추가 vs code 제거
+```
+
+## U7. #639 회귀 시나리오 (환각 검출)
+
+### 가상 재현
+
+새 구조에서 같은 종류의 환각이 시도된다고 가정.
+
+**가정**: L1 (`database.md` 담당) 이 hallucinate.
+
+가짜 출력:
+
+```markdown
+## Spec Claims
+- [S99] `database.md:99999` — "content_type ENUM('json','multipart','form')"
+```
+
+### 차단 메커니즘
+
+1. **인용 검증 (오케스트레이터)**: `database.md` 의 라인 99999 가 존재하는지 확인 → 없음 → finding drop + 경고
+2. **substring 검증**: 인용된 텍스트가 `database.md:99999` 에 실제 존재하는지 → 없음 → drop
+3. **L2 영향 차단**: 검증 실패한 finding 은 L2 입력에서 제거되므로 환각이 cross-file 결론으로 번지지 않음
+
+### 환각 전파 단절
+
+- L1 한 에이전트의 환각은 그 파일 검증 단계에서 차단됨
+- 다른 파일 L1 들은 영향 없음 (서로 격리)
+- L2 는 검증 통과한 항목만 봄
+
+### 검증 못 잡는 케이스 (잔여 위험)
+
+- 인용 라인이 실재하고 substring 도 매치하지만, **해석이 왜곡** 된 경우
+- 예: 실제로 "VARCHAR(255)" 인데 L1 이 "VARCHAR(255) (=ENUM 의 일종)" 로 적음
+- 잔여 대응: L1 의 출력 형식을 "**원문 그대로 인용 + 한 줄 분류**" 로 강제하여 해석을 최소화
+
+## 결론
+
+새 구조는 기존 6개 에이전트의 모든 use case 를 cover 하며, 추가로 다음 능력을 얻는다:
+
+- code 를 외부 ground truth 로 활용한 모호함 발견 (U4 Mode B)
+- 환각 차단 메커니즘 (U7)
+- L1 병렬화로 성능 향상
+
+다음 문서(`02-architecture.md`)에서 L1/L2 인터페이스를 명시한다.

--- a/plans/spec-kit-redesign/02-architecture.md
+++ b/plans/spec-kit-redesign/02-architecture.md
@@ -1,0 +1,251 @@
+# Architecture — L1/L2 인터페이스, 호출 흐름
+
+## 전체 흐름
+
+```
+/spec-kit:spec-review (커맨드)
+  │
+  ├─ Step 1: spec 파일 목록 수집 + frontmatter 파싱 (related_paths)
+  │
+  ├─ Step 2: L1 에이전트 N개 병렬 spawn (Haiku)
+  │            ├─ file-pair-observer(spec_file=A.md, code_paths=...)
+  │            ├─ file-pair-observer(spec_file=B.md, code_paths=...)
+  │            └─ ...
+  │
+  ├─ Step 3: 각 L1 출력에 대한 인용 검증 (오케스트레이터)
+  │            ├─ file:line 범위가 실재하는가
+  │            ├─ 인용 excerpt 가 그 라인의 substring 인가
+  │            └─ 검증 실패 항목 drop + 경고
+  │
+  ├─ Step 4: L2 에이전트 spawn (Sonnet) — L1 검증 통과 리포트만 입력
+  │            └─ gap-analyzer
+  │
+  ├─ Step 5: L2 출력에 대한 인용 검증 (오케스트레이터)
+  │            └─ L2 가 인용한 L1 항목 ID 가 실재하는가
+  │
+  └─ Step 6: 최종 리포트 출력
+```
+
+## L1: file-pair-observer
+
+### Frontmatter
+
+```yaml
+---
+description: (내부용) /spec-kit:spec-review 가 호출하는 per-file 관찰 에이전트. spec 파일 1개와 관련 code 영역을 읽고 사실만 나열.
+model: haiku
+tools: ["Read", "Glob", "Grep"]
+---
+```
+
+`tools` 에 Read/Glob/Grep 부여. spec 파일과 code 를 직접 읽어야 인용 가능.
+
+### 입력 형식
+
+오케스트레이터로부터 다음 형식의 프롬프트:
+
+```
+# File Observation Request
+
+## Spec 파일
+- 경로: {spec_file_path}
+
+## 관련 code 경로 (Hint)
+{related_paths_from_frontmatter, 없으면 비움}
+
+## 자율 탐색 허용 범위
+- 위 경로 + 그 경로에서 import/require 된 인접 파일
+
+## 출력 (아래 스키마 엄수)
+[출력 스키마 보기 → 03-detailed-spec.md]
+```
+
+### 출력 형식 요약 (상세는 03)
+
+```markdown
+# Per-File Report: {spec_file_path}
+
+## Spec Claims
+- [S{n}] `{file}:{line_start}-{line_end}` — "{원문 인용, 50자 이내 요약 가능}"
+
+## Code Observations
+- [C{n}] `{file}:{line}` — `{code 단편 또는 시그니처}`
+
+## Mismatches
+- [S{n}] vs [C{n}] — {일치 / 차이 한 줄}
+
+## Gaps
+- [G{n}] {Spec 만 / Code 만 / 부분 구현} — {참조 ID + 한 줄 설명}
+
+## Notes (선택)
+- [N{n}] `{file}:{line}` — "{모호한 표현 인용}" (모호 사유 한 줄)
+```
+
+### 제약
+
+- 종합/추론 금지. **나열만**
+- 모든 항목에 file:line 인용 필수
+- 인용은 원문을 그대로 (자유 의역 금지)
+- 원문 발췌가 너무 길면 "..." 으로 생략 표시 (가공 금지)
+
+## L2: gap-analyzer
+
+### Frontmatter
+
+```yaml
+---
+description: (내부용) /spec-kit:spec-review 의 종합 분석 에이전트. L1 리포트들을 받아 code↔spec gap 과 spec↔spec gap 을 식별.
+model: sonnet
+tools: []
+---
+```
+
+`tools: []` — L2 는 raw 파일 안 봄. L1 리포트만 처리.
+
+### 입력 형식
+
+```
+# Gap Analysis Request
+
+## L1 Reports (검증 통과분)
+
+### Report 1
+{database.md report 본문}
+
+### Report 2
+{proxy.md report 본문}
+...
+
+## 출력 (아래 스키마 엄수)
+[출력 스키마 보기 → 03-detailed-spec.md]
+```
+
+### 출력 형식 요약
+
+```markdown
+# Spec Review Report
+
+## Code ↔ Spec Gaps
+
+### [{severity}] {제목}
+- 증거 (L1 인용):
+  - {report_name} {claim_id}
+  - ...
+- {판단/권장}
+
+## Spec ↔ Spec Gaps
+
+### [{severity}] {제목}
+- 증거 (L1 인용):
+  - {report_a} {S/C/G id}
+  - {report_b} {S/C/G id}
+- {판단/권장}
+
+## Notes (모호한 spec 항목)
+
+### [{severity}] {제목}
+- 증거: {report} {N id}
+- {권장}
+```
+
+### 제약
+
+- L1 에 없는 사실 추가 금지
+- 모든 결론에 L1 인용 (report_name + claim_id)
+- 우선순위/판단은 자유롭게 (L2 의 본업) — 단 사실은 L1 인용에서만
+
+## 입력 결정 — `related_paths` 처리
+
+L1 의 "관련 code 영역" 결정 방식 (옵션 C 채택):
+
+### 1차: spec 파일 frontmatter
+
+```yaml
+---
+title: Database Schema
+related_paths:
+  - migrations/
+  - internal/dao/
+---
+```
+
+명시되어 있으면 그대로 사용.
+
+### 2차: 자율 보강
+
+frontmatter 가 비어 있거나 불충분할 때 L1 에이전트가 Glob/Grep 으로 보강:
+
+- spec 파일 본문에 등장하는 식별자/경로 패턴을 grep
+- 프로젝트 루트의 디렉토리 구조 (Glob `*/`) 와 spec 헤딩을 매칭
+- 발견된 경로를 입력에 추가하고 출력 메타에 기록
+
+### 3차: 사용자 확인 (선택)
+
+자율 보강 결과가 너무 많거나 적으면 오케스트레이터가 사용자에게 confirm 요청.
+
+## 호출자 변경 (commands)
+
+### `/spec-kit:spec-review` (개정)
+
+기존: `spec-parser` → 6개 checker 호출 → 통합
+
+신: 위 "전체 흐름" 그대로
+
+### `/spec-kit:spec-quality` (있다면)
+
+L2 만 단독 호출하는 모드 추가 가능. 기존 `spec-quality-checker` 단독 호출 use case 대체.
+
+### 기타 의존자
+
+`gap-analyzer`, `reverse-gap-analyzer`, `structure-mapper`, `cross-reference-checker`, `spec-quality-checker`, `spec-parser` 를 직접 호출하는 곳:
+
+```bash
+grep -rn "spec-parser\|cross-reference-checker\|spec-quality-checker\|gap-analyzer\|reverse-gap-analyzer\|structure-mapper" plugins/
+```
+
+마이그레이션 단계에서 호출 지점을 모두 새 흐름으로 전환.
+
+## 마이그레이션 단계
+
+### Phase 1 (이 PR 이후)
+
+설계 합의. 코드 변경 없음.
+
+### Phase 2 — 신규 에이전트 추가
+
+- `plugins/spec-kit/agents/file-pair-observer.md` (L1) 추가
+- `plugins/spec-kit/agents/gap-analyzer-v2.md` (L2) 추가 (기존 `gap-analyzer.md` 와 이름 충돌 회피)
+- 단위 검증: 단일 spec 파일에 대해 L1 호출, 출력 검증
+
+### Phase 3 — 오케스트레이터 추가
+
+- `/spec-kit:spec-review-v2` 커맨드 신설 (병행 운영)
+- 인용 검증 로직 (L1 인용이 실파일에 있는지, L2 인용이 L1 에 있는지)
+- 기존 `/spec-kit:spec-review` 와 동일 입력으로 비교 테스트
+
+### Phase 4 — 호출자 마이그레이션
+
+- 기존 `/spec-kit:spec-review` 를 새 흐름으로 교체
+- `gap-analyzer`, `reverse-gap-analyzer` 등을 호출하는 다른 커맨드/스킬 마이그레이션
+
+### Phase 5 — 구 에이전트 deprecate
+
+- 6개 기존 에이전트에 `**DEPRECATED**` 헤더 추가
+- 한 릴리스 후 삭제
+
+### Phase 6 — 정리
+
+- `gap-analyzer-v2.md` → `gap-analyzer.md` (이름 환원)
+- 마이그레이션 노트 정리
+
+## 위험 평가
+
+| 위험 | 영향 | 완화 |
+|------|------|------|
+| L1 토큰 비용 증가 | 중 | 병렬 호출 + Haiku 단가. 실측 후 결정 |
+| `related_paths` frontmatter 미설정 spec 다수 | 중 | 자율 보강 fallback. 점진 추가 |
+| 기존 호출자 마이그레이션 누락 | 고 | grep 기반 의존성 매트릭스 작성 후 체크 |
+| L2 가 L1 사실을 왜곡 | 중 | 인용 검증으로 차단 |
+| Haiku 가 인용 형식 어김 | 중 | few-shot example + 사후 검증 + 재시도 |
+
+다음 문서(`03-detailed-spec.md`)에서 출력 스키마 / 인용 형식 / 검증 알고리즘을 정확히 정의.

--- a/plans/spec-kit-redesign/02-architecture.md
+++ b/plans/spec-kit-redesign/02-architecture.md
@@ -207,36 +207,39 @@ grep -rn "spec-parser\|cross-reference-checker\|spec-quality-checker\|gap-analyz
 
 ## 마이그레이션 단계
 
-### Phase 1 (이 PR 이후)
+플러그인 배포가 자동 버전 범프를 처리하므로 내부 에이전트/커맨드의 점진 cohabitation 은 불필요하다. v2 suffix 와 deprecate-then-rename 단계를 생략하고 **3-Phase 아토믹 마이그레이션**으로 진행한다.
+
+### Phase 1 — 설계 (이 PR)
 
 설계 합의. 코드 변경 없음.
 
-### Phase 2 — 신규 에이전트 추가
+### Phase 2 — 신규 에이전트 추가 (additive)
 
 - `plugins/spec-kit/agents/file-pair-observer.md` (L1) 추가
-- `plugins/spec-kit/agents/gap-analyzer-v2.md` (L2) 추가 (기존 `gap-analyzer.md` 와 이름 충돌 회피)
-- 단위 검증: 단일 spec 파일에 대해 L1 호출, 출력 검증
+- `plugins/spec-kit/agents/gap-aggregator.md` (L2) 추가 (역할 기반 이름 — legacy `gap-analyzer.md` 와 자연스레 공존)
+- 단위 검증: 단일 spec 파일에 대해 L1 호출 → 출력 스키마 검증, 수기 작성 L1 리포트로 L2 호출 → 출력 검증
+- legacy 에이전트는 그대로 유지 (커맨드들이 여전히 호출)
 
-### Phase 3 — 오케스트레이터 추가
+### Phase 3 — 아토믹 마이그레이션
 
-- `/spec-kit:spec-review-v2` 커맨드 신설 (병행 운영)
-- 인용 검증 로직 (L1 인용이 실파일에 있는지, L2 인용이 L1 에 있는지)
-- 기존 `/spec-kit:spec-review` 와 동일 입력으로 비교 테스트
+한 PR 에서 다음을 동시에 수행. 부분 적용 시 깨지므로 분할 불가:
 
-### Phase 4 — 호출자 마이그레이션
+- `plugins/spec-kit/commands/spec-review.md` 새 흐름으로 재작성 (file-pair-observer × N → 인용 검증 → gap-aggregator)
+- `plugins/spec-kit/commands/gap-detect.md` 도 동일 흐름으로 재작성 (또는 spec-review 로 흡수)
+- 인용 검증 로직 추가 (L1 인용이 실파일 substring 매치, L2 인용이 검증 통과 L1 항목 ID 실재)
+- legacy 에이전트 6개 삭제:
+  - `spec-parser.md`
+  - `cross-reference-checker.md`
+  - `spec-quality-checker.md`
+  - `gap-analyzer.md` (gap-aggregator 가 대체)
+  - `reverse-gap-analyzer.md`
+  - `structure-mapper.md`
+- `plugins/github-autopilot/agents/gap-detector.md` 의 doc 참조 (`spec-parser → structure-mapper → gap-analyzer`) 갱신
+- e2e 회귀: 동일 spec-set 으로 v1 결과와 비교, `04-test-scenarios.md` 의 통과 기준 충족 확인
 
-- 기존 `/spec-kit:spec-review` 를 새 흐름으로 교체
-- `gap-analyzer`, `reverse-gap-analyzer` 등을 호출하는 다른 커맨드/스킬 마이그레이션
+### Phase 후속 — 사용자 노출 변경
 
-### Phase 5 — 구 에이전트 deprecate
-
-- 6개 기존 에이전트에 `**DEPRECATED**` 헤더 추가
-- 한 릴리스 후 삭제
-
-### Phase 6 — 정리
-
-- `gap-analyzer-v2.md` → `gap-analyzer.md` (이름 환원)
-- 마이그레이션 노트 정리
+CI 의 자동 버전 범프가 `feat:` prefix 로 minor 범프를 트리거. 릴리스 노트에 "spec-kit 가 2-layer 구조로 재작성됨, 사용자 노출 인터페이스(`/spec-kit:spec-review`, `/spec-kit:gap-detect`)는 동일하나 내부 동작/출력 형식이 변경됨" 명시.
 
 ## 위험 평가
 

--- a/plans/spec-kit-redesign/03-detailed-spec.md
+++ b/plans/spec-kit-redesign/03-detailed-spec.md
@@ -1,0 +1,266 @@
+# Detailed Spec — 출력 스키마, 인용 형식, 검증 규칙
+
+## 1. L1 출력 스키마
+
+### 1.1 전체 구조
+
+```markdown
+# Per-File Report: {spec_file_path}
+
+## Metadata
+- spec_file: {spec_file_path}
+- spec_lines: {total}
+- code_paths_examined: [{path1}, {path2}, ...]
+- frontmatter_related_paths: [{path1}, ...]    # spec frontmatter 에 명시된 것
+- autonomous_paths: [{path3}, ...]              # 자율 탐색으로 추가된 것
+- generated_at: {ISO 8601}
+
+## Spec Claims
+- [S{n}] `{file}:{line_start}-{line_end}` — "{발췌}"
+  ...
+
+## Code Observations
+- [C{n}] `{file}:{line_start}-{line_end}` — `{code 발췌 또는 시그니처}`
+  ...
+
+## Mismatches
+- [{S id}] vs [{C id}] — {일치 / 차이 한 줄}
+  ...
+
+## Gaps
+- [G{n}] {SPEC_ONLY | CODE_ONLY | PARTIAL} — {참조 ID 들} — {한 줄 설명}
+  ...
+
+## Notes
+- [N{n}] `{file}:{line_start}-{line_end}` — "{발췌}" — {모호 사유 한 줄}
+  ...
+```
+
+### 1.2 항목 ID 규칙
+
+- `S` = Spec Claim, `C` = Code Observation, `G` = Gap, `N` = Note, `M` = Mismatch
+- 각 카테고리별 1부터 순차. 한 리포트 내 ID 충돌 금지
+- L2 가 인용할 때 `{report_filename}:{ID}` 형식 사용 (예: `database.md:S3`)
+
+### 1.3 인용 형식 (file:line)
+
+```
+`{relative_path_from_repo_root}:{line_start}` — 단일 라인
+`{relative_path_from_repo_root}:{line_start}-{line_end}` — 라인 범위
+```
+
+#### 발췌 (excerpt)
+
+- spec 인용: 큰따옴표로 감싼 원문 그대로
+- code 인용: 백틱 코드 스팬으로 감싼 원문 그대로
+- 길이 제한: 발췌는 200자 이내. 초과 시 끝에 `...` (가공 금지, 단순 절단)
+
+#### 예시
+
+```markdown
+- [S1] `spec/database.md:120` — "content_type 컬럼은 VARCHAR(255)"
+- [C1] `migrations/001.sql:34` — `content_type VARCHAR(255) NOT NULL DEFAULT ''`
+- [S5] `spec/auth.md:200-215` — "Refresh token 회전: 매 사용 시 새 토큰 발급, 이전 토큰 무효화..."
+```
+
+### 1.4 Gap 항목 분류 enum
+
+| 값 | 의미 |
+|----|------|
+| `SPEC_ONLY` | spec 에 있지만 code 에 없음 |
+| `CODE_ONLY` | code 에 있지만 spec 에 없음 |
+| `PARTIAL` | 양쪽에 있으나 일부 누락 |
+
+L2 는 이 enum 으로 자동 분류 가능.
+
+### 1.5 빈 섹션 처리
+
+- 항목이 0개여도 섹션 헤더는 유지 (스키마 일관성)
+- 본문은 `(없음)` 표시
+
+```markdown
+## Mismatches
+(없음)
+```
+
+## 2. L2 출력 스키마
+
+### 2.1 전체 구조
+
+```markdown
+# Spec Review Report
+
+## Summary
+- spec_files_reviewed: {N}
+- l1_reports_received: {N} (drop: {M})
+- code_spec_gaps: {count by severity}
+- spec_spec_gaps: {count by severity}
+- generated_at: {ISO 8601}
+
+## Code ↔ Spec Gaps
+
+### [{HIGH|MEDIUM|LOW}] {제목}
+- 증거:
+  - {report_filename}:{S/C/G id} — "{원 인용 그대로}"
+  - {report_filename}:{S/C/G id} — "{원 인용 그대로}"
+- 분류: {SPEC_ONLY | CODE_ONLY | PARTIAL | DIVERGENT}
+- 권장: {1-2 문장}
+
+## Spec ↔ Spec Gaps
+
+### [{severity}] {제목}
+- 증거:
+  - {report_a}:{id} — "{인용}"
+  - {report_b}:{id} — "{인용}"
+- 분류: {DEFINITION_CONFLICT | INTERFACE_DRIFT | TERM_AMBIGUITY | ...}
+- 권장: {1-2 문장}
+
+## Notes (모호함)
+
+### [{severity}] {제목}
+- 증거: {report}:{N id} — "{인용}"
+- 권장: {1-2 문장}
+```
+
+### 2.2 Severity 기준
+
+| 등급 | 기준 |
+|------|------|
+| HIGH | 사용자 영향 직접 / 보안 / 데이터 무결성 / spec 전제와 code 가 정반대 |
+| MEDIUM | 기능 영향 있으나 우회 가능 / 부분 구현 / 모호함이 다중 해석 야기 |
+| LOW | 문서화 누락 / 미세 표기 차이 / 스타일 |
+
+### 2.3 분류 (Code↔Spec) enum
+
+| 값 | 의미 |
+|----|------|
+| `SPEC_ONLY` | spec 약속, code 없음 |
+| `CODE_ONLY` | code 동작, spec 미언급 |
+| `PARTIAL` | 부분 구현 |
+| `DIVERGENT` | 양쪽 다 있으나 동작이 다름 |
+
+### 2.4 분류 (Spec↔Spec) enum
+
+| 값 | 의미 |
+|----|------|
+| `DEFINITION_CONFLICT` | 같은 용어/개념을 다르게 정의 |
+| `INTERFACE_DRIFT` | 같은 인터페이스를 다르게 명세 |
+| `TERM_AMBIGUITY` | 한 spec 이 다른 spec 의 용어를 가정만 함 |
+| `REQUIREMENT_OVERLAP` | 요구사항이 중복/모순 |
+
+### 2.5 인용 형식 (L1 참조)
+
+```
+{report_filename}:{ID} — "{원 인용 그대로}"
+```
+
+L2 는 새 발췌를 만들지 않음. L1 항목의 발췌를 그대로 가져옴.
+
+## 3. 인용 검증 규칙 (오케스트레이터)
+
+### 3.1 L1 인용 검증
+
+각 L1 출력에 대해:
+
+1. **파일 존재**: `{file}` 가 실재하는가
+2. **라인 범위 유효**: `{line_start}` ≤ `{line_end}` ≤ 파일 총 라인 수
+3. **substring 매치**: 발췌(따옴표/백틱 안 텍스트)가 `{file}:{line_start}-{line_end}` 범위 텍스트에 substring 으로 존재하는가 (공백 정규화 후)
+
+검증 알고리즘 (의사 코드):
+
+```python
+def verify_l1_citation(citation):
+    file_path, line_range, excerpt = parse(citation)
+    if not exists(file_path):
+        return DROP, "file not found"
+    file_lines = read_lines(file_path)
+    line_start, line_end = line_range
+    if line_end > len(file_lines):
+        return DROP, "line out of range"
+    text = "\n".join(file_lines[line_start-1 : line_end])
+    if normalize_ws(excerpt.rstrip("...")) not in normalize_ws(text):
+        return DROP, "excerpt mismatch"
+    return PASS
+```
+
+검증 실패 항목은 L1 리포트에서 제거. 리포트 메타에 drop 카운트 기록.
+
+### 3.2 L1 자체 출력 검증
+
+- 모든 항목이 ID 부여되었는가 (S{n}, C{n}, G{n}, N{n})
+- ID 충돌 없는가
+- Mismatches 의 참조 ID 가 같은 리포트 내 실재하는가
+- Gaps 의 참조 ID 들이 같은 리포트 내 실재하는가
+
+위반 항목은 drop.
+
+### 3.3 L2 인용 검증
+
+각 L2 finding 의 증거에 대해:
+
+1. **리포트 존재**: `{report_filename}` 이 검증 통과한 L1 리포트 중 있는가
+2. **항목 존재**: `{ID}` 가 그 리포트에 실재하는가
+3. **발췌 일치**: L2 가 인용한 발췌가 L1 의 해당 항목 발췌와 일치하는가 (공백 정규화 후 동일)
+
+검증 실패 finding 은 drop. 사용자에게 경고.
+
+### 3.4 검증 실패 처리 정책
+
+- **L1 항목 단위 drop**: 환각 의심 항목만 제거. 해당 리포트의 다른 항목은 살림
+- **전체 리포트 drop**: 한 리포트의 drop 비율이 50% 초과 시 전체 drop + 재실행 (Haiku 재시도)
+- **재시도 한계**: 동일 spec 파일 3회 연속 실패 시 사용자 confirm 요청
+- **드롭 로그**: 모든 drop 을 사용자에게 노출 (silent fail 금지)
+
+## 4. spec 파일 frontmatter 컨벤션
+
+### 4.1 권장 프론트매터
+
+```yaml
+---
+title: {스펙 제목}
+related_paths:
+  - {레포 루트 기준 경로 1}
+  - {레포 루트 기준 경로 2}
+spec_kit:
+  level: {detailed | overview}    # 선택
+  category: {database | api | ...}   # 선택
+---
+```
+
+### 4.2 `related_paths` 의미
+
+- 디렉토리: 그 디렉토리의 모든 source 파일 (텍스트 파일, 빌드 산출물 제외)
+- 파일: 정확히 그 파일
+- 와일드카드 미허용 (Glob 은 자율 탐색이 담당)
+
+### 4.3 누락 처리
+
+frontmatter 가 없거나 `related_paths` 가 비면 L1 에이전트가 자율 탐색. 자율 탐색 결과는 출력 메타에 명시되어 사후 검증 가능.
+
+## 5. 출력 사이즈 제어
+
+### 5.1 L1 사이즈 가이드
+
+- 한 리포트 당 항목 100개 이내 권장. 초과 시 spec 을 분할하라는 경고
+- 발췌 200자 제한
+- 빈 섹션은 `(없음)` 한 줄
+
+### 5.2 L2 사이즈 가이드
+
+- finding 50개 이내. 초과 시 severity LOW 부터 잘라냄 (제거된 것은 메타에 기록)
+- 한 finding 의 증거는 최대 5개 인용. 초과 시 대표 5개만
+
+## 6. 결정 사항 정리
+
+| 항목 | 결정 |
+|------|------|
+| L1 모델 | haiku |
+| L2 모델 | sonnet |
+| L1 tools | Read, Glob, Grep |
+| L2 tools | (none) |
+| 인용 형식 | `file:line` + excerpt |
+| 입력 결정 | frontmatter `related_paths` + 자율 보강 |
+| 검증 위치 | 오케스트레이터 (커맨드 레벨) |
+| Drop 정책 | 항목 단위 drop, 50% 초과 시 전체 재실행 |
+
+다음 문서(`04-test-scenarios.md`)에서 회귀 / 정확도 / 성능 테스트 계획.

--- a/plans/spec-kit-redesign/04-test-scenarios.md
+++ b/plans/spec-kit-redesign/04-test-scenarios.md
@@ -154,23 +154,20 @@ grep -rn "spec-parser\|cross-reference-checker\|spec-quality-checker\|gap-analyz
 각 호출 지점별로:
 - 마이그레이션 필요 여부
 - 신구조에서의 대체 호출
-- Phase 4 에서 변경
+- Phase 3 에서 변경
 
 ### 5.2 Phase 별 회귀 테스트
 
 | Phase | 테스트 |
 |-------|--------|
-| Phase 2 (L1/L2 신설) | 단일 spec 입력으로 L1, L2 단독 실행 정상 동작 |
-| Phase 3 (오케스트레이터 신설) | `/spec-kit:spec-review-v2` 결과가 v1 과 동일 spec-set 에서 동등 발견 |
-| Phase 4 (호출자 마이그레이션) | 마이그레이션된 호출자 각각의 기존 e2e 테스트 통과 |
-| Phase 5 (구 에이전트 deprecate) | DEPRECATED 헤더만 — 동작 변경 없음 |
-| Phase 6 (정리) | v2 → v1 이름 환원 후 모든 호출자 정상 |
+| Phase 2 (L1/L2 신설) | 단일 spec 입력으로 L1, L2 단독 실행 정상 동작 (legacy 에이전트는 그대로) |
+| Phase 3 (아토믹 마이그레이션) | 재작성된 `/spec-kit:spec-review` / `/spec-kit:gap-detect` 가 동일 spec-set 에서 v1 과 동등 발견. legacy 6개 에이전트 0회 호출 (grep 확인). github-autopilot 의 doc 참조 갱신 확인 |
 
 ### 5.3 통과 기준
 
 - Phase 3 비교 테스트: 동일 spec-set 에서 finding 의 90% 이상 일치 (10% 신규 발견은 허용)
-- Phase 4 e2e: 모든 호출자 회귀 없음
-- Phase 6 후: 기존 6개 에이전트 0회 호출 (grep 으로 확인)
+- Phase 3 e2e: 모든 호출자 (spec-review, gap-detect, github-autopilot/gap-detector 의 doc 참조) 회귀 없음
+- Phase 3 후: 기존 6개 에이전트 (`spec-parser`, `cross-reference-checker`, `spec-quality-checker`, `gap-analyzer` (legacy), `reverse-gap-analyzer`, `structure-mapper`) 0회 호출 + 파일 삭제 (grep 확인)
 
 ## 6. 사용자 시나리오 dogfooding
 
@@ -187,7 +184,7 @@ grep -rn "spec-parser\|cross-reference-checker\|spec-quality-checker\|gap-analyz
 
 ## 7. 통과 기준 종합
 
-신구조 채택 결정 (Phase 4 진입) 의 게이트:
+Phase 3 (아토믹 마이그레이션) 진입 게이트:
 
 - [ ] 환각 회귀 (1.x): 100% drop, finding 미발생
 - [ ] 정확도 (2.x): D1-D5/A/B/C 95% 이상 회귀, 신규 케이스 5+

--- a/plans/spec-kit-redesign/04-test-scenarios.md
+++ b/plans/spec-kit-redesign/04-test-scenarios.md
@@ -1,0 +1,207 @@
+# Test Scenarios — 회귀, 정확도, 성능, 마이그레이션
+
+## 1. 환각 회귀 시나리오 (#639 재현)
+
+### 1.1 입력 fixture
+
+`fixtures/issue-639/` 에 다음 배치:
+
+- `spec/concerns/database.md` — 실제 spec (300+ 라인, `mcp_tools.content_type` 컬럼 정의 포함, VARCHAR(255))
+- `spec/concerns/proxy.md` — 실제 spec
+- `migrations/001.sql` — 실제 schema
+- `internal/dao/tool.go` — Go struct 정의
+- `internal/handler/embed.go` — embedded resource URI 생성
+
+### 1.2 기대 동작
+
+**L1 (database.md 담당)** 출력 검증:
+- `## Spec Claims` 에 `mcp_tools.content_type` 정의가 정확한 라인 인용으로 포함
+- 발췌가 spec 원문과 substring 매치
+- 환각 없으면 `## Mismatches` 는 일치 표시
+
+**L1 (proxy.md 담당)** 출력 검증:
+- proxy.md 가 다른 스펙을 가정하지 않음을 확인 (실제 spec 에 없는 ENUM 주장 금지)
+- `database.md` 의 내용을 인용하지 않음 (자기 파일 외 발언권 없음)
+
+**L2** 출력 검증:
+- "content_type ENUM 충돌" 같은 가짜 finding 이 발생하지 않음
+- 모든 finding 의 증거 인용이 L1 리포트에 실재
+
+### 1.3 환각 주입 테스트
+
+L1 에이전트의 응답을 강제로 환각시킨 mock 출력으로 오케스트레이터 검증:
+
+```markdown
+## Spec Claims
+- [S1] `spec/concerns/database.md:99999` — "content_type ENUM('json','multipart','form')"
+```
+
+기대: 오케스트레이터의 인용 검증이 다음을 수행
+- 라인 99999 가 파일 범위를 벗어남 → DROP
+- 사용자에게 drop 경고 노출
+- L2 입력에서 제거되어 환각 finding 미발생
+
+### 1.4 통과 기준
+
+- 정상 입력: L2 finding 0개 (환각 없음 확인)
+- 환각 주입 입력: 100% drop, L2 결과에 영향 없음
+
+## 2. Use case 정확도 회귀
+
+### 2.1 D1-D5 회귀
+
+기존 `cross-reference-checker` 테스트 케이스를 그대로 새 구조에 통과:
+
+| 케이스 | 입력 | 기대 발견 |
+|--------|------|-----------|
+| D1-1 | 두 spec 이 같은 용어를 다르게 정의 | L2 의 spec↔spec gap (DEFINITION_CONFLICT) |
+| D2-1 | 요구사항이 미구현 | L2 의 code↔spec gap (SPEC_ONLY) |
+| D5-1 | 인터페이스 시그니처 mismatch | L2 의 spec↔spec gap (INTERFACE_DRIFT) |
+
+### 2.2 A/B/C 회귀
+
+기존 `spec-quality-checker` 테스트 케이스:
+
+| 케이스 | 입력 | 기대 발견 |
+|--------|------|-----------|
+| A-1 | 모호한 시점 표현 ("적절한 시점") | L1 의 Notes 항목 → L2 의 TERM_AMBIGUITY |
+| B-1 | 요구사항 누락 | L1 Gaps SPEC_ONLY → L2 code↔spec gap |
+| C-1 | 검증 불가 표현 | L1 Notes |
+
+### 2.3 Code 활용 효과 (신규 능력)
+
+기존 spec-only 검증이 못 잡던 모호함을 code 대조로 잡는지 검증:
+
+- 입력: spec 이 "권한" 만 언급, code 는 permission/role 둘 다 사용
+- 기대: L2 가 "권한 정의 부재" 발견 (TERM_AMBIGUITY)
+- 기존 구조에서는 spec-only 를 보므로 미발견 → 신규 능력 확인
+
+### 2.4 통과 기준
+
+- D1-D5 / A/B/C 케이스 발견율 ≥ 기존 대비 95% (회귀 없음)
+- 신규 능력 케이스 ≥ 5개 발견 (실 spec-set 기준)
+
+## 3. 성능 / 비용
+
+### 3.1 측정 항목
+
+| 지표 | 정의 |
+|------|------|
+| Wall-clock | 커맨드 시작 → 최종 리포트 출력까지 시간 |
+| Token 사용량 | 모든 L1 + L2 호출의 input + output token 합 |
+| API 호출 수 | spawn 된 에이전트 수 |
+| 비용 | 모델별 단가 적용 (Haiku × N + Sonnet × 1) |
+
+### 3.2 기준선 (기존 구조)
+
+- spec-parser 1회 + checker 들 (cross-reference, quality, gap, reverse-gap, structure-mapper) 5회 = **6 호출**
+- 모두 Sonnet/Opus
+- 직렬 (의존성 있음)
+
+### 3.3 신구조
+
+- L1 N회 (spec 파일 수, 병렬 가능) + L2 1회 = **N+1 호출**
+- L1 = Haiku, L2 = Sonnet
+- L1 병렬
+
+### 3.4 가설 / 검증
+
+- 가설: 토큰량은 증가, **비용은 감소** (Haiku 단가 ≪ Sonnet)
+- 가설: wall-clock 은 **감소** (병렬 + L1 짧은 추론)
+- N=5 spec set 기준 측정 후 비교
+- N=20 spec set 으로 확장성 측정
+
+### 3.5 통과 기준
+
+- 비용: 기존의 70% 이하
+- Wall-clock: 기존의 80% 이하
+- 만족하지 못하면 L1 batch (한 Haiku 가 여러 파일 처리) 옵션 검토
+
+## 4. 검증 알고리즘 단위 테스트
+
+### 4.1 인용 검증 unit tests
+
+오케스트레이터의 검증 로직을 단위 테스트:
+
+| 케이스 | 입력 | 기대 |
+|--------|------|------|
+| V1 | 정상 인용 (file 존재, 라인 유효, 발췌 매치) | PASS |
+| V2 | file 미존재 | DROP "file not found" |
+| V3 | 라인 범위 초과 | DROP "line out of range" |
+| V4 | 발췌가 substring 미매치 | DROP "excerpt mismatch" |
+| V5 | 공백/줄바꿈 차이만 있는 발췌 | PASS (정규화 후 매치) |
+| V6 | `...` 절단된 발췌의 prefix 매치 | PASS |
+| V7 | L1 항목 ID 충돌 | DROP "duplicate id" |
+| V8 | Mismatch/Gap 의 참조 ID 가 같은 리포트에 없음 | DROP "dangling reference" |
+| V9 | L2 의 인용된 L1 리포트가 검증 통과 리스트에 없음 | DROP "phantom report" |
+| V10 | L2 인용 항목 ID 가 L1 에 없음 | DROP "phantom item" |
+
+### 4.2 통과 기준
+
+- 모든 unit test 통과
+- 정규화 함수 (공백, 줄바꿈) 가 false positive/negative 없음
+
+## 5. 마이그레이션 호환성
+
+### 5.1 호출자 인벤토리
+
+다음 명령으로 의존성 매트릭스 작성:
+
+```bash
+grep -rn "spec-parser\|cross-reference-checker\|spec-quality-checker\|gap-analyzer\|reverse-gap-analyzer\|structure-mapper" plugins/
+```
+
+각 호출 지점별로:
+- 마이그레이션 필요 여부
+- 신구조에서의 대체 호출
+- Phase 4 에서 변경
+
+### 5.2 Phase 별 회귀 테스트
+
+| Phase | 테스트 |
+|-------|--------|
+| Phase 2 (L1/L2 신설) | 단일 spec 입력으로 L1, L2 단독 실행 정상 동작 |
+| Phase 3 (오케스트레이터 신설) | `/spec-kit:spec-review-v2` 결과가 v1 과 동일 spec-set 에서 동등 발견 |
+| Phase 4 (호출자 마이그레이션) | 마이그레이션된 호출자 각각의 기존 e2e 테스트 통과 |
+| Phase 5 (구 에이전트 deprecate) | DEPRECATED 헤더만 — 동작 변경 없음 |
+| Phase 6 (정리) | v2 → v1 이름 환원 후 모든 호출자 정상 |
+
+### 5.3 통과 기준
+
+- Phase 3 비교 테스트: 동일 spec-set 에서 finding 의 90% 이상 일치 (10% 신규 발견은 허용)
+- Phase 4 e2e: 모든 호출자 회귀 없음
+- Phase 6 후: 기존 6개 에이전트 0회 호출 (grep 으로 확인)
+
+## 6. 사용자 시나리오 dogfooding
+
+### 6.1 본 레포의 spec 으로 테스트
+
+`plans/github-autopilot/`, `plans/spec-kit-redesign/` 자체를 입력으로 새 구조 실행:
+
+- 신규 능력 케이스 발견 (이 프로젝트의 spec 모호함)
+- 출력의 가독성 / 클릭 가능 인용 / 우선순위 정렬 점검
+
+### 6.2 외부 spec set (선택)
+
+가능하면 협업 프로젝트의 실 spec 으로 검증. 사용자 직접 점검.
+
+## 7. 통과 기준 종합
+
+신구조 채택 결정 (Phase 4 진입) 의 게이트:
+
+- [ ] 환각 회귀 (1.x): 100% drop, finding 미발생
+- [ ] 정확도 (2.x): D1-D5/A/B/C 95% 이상 회귀, 신규 케이스 5+
+- [ ] 비용 (3.5): 기존 70% 이하
+- [ ] Wall-clock (3.5): 기존 80% 이하
+- [ ] 검증 unit test (4.x): 전체 통과
+- [ ] Phase 3 비교 (5.3): 90% 일치
+- [ ] dogfooding (6.x): 사용자 만족
+
+게이트 미달 시 설계 보완 후 재측정.
+
+## 8. 미해결 / 후속 검토
+
+- L1 batch 모드 (Haiku 한 호출에 여러 파일) 의 정확도 영향
+- `related_paths` 자율 탐색의 false positive 비율 (관련 없는 code 를 끌어오는 경우)
+- 매우 큰 spec 파일 (1000+ 라인) 의 L1 처리 전략 (라인 범위 분할 vs 전체 처리)
+- 인용 검증의 i18n / non-ASCII 처리 (한국어 spec 의 substring 매치)


### PR DESCRIPTION
## Summary

#639 (cross-reference-checker 환각) 을 prompt 레벨이 아닌 **아키텍처 레벨**에서 다루는 설계 PR. 코드 변경 없이 `plans/spec-kit-redesign/` 5분할 설계 문서만 추가합니다.

## 핵심 변화

기존 spec-kit 의 6개 에이전트(`spec-parser`, `cross-reference-checker`, `spec-quality-checker`, `gap-analyzer`, `reverse-gap-analyzer`, `structure-mapper`) 를 2-layer 구조로 통합:

```
[L1] file-pair-observer  (Haiku × N, 병렬)
  - spec 파일 1개 + 관련 code 영역 직접 Read
  - 사실 나열만 (Spec Claims / Code Observations / Mismatches / Gaps)
  - 모든 항목 file:line + excerpt 인용 필수, 종합/추론 금지

[L2] gap-analyzer  (Sonnet, 1개)
  - L1 리포트만 입력 (raw 파일 안 봄)
  - code ↔ spec gaps + spec ↔ spec gaps 식별
  - 새 사실 만들지 않고 L1 항목 인용만으로 결론
```

오케스트레이터가 인용을 검증해 환각 항목을 사전 드롭. #639 의 가짜 \`content_type ENUM(...)\` 같은 finding 은 구조적으로 도달 불가능.

## 왜 이 방향인가

- 기존 `spec-parser` 의 "N 파일 → 1 JSON 종합 요약" 단계가 환각 진입점
- prompt-level 부정형 지시 ("환각 금지") 는 LLM 이 어기기 쉬움
- per-file 격리 + 인용 by construction 으로 발언권 범위 자체를 좁힘
- code 를 외부 ground truth 로 활용 → spec-only 검증이 못 잡던 모호함도 발견 (신규 능력)

## 문서 구조

- \`00-concept.md\` (110줄) — 환각 면적 축소 논리, 2-layer 동기, 모델 선택, 기존 6개 흡수 매핑
- \`01-use-cases.md\` (247줄) — D1-D5 / A/B/C / gap / reverse-gap / #639 회귀 시나리오가 새 구조에서 어떻게 풀리는지
- \`02-architecture.md\` (251줄) — L1/L2 frontmatter, 입출력 인터페이스, 호출 흐름, 마이그레이션 6 phase, 위험 평가
- \`03-detailed-spec.md\` (266줄) — 출력 스키마, 인용 형식, 검증 알고리즘, frontmatter 컨벤션, severity/분류 enum
- \`04-test-scenarios.md\` (207줄) — #639 환각 회귀, D1-D5/A/B/C 정확도, 비용/지연 목표, 검증 unit test, 마이그레이션 호환성, dogfooding

## #650 처리

이 설계가 합의되면 #650 은 **임시방편으로 머지**. 새 구조 구현/마이그레이션은 다중 단계라 시간이 걸리고, 그 사이의 환각 가드로는 약하더라도 #650 이 있는 게 낫습니다. 새 구조 안정화 후 두 checker 에이전트 자체가 사라지면 자연스레 함께 제거됩니다.

## Phase 진입 게이트

\`04-test-scenarios.md\` 의 통과 기준 (환각 100% drop, 정확도 95% 회귀, 비용 70%, wall-clock 80%, 검증 unit test 전체 통과, Phase 3 비교 90% 일치, dogfooding 성공) 을 모두 만족해야 Phase 4 (호출자 마이그레이션) 진입.

## Test plan

이 PR 자체는 설계만 다루므로 다음을 검증:

- [ ] 5개 문서가 일관된 용어 사용 (L1/L2, 인용 형식, 분류 enm)
- [ ] \`02-architecture.md\` 의 L1/L2 인터페이스가 \`03-detailed-spec.md\` 의 스키마와 정합
- [ ] \`01-use-cases.md\` 의 시나리오가 \`03-detailed-spec.md\` 의 스키마로 표현 가능
- [ ] \`04-test-scenarios.md\` 의 통과 기준이 \`00-concept.md\` 의 핵심 약속(환각 차단, 비용 효율) 과 일치

설계 합의 후 Phase 2 부터는 실제 코드 PR 로 진행합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)