### PR TITLE
feat(github-autopilot): add suppress + events CLI and config wiring

### DIFF
--- a/plugins/github-autopilot/cli/Cargo.lock
+++ b/plugins/github-autopilot/cli/Cargo.lock
@@ -99,6 +99,7 @@ dependencies = [
  "sha2",
  "tempfile",
  "thiserror",
+ "toml",
  "unicode-normalization",
 ]
 
@@ -630,6 +631,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -722,6 +732,47 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "typenum"
@@ -931,6 +982,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/plugins/github-autopilot/cli/Cargo.toml
+++ b/plugins/github-autopilot/cli/Cargo.toml
@@ -21,6 +21,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
 thiserror = "1"
+toml = "0.8"
 unicode-normalization = "0.1"
 
 [dev-dependencies]

--- a/plugins/github-autopilot/cli/src/cmd/epic.rs
+++ b/plugins/github-autopilot/cli/src/cmd/epic.rs
@@ -12,6 +12,7 @@ use anyhow::{Context, Result};
 use clap::{Args, Subcommand, ValueEnum};
 use serde::{Deserialize, Serialize};
 
+use crate::cmd::output::write_json;
 use crate::domain::{DomainError, Epic, EpicStatus, TaskId, TaskSource, TaskStatus};
 use crate::ports::clock::Clock;
 use crate::ports::task_store::{
@@ -376,12 +377,6 @@ fn render_epic(e: &Epic, json: bool, out: &mut dyn Write) -> Result<()> {
     if let Some(ts) = e.completed_at {
         writeln!(out, "completed_at: {}", ts.to_rfc3339())?;
     }
-    Ok(())
-}
-
-fn write_json<T: Serialize>(out: &mut dyn Write, value: &T) -> Result<()> {
-    serde_json::to_writer(&mut *out, value)?;
-    writeln!(out)?;
     Ok(())
 }
 

--- a/plugins/github-autopilot/cli/src/cmd/events.rs
+++ b/plugins/github-autopilot/cli/src/cmd/events.rs
@@ -1,0 +1,170 @@
+//! Event log query CLI (spec §6.4).
+//!
+//! Thin adapter over [`EventLog::list_events`]. The CLI does not synthesize
+//! events — it only renders what the store recorded — so filters here mirror
+//! [`EventFilter`] one-to-one.
+
+use std::io::Write;
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use clap::{Args, Subcommand};
+use serde::Serialize;
+
+use crate::domain::{Event, EventKind, TaskId};
+use crate::ports::task_store::{EventFilter, EventLog};
+
+const PAYLOAD_PREVIEW_LIMIT: usize = 40;
+
+#[derive(Subcommand)]
+pub enum EventsCommands {
+    /// List events in chronological order (oldest first), with filters
+    List(ListArgs),
+}
+
+#[derive(Args)]
+pub struct ListArgs {
+    /// Filter by epic name
+    #[arg(long)]
+    pub epic: Option<String>,
+    /// Filter by task id
+    #[arg(long)]
+    pub task: Option<String>,
+    /// Filter by event kind. Repeatable; unknown kinds cause exit 1.
+    #[arg(long = "kind")]
+    pub kinds: Vec<String>,
+    /// Earliest timestamp (RFC3339); inclusive
+    #[arg(long)]
+    pub since: Option<String>,
+    /// Maximum number of events to return
+    #[arg(long)]
+    pub limit: Option<u32>,
+    /// Output JSON instead of a human-readable table
+    #[arg(long)]
+    pub json: bool,
+}
+
+pub struct EventsService<'a> {
+    store: &'a dyn EventLog,
+}
+
+impl<'a> EventsService<'a> {
+    pub fn new(store: &'a dyn EventLog) -> Self {
+        Self { store }
+    }
+
+    pub fn list(&self, args: &ListArgs, out: &mut dyn Write) -> Result<i32> {
+        let kinds = match parse_kinds(&args.kinds) {
+            Ok(k) => k,
+            Err(unknown) => {
+                writeln!(out, "unknown event kind '{unknown}'")?;
+                return Ok(1);
+            }
+        };
+        let since = match args.since.as_deref().map(parse_since).transpose() {
+            Ok(s) => s,
+            Err(e) => {
+                writeln!(out, "{e}")?;
+                return Ok(1);
+            }
+        };
+
+        let filter = EventFilter {
+            epic: args.epic.clone(),
+            task: args.task.as_deref().map(TaskId::from_raw),
+            kinds,
+            since,
+            limit: args.limit,
+        };
+        let events = self.store.list_events(filter).context("listing events")?;
+
+        if args.json {
+            return write_json(
+                out,
+                &events.iter().map(EventRecord::from).collect::<Vec<_>>(),
+            )
+            .map(|()| 0);
+        }
+        render_table(&events, out)?;
+        Ok(0)
+    }
+}
+
+fn parse_kinds(raw: &[String]) -> Result<Vec<EventKind>, String> {
+    raw.iter()
+        .map(|s| EventKind::parse(s).ok_or_else(|| s.clone()))
+        .collect()
+}
+
+fn parse_since(raw: &str) -> Result<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(raw)
+        .map(|dt| dt.with_timezone(&Utc))
+        .with_context(|| format!("parsing --since '{raw}' as RFC3339"))
+}
+
+fn render_table(events: &[Event], out: &mut dyn Write) -> Result<()> {
+    if events.is_empty() {
+        writeln!(out, "(no events)")?;
+        return Ok(());
+    }
+    writeln!(
+        out,
+        "AT                            KIND                  EPIC                TASK          PAYLOAD-SUMMARY"
+    )?;
+    for e in events {
+        writeln!(
+            out,
+            "{:<28}  {:<20}  {:<18}  {:<12}  {}",
+            e.at.to_rfc3339(),
+            e.kind.as_str(),
+            e.epic_name.as_deref().unwrap_or("-"),
+            e.task_id.as_ref().map(TaskId::as_str).unwrap_or("-"),
+            payload_preview(&e.payload),
+        )?;
+    }
+    Ok(())
+}
+
+fn payload_preview(value: &serde_json::Value) -> String {
+    let s = if value.is_null() {
+        "-".to_string()
+    } else {
+        value.to_string()
+    };
+    if s.chars().count() <= PAYLOAD_PREVIEW_LIMIT {
+        return s;
+    }
+    let truncated: String = s.chars().take(PAYLOAD_PREVIEW_LIMIT).collect();
+    format!("{truncated}…")
+}
+
+#[derive(Debug, Serialize)]
+struct EventRecord<'a> {
+    at: String,
+    kind: &'static str,
+    epic: Option<&'a str>,
+    task: Option<&'a str>,
+    payload: &'a serde_json::Value,
+}
+
+impl<'a> From<&'a Event> for EventRecord<'a> {
+    fn from(e: &'a Event) -> Self {
+        Self {
+            at: e.at.to_rfc3339(),
+            kind: e.kind.as_str(),
+            epic: e.epic_name.as_deref(),
+            task: e.task_id.as_ref().map(TaskId::as_str),
+            payload: &e.payload,
+        }
+    }
+}
+
+fn write_json<T: Serialize>(out: &mut dyn Write, value: &T) -> Result<()> {
+    serde_json::to_writer(&mut *out, value)?;
+    writeln!(out)?;
+    Ok(())
+}
+
+pub fn events_service(store: &dyn EventLog) -> EventsService<'_> {
+    EventsService::new(store)
+}

--- a/plugins/github-autopilot/cli/src/cmd/events.rs
+++ b/plugins/github-autopilot/cli/src/cmd/events.rs
@@ -11,6 +11,7 @@ use chrono::{DateTime, Utc};
 use clap::{Args, Subcommand};
 use serde::Serialize;
 
+use crate::cmd::output::write_json;
 use crate::domain::{Event, EventKind, TaskId};
 use crate::ports::task_store::{EventFilter, EventLog};
 
@@ -157,12 +158,6 @@ impl<'a> From<&'a Event> for EventRecord<'a> {
             payload: &e.payload,
         }
     }
-}
-
-fn write_json<T: Serialize>(out: &mut dyn Write, value: &T) -> Result<()> {
-    serde_json::to_writer(&mut *out, value)?;
-    writeln!(out)?;
-    Ok(())
 }
 
 pub fn events_service(store: &dyn EventLog) -> EventsService<'_> {

--- a/plugins/github-autopilot/cli/src/cmd/mod.rs
+++ b/plugins/github-autopilot/cli/src/cmd/mod.rs
@@ -4,6 +4,7 @@ pub mod events;
 pub mod issue;
 pub mod issue_list;
 pub mod labels;
+pub mod output;
 pub mod pipeline;
 pub mod preflight;
 pub mod simhash;

--- a/plugins/github-autopilot/cli/src/cmd/mod.rs
+++ b/plugins/github-autopilot/cli/src/cmd/mod.rs
@@ -1,5 +1,6 @@
 pub mod check;
 pub mod epic;
+pub mod events;
 pub mod issue;
 pub mod issue_list;
 pub mod labels;
@@ -7,6 +8,7 @@ pub mod pipeline;
 pub mod preflight;
 pub mod simhash;
 pub mod stats;
+pub mod suppress;
 pub mod task;
 pub mod watch;
 pub mod worktree;
@@ -20,6 +22,10 @@ use clap::{Args, Parser, Subcommand, ValueEnum};
     about = "github-autopilot deterministic CLI"
 )]
 pub struct Cli {
+    /// Path to autopilot.toml; defaults to `./autopilot.toml` if it exists
+    #[arg(long, global = true)]
+    pub config: Option<std::path::PathBuf>,
+
     #[command(subcommand)]
     pub command: Commands,
 }
@@ -64,6 +70,16 @@ pub enum Commands {
     Epic {
         #[command(subcommand)]
         command: epic::EpicCommands,
+    },
+    /// Fingerprint suppression for HITL alerts
+    Suppress {
+        #[command(subcommand)]
+        command: suppress::SuppressCommands,
+    },
+    /// Event log queries
+    Events {
+        #[command(subcommand)]
+        command: events::EventsCommands,
     },
 }
 

--- a/plugins/github-autopilot/cli/src/cmd/output.rs
+++ b/plugins/github-autopilot/cli/src/cmd/output.rs
@@ -1,0 +1,14 @@
+//! Shared output helpers for CLI subcommands.
+
+use std::io::Write;
+
+use anyhow::Result;
+use serde::Serialize;
+
+/// Serialize `value` as a single line of compact JSON followed by a newline.
+/// Used by every subcommand that supports `--json`.
+pub fn write_json<T: Serialize>(out: &mut dyn Write, value: &T) -> Result<()> {
+    serde_json::to_writer(&mut *out, value)?;
+    writeln!(out)?;
+    Ok(())
+}

--- a/plugins/github-autopilot/cli/src/cmd/suppress.rs
+++ b/plugins/github-autopilot/cli/src/cmd/suppress.rs
@@ -1,0 +1,118 @@
+//! Fingerprint suppression CLI (spec §6.3).
+//!
+//! Thin adapter over [`SuppressionRepo`]. The CLI never decides what
+//! `reason` strings mean — agents own that vocabulary (`unmatched_watch`,
+//! `rejected_by_human`, ...). This layer only persists `(fingerprint,
+//! reason) -> until` and reports whether `now` is still inside the window.
+
+use std::io::Write;
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use clap::{Args, Subcommand};
+
+use crate::ports::clock::Clock;
+use crate::ports::task_store::SuppressionRepo;
+
+#[derive(Subcommand)]
+pub enum SuppressCommands {
+    /// Suppress alerts for `(fingerprint, reason)` until the given timestamp
+    Add(AddArgs),
+    /// Exit 0 if currently suppressed, exit 1 otherwise (script-friendly)
+    Check(CheckArgs),
+    /// Remove a suppression entry
+    Clear(ClearArgs),
+}
+
+#[derive(Args)]
+pub struct AddArgs {
+    #[arg(long)]
+    pub fingerprint: String,
+    #[arg(long)]
+    pub reason: String,
+    /// RFC3339 / ISO8601 timestamp (e.g. `2026-05-04T12:00:00Z`)
+    #[arg(long)]
+    pub until: String,
+}
+
+#[derive(Args)]
+pub struct CheckArgs {
+    #[arg(long)]
+    pub fingerprint: String,
+    #[arg(long)]
+    pub reason: String,
+}
+
+#[derive(Args)]
+pub struct ClearArgs {
+    #[arg(long)]
+    pub fingerprint: String,
+    #[arg(long)]
+    pub reason: String,
+}
+
+pub struct SuppressService<'a> {
+    store: &'a dyn SuppressionRepo,
+    clock: &'a dyn Clock,
+}
+
+impl<'a> SuppressService<'a> {
+    pub fn new(store: &'a dyn SuppressionRepo, clock: &'a dyn Clock) -> Self {
+        Self { store, clock }
+    }
+
+    pub fn add(
+        &self,
+        fingerprint: &str,
+        reason: &str,
+        until: &str,
+        out: &mut dyn Write,
+    ) -> Result<i32> {
+        let parsed: DateTime<Utc> = parse_until(until)?;
+        self.store
+            .suppress(fingerprint, reason, parsed)
+            .with_context(|| format!("suppressing fingerprint '{fingerprint}'"))?;
+        writeln!(
+            out,
+            "suppressed fingerprint='{fingerprint}' reason='{reason}' until={}",
+            parsed.to_rfc3339()
+        )?;
+        Ok(0)
+    }
+
+    pub fn check(&self, fingerprint: &str, reason: &str, out: &mut dyn Write) -> Result<i32> {
+        let now = self.clock.now();
+        let active = self
+            .store
+            .is_suppressed(fingerprint, reason, now)
+            .with_context(|| format!("checking suppression for '{fingerprint}'"))?;
+        if active {
+            writeln!(out, "suppressed")?;
+            Ok(0)
+        } else {
+            writeln!(out, "not suppressed")?;
+            Ok(1)
+        }
+    }
+
+    pub fn clear(&self, fingerprint: &str, reason: &str, out: &mut dyn Write) -> Result<i32> {
+        self.store
+            .clear(fingerprint, reason)
+            .with_context(|| format!("clearing suppression for '{fingerprint}'"))?;
+        writeln!(out, "cleared fingerprint='{fingerprint}' reason='{reason}'")?;
+        Ok(0)
+    }
+}
+
+fn parse_until(raw: &str) -> Result<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(raw)
+        .map(|dt| dt.with_timezone(&Utc))
+        .with_context(|| format!("parsing --until '{raw}' as RFC3339"))
+}
+
+pub fn suppress_service<'a>(
+    store: &'a dyn SuppressionRepo,
+    clock: &'a dyn Clock,
+) -> SuppressService<'a> {
+    SuppressService::new(store, clock)
+}

--- a/plugins/github-autopilot/cli/src/cmd/task.rs
+++ b/plugins/github-autopilot/cli/src/cmd/task.rs
@@ -17,10 +17,10 @@ use crate::domain::{DomainError, Task, TaskFailureOutcome, TaskId, TaskSource, T
 use crate::ports::clock::{Clock, StdClock};
 use crate::ports::task_store::{NewWatchTask, TaskStore, TaskStoreError, UpsertOutcome};
 
-/// Task fail threshold above which `mark_task_failed` escalates instead of
-/// retrying. PR-C will wire this from a config file; for v1 it's fixed.
-// TODO(PR-C): wire from config (`max_attempts` in github-autopilot.local.md).
-const DEFAULT_MAX_ATTEMPTS: u32 = 3;
+/// Default `max_attempts` used when no config / explicit override is present.
+/// `main.rs` now resolves this from `autopilot.toml` (`epic.default_max_attempts`)
+/// and threads it into [`TaskService::with_max_attempts`].
+pub const DEFAULT_MAX_ATTEMPTS: u32 = 3;
 
 #[derive(Clone, Copy, Debug, ValueEnum, PartialEq, Eq)]
 pub enum TaskStatusArg {
@@ -67,11 +67,24 @@ impl From<TaskSourceArg> for TaskSource {
 pub struct TaskService<'a> {
     store: &'a dyn TaskStore,
     clock: &'a dyn Clock,
+    max_attempts: u32,
 }
 
 impl<'a> TaskService<'a> {
     pub fn new(store: &'a dyn TaskStore, clock: &'a dyn Clock) -> Self {
-        Self { store, clock }
+        Self::with_max_attempts(store, clock, DEFAULT_MAX_ATTEMPTS)
+    }
+
+    pub fn with_max_attempts(
+        store: &'a dyn TaskStore,
+        clock: &'a dyn Clock,
+        max_attempts: u32,
+    ) -> Self {
+        Self {
+            store,
+            clock,
+            max_attempts,
+        }
     }
 
     pub fn list(
@@ -331,7 +344,7 @@ impl<'a> TaskService<'a> {
         let now = self.clock.now();
         let outcome = self
             .store
-            .mark_task_failed(&id, DEFAULT_MAX_ATTEMPTS, now)
+            .mark_task_failed(&id, self.max_attempts, now)
             .with_context(|| format!("failing task '{task_id}'"))?;
         write_json(out, &FailReport::from(outcome))?;
         Ok(0)

--- a/plugins/github-autopilot/cli/src/cmd/task.rs
+++ b/plugins/github-autopilot/cli/src/cmd/task.rs
@@ -12,6 +12,7 @@ use anyhow::{Context, Result};
 use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 
+use crate::cmd::output::write_json;
 use crate::cmd::simhash;
 use crate::domain::{DomainError, Task, TaskFailureOutcome, TaskId, TaskSource, TaskStatus};
 use crate::ports::clock::{Clock, StdClock};
@@ -415,12 +416,6 @@ fn render_task(t: &Task, json: bool, out: &mut dyn Write) -> Result<()> {
         return write_json(out, t);
     }
     print_task_human(t, out)
-}
-
-fn write_json<T: Serialize>(out: &mut dyn Write, value: &T) -> Result<()> {
-    serde_json::to_writer(&mut *out, value)?;
-    writeln!(out)?;
-    Ok(())
 }
 
 fn derive_fingerprint(title: &str, body: Option<&str>) -> String {

--- a/plugins/github-autopilot/cli/src/config.rs
+++ b/plugins/github-autopilot/cli/src/config.rs
@@ -1,0 +1,82 @@
+//! `autopilot.toml` config loader.
+//!
+//! Spec §8: tiny ledger-scoped config — `storage.db_path`,
+//! `epic.default_max_attempts`, `suppression.default_window_hours`. Sections are
+//! all optional; missing files yield [`Config::default`]. Field-level defaults
+//! match the values previously hardcoded in `main.rs` / `cmd::task`.
+//!
+//! Precedence (resolved by callers, not here): CLI flag > env var > file > default.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(default)]
+pub struct Config {
+    pub storage: StorageConfig,
+    pub epic: EpicConfig,
+    pub suppression: SuppressionConfig,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(default)]
+pub struct StorageConfig {
+    pub db_path: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(default)]
+pub struct EpicConfig {
+    pub default_max_attempts: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(default)]
+pub struct SuppressionConfig {
+    // TODO: wire into agent suppression flows. Defined here so operators can
+    // tune the default `--until` window, but the autopilot CLI itself never
+    // reads this — consumer agents pick it up from `autopilot.toml`.
+    #[allow(dead_code)]
+    pub default_window_hours: u32,
+}
+
+impl Default for StorageConfig {
+    fn default() -> Self {
+        Self {
+            db_path: PathBuf::from(".autopilot/state.db"),
+        }
+    }
+}
+
+impl Default for EpicConfig {
+    fn default() -> Self {
+        Self {
+            default_max_attempts: 3,
+        }
+    }
+}
+
+impl Default for SuppressionConfig {
+    fn default() -> Self {
+        Self {
+            default_window_hours: 24,
+        }
+    }
+}
+
+impl Config {
+    /// Loads `path` if it exists; otherwise returns [`Config::default`].
+    /// Returns Err only on read or parse failure (not on missing file).
+    pub fn load(path: &Path) -> Result<Self> {
+        if !path.exists() {
+            return Ok(Self::default());
+        }
+        let raw = std::fs::read_to_string(path)
+            .with_context(|| format!("reading config {}", path.display()))?;
+        let cfg: Self =
+            toml::from_str(&raw).with_context(|| format!("parsing config {}", path.display()))?;
+        Ok(cfg)
+    }
+}

--- a/plugins/github-autopilot/cli/src/lib.rs
+++ b/plugins/github-autopilot/cli/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod cmd;
+pub mod config;
 pub mod domain;
 pub mod fs;
 pub mod gh;

--- a/plugins/github-autopilot/cli/src/main.rs
+++ b/plugins/github-autopilot/cli/src/main.rs
@@ -158,14 +158,7 @@ fn main() {
             )
         }
         Commands::Task { command } => {
-            let db_path = task_store_db_path(&config);
-            let store = match SqliteTaskStore::open(&db_path) {
-                Ok(s) => s,
-                Err(e) => {
-                    eprintln!("failed to open task store at {}: {e}", db_path.display());
-                    std::process::exit(2);
-                }
-            };
+            let store = open_store(&config);
             let clock = cmd::task::default_clock();
             let svc = cmd::task::TaskService::with_max_attempts(
                 &store,
@@ -214,14 +207,7 @@ fn main() {
             }
         }
         Commands::Epic { command } => {
-            let db_path = task_store_db_path(&config);
-            let store = match SqliteTaskStore::open(&db_path) {
-                Ok(s) => s,
-                Err(e) => {
-                    eprintln!("failed to open task store at {}: {e}", db_path.display());
-                    std::process::exit(2);
-                }
-            };
+            let store = open_store(&config);
             let clock = cmd::task::default_clock();
             let svc = cmd::epic::epic_service(&store, &clock);
             let mut out = stdout();
@@ -245,14 +231,7 @@ fn main() {
             }
         }
         Commands::Suppress { command } => {
-            let db_path = task_store_db_path(&config);
-            let store = match SqliteTaskStore::open(&db_path) {
-                Ok(s) => s,
-                Err(e) => {
-                    eprintln!("failed to open task store at {}: {e}", db_path.display());
-                    std::process::exit(2);
-                }
-            };
+            let store = open_store(&config);
             let clock = cmd::task::default_clock();
             let svc = cmd::suppress::suppress_service(&store, &clock);
             let mut out = stdout();
@@ -269,14 +248,7 @@ fn main() {
             }
         }
         Commands::Events { command } => {
-            let db_path = task_store_db_path(&config);
-            let store = match SqliteTaskStore::open(&db_path) {
-                Ok(s) => s,
-                Err(e) => {
-                    eprintln!("failed to open task store at {}: {e}", db_path.display());
-                    std::process::exit(2);
-                }
-            };
+            let store = open_store(&config);
             let svc = cmd::events::events_service(&store);
             let mut out = stdout();
             match command {
@@ -311,4 +283,18 @@ fn load_config(explicit: Option<&Path>) -> anyhow::Result<Config> {
     let default_path = PathBuf::from("autopilot.toml");
     let path = explicit.unwrap_or(default_path.as_path());
     Config::load(path)
+}
+
+/// Opens the SQLite task store at the configured path, exiting with code 2
+/// on failure. Centralizes the error message so every `Commands::*` arm that
+/// needs the store stays a one-liner.
+fn open_store(config: &Config) -> SqliteTaskStore {
+    let db_path = task_store_db_path(config);
+    match SqliteTaskStore::open(&db_path) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("failed to open task store at {}: {e}", db_path.display());
+            std::process::exit(2);
+        }
+    }
 }

--- a/plugins/github-autopilot/cli/src/main.rs
+++ b/plugins/github-autopilot/cli/src/main.rs
@@ -2,6 +2,7 @@ use autopilot::cmd::{
     CheckCommands, Cli, Commands, IssueCommands, ListArgs, PipelineCommands, PreflightArgs,
     StatsCommands, TaskCommands, WorktreeCommands,
 };
+use autopilot::config::Config;
 use autopilot::store::SqliteTaskStore;
 use autopilot::{cmd, fs, gh, git, github};
 use clap::Parser;
@@ -10,6 +11,13 @@ use std::path::{Path, PathBuf};
 
 fn main() {
     let cli = Cli::parse();
+    let config = match load_config(cli.config.as_deref()) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("{e:#}");
+            std::process::exit(2);
+        }
+    };
 
     let result = match cli.command {
         Commands::Issue { command } => match command {
@@ -150,7 +158,7 @@ fn main() {
             )
         }
         Commands::Task { command } => {
-            let db_path = task_store_db_path();
+            let db_path = task_store_db_path(&config);
             let store = match SqliteTaskStore::open(&db_path) {
                 Ok(s) => s,
                 Err(e) => {
@@ -159,7 +167,11 @@ fn main() {
                 }
             };
             let clock = cmd::task::default_clock();
-            let svc = cmd::task::task_service(&store, &clock);
+            let svc = cmd::task::TaskService::with_max_attempts(
+                &store,
+                &clock,
+                config.epic.default_max_attempts,
+            );
             let mut out = stdout();
             match command {
                 TaskCommands::List { epic, status, json } => {
@@ -202,7 +214,7 @@ fn main() {
             }
         }
         Commands::Epic { command } => {
-            let db_path = task_store_db_path();
+            let db_path = task_store_db_path(&config);
             let store = match SqliteTaskStore::open(&db_path) {
                 Ok(s) => s,
                 Err(e) => {
@@ -232,6 +244,45 @@ fn main() {
                 }
             }
         }
+        Commands::Suppress { command } => {
+            let db_path = task_store_db_path(&config);
+            let store = match SqliteTaskStore::open(&db_path) {
+                Ok(s) => s,
+                Err(e) => {
+                    eprintln!("failed to open task store at {}: {e}", db_path.display());
+                    std::process::exit(2);
+                }
+            };
+            let clock = cmd::task::default_clock();
+            let svc = cmd::suppress::suppress_service(&store, &clock);
+            let mut out = stdout();
+            match command {
+                cmd::suppress::SuppressCommands::Add(args) => {
+                    svc.add(&args.fingerprint, &args.reason, &args.until, &mut out)
+                }
+                cmd::suppress::SuppressCommands::Check(args) => {
+                    svc.check(&args.fingerprint, &args.reason, &mut out)
+                }
+                cmd::suppress::SuppressCommands::Clear(args) => {
+                    svc.clear(&args.fingerprint, &args.reason, &mut out)
+                }
+            }
+        }
+        Commands::Events { command } => {
+            let db_path = task_store_db_path(&config);
+            let store = match SqliteTaskStore::open(&db_path) {
+                Ok(s) => s,
+                Err(e) => {
+                    eprintln!("failed to open task store at {}: {e}", db_path.display());
+                    std::process::exit(2);
+                }
+            };
+            let svc = cmd::events::events_service(&store);
+            let mut out = stdout();
+            match command {
+                cmd::events::EventsCommands::List(args) => svc.list(&args, &mut out),
+            }
+        }
     };
 
     match result {
@@ -243,13 +294,21 @@ fn main() {
     }
 }
 
-fn task_store_db_path() -> PathBuf {
+fn task_store_db_path(config: &Config) -> PathBuf {
     if let Ok(p) = std::env::var("AUTOPILOT_DB_PATH") {
         return PathBuf::from(p);
     }
-    let dir = PathBuf::from(".autopilot");
-    if !dir.exists() {
-        let _ = std::fs::create_dir_all(&dir);
+    let path = config.storage.db_path.clone();
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() && !parent.exists() {
+            let _ = std::fs::create_dir_all(parent);
+        }
     }
-    dir.join("state.db")
+    path
+}
+
+fn load_config(explicit: Option<&Path>) -> anyhow::Result<Config> {
+    let default_path = PathBuf::from("autopilot.toml");
+    let path = explicit.unwrap_or(default_path.as_path());
+    Config::load(path)
 }

--- a/plugins/github-autopilot/cli/tests/config_tests.rs
+++ b/plugins/github-autopilot/cli/tests/config_tests.rs
@@ -1,0 +1,65 @@
+use std::path::PathBuf;
+
+use autopilot::config::Config;
+use tempfile::NamedTempFile;
+
+// ---------- helpers ----------
+
+fn write_toml(content: &str) -> NamedTempFile {
+    let f = NamedTempFile::new().unwrap();
+    std::fs::write(f.path(), content).unwrap();
+    f
+}
+
+// ---------- defaults ----------
+
+#[test]
+fn config_loads_defaults_when_file_missing() {
+    // Pick a path that does not exist; load() must not error and must return defaults.
+    let tmp = NamedTempFile::new().unwrap();
+    let path = tmp.path().to_path_buf();
+    drop(tmp); // closes and removes the file
+    assert!(!path.exists(), "precondition: path must be missing");
+
+    let cfg = Config::load(&path).expect("load() with missing file should be Ok");
+    assert_eq!(cfg, Config::default());
+    assert_eq!(
+        cfg.storage.db_path,
+        PathBuf::from(".autopilot/state.db"),
+        "default db_path"
+    );
+    assert_eq!(
+        cfg.epic.default_max_attempts, 3,
+        "default max_attempts matches PR-B's previous constant"
+    );
+}
+
+// ---------- field overrides ----------
+
+#[test]
+fn config_loads_storage_db_path_from_toml() {
+    let f = write_toml("[storage]\ndb_path = \"/tmp/custom.db\"\n");
+    let cfg = Config::load(f.path()).expect("load()");
+    assert_eq!(cfg.storage.db_path, PathBuf::from("/tmp/custom.db"));
+    // Other sections still get defaults.
+    assert_eq!(cfg.epic.default_max_attempts, 3);
+}
+
+#[test]
+fn config_loads_epic_max_attempts_from_toml() {
+    let f = write_toml("[epic]\ndefault_max_attempts = 7\n");
+    let cfg = Config::load(f.path()).expect("load()");
+    assert_eq!(cfg.epic.default_max_attempts, 7);
+    // Storage default still applies.
+    assert_eq!(cfg.storage.db_path, PathBuf::from(".autopilot/state.db"));
+}
+
+// ---------- failure modes ----------
+
+#[test]
+fn config_load_returns_error_on_invalid_toml() {
+    let f = write_toml("this is = not = valid toml [[\n");
+    let err = Config::load(f.path()).unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(msg.contains("parsing config"), "error: {msg}");
+}

--- a/plugins/github-autopilot/cli/tests/events_tests.rs
+++ b/plugins/github-autopilot/cli/tests/events_tests.rs
@@ -1,0 +1,196 @@
+use std::sync::Arc;
+
+use autopilot::cmd::events::{EventsService, ListArgs};
+use autopilot::domain::{Event, EventKind, TaskId};
+use autopilot::ports::task_store::TaskStore;
+use autopilot::store::InMemoryTaskStore;
+use chrono::{DateTime, TimeZone, Utc};
+
+// ---------- helpers ----------
+
+fn base_time() -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap()
+}
+
+fn fixture_with_events() -> Arc<dyn TaskStore> {
+    let store: Arc<dyn TaskStore> = Arc::new(InMemoryTaskStore::new());
+    let t0 = base_time();
+    // (epic, task, kind, +seconds)
+    let seeds: &[(Option<&str>, Option<&str>, EventKind, i64)] = &[
+        (Some("e1"), None, EventKind::EpicStarted, 0),
+        (
+            Some("e1"),
+            Some("aaaaaaaaaaaa"),
+            EventKind::TaskInserted,
+            10,
+        ),
+        (Some("e1"), Some("aaaaaaaaaaaa"), EventKind::TaskClaimed, 20),
+        (
+            Some("e1"),
+            Some("bbbbbbbbbbbb"),
+            EventKind::TaskInserted,
+            30,
+        ),
+        (Some("e2"), None, EventKind::EpicStarted, 40),
+        (
+            Some("e2"),
+            Some("cccccccccccc"),
+            EventKind::TaskInserted,
+            50,
+        ),
+    ];
+    for (epic, task, kind, sec) in seeds {
+        let event = Event {
+            task_id: task.map(TaskId::from_raw),
+            epic_name: epic.map(|s| s.to_string()),
+            kind: *kind,
+            payload: serde_json::Value::Null,
+            at: t0 + chrono::Duration::seconds(*sec),
+        };
+        store.append_event(&event).unwrap();
+    }
+    store
+}
+
+fn capture<F>(f: F) -> (i32, String)
+where
+    F: FnOnce(&mut Vec<u8>) -> anyhow::Result<i32>,
+{
+    let mut buf: Vec<u8> = Vec::new();
+    let code = f(&mut buf).expect("service call");
+    (code, String::from_utf8(buf).expect("utf-8"))
+}
+
+fn list_args() -> ListArgs {
+    ListArgs {
+        epic: None,
+        task: None,
+        kinds: vec![],
+        since: None,
+        limit: None,
+        json: false,
+    }
+}
+
+// ---------- list filters ----------
+
+#[test]
+fn events_list_filters_by_epic() {
+    let store = fixture_with_events();
+    let svc = EventsService::new(store.as_ref());
+    let args = ListArgs {
+        epic: Some("e1".to_string()),
+        json: true,
+        ..list_args()
+    };
+    let (code, out) = capture(|w| svc.list(&args, w));
+    assert_eq!(code, 0);
+    let arr: Vec<serde_json::Value> = serde_json::from_str(out.trim()).unwrap();
+    assert_eq!(arr.len(), 4);
+    for e in &arr {
+        assert_eq!(e["epic"], "e1");
+    }
+}
+
+#[test]
+fn events_list_filters_by_task() {
+    let store = fixture_with_events();
+    let svc = EventsService::new(store.as_ref());
+    let args = ListArgs {
+        task: Some("aaaaaaaaaaaa".to_string()),
+        json: true,
+        ..list_args()
+    };
+    let (code, out) = capture(|w| svc.list(&args, w));
+    assert_eq!(code, 0);
+    let arr: Vec<serde_json::Value> = serde_json::from_str(out.trim()).unwrap();
+    assert_eq!(arr.len(), 2);
+    for e in &arr {
+        assert_eq!(e["task"], "aaaaaaaaaaaa");
+    }
+}
+
+#[test]
+fn events_list_filters_by_kind() {
+    let store = fixture_with_events();
+    let svc = EventsService::new(store.as_ref());
+    let args = ListArgs {
+        kinds: vec!["task_inserted".to_string()],
+        json: true,
+        ..list_args()
+    };
+    let (code, out) = capture(|w| svc.list(&args, w));
+    assert_eq!(code, 0);
+    let arr: Vec<serde_json::Value> = serde_json::from_str(out.trim()).unwrap();
+    assert_eq!(arr.len(), 3);
+    for e in &arr {
+        assert_eq!(e["kind"], "task_inserted");
+    }
+}
+
+#[test]
+fn events_list_filters_by_since() {
+    let store = fixture_with_events();
+    let svc = EventsService::new(store.as_ref());
+    // Drop the first 3 events (at t+0, t+10s, t+20s) by passing t+25s.
+    let args = ListArgs {
+        since: Some("2026-01-01T00:00:25Z".to_string()),
+        json: true,
+        ..list_args()
+    };
+    let (code, out) = capture(|w| svc.list(&args, w));
+    assert_eq!(code, 0);
+    let arr: Vec<serde_json::Value> = serde_json::from_str(out.trim()).unwrap();
+    assert_eq!(arr.len(), 3);
+}
+
+#[test]
+fn events_list_respects_limit() {
+    let store = fixture_with_events();
+    let svc = EventsService::new(store.as_ref());
+    let args = ListArgs {
+        limit: Some(2),
+        json: true,
+        ..list_args()
+    };
+    let (code, out) = capture(|w| svc.list(&args, w));
+    assert_eq!(code, 0);
+    let arr: Vec<serde_json::Value> = serde_json::from_str(out.trim()).unwrap();
+    assert_eq!(arr.len(), 2);
+}
+
+#[test]
+fn events_list_json_output_is_array_of_event_records() {
+    let store = fixture_with_events();
+    let svc = EventsService::new(store.as_ref());
+    let args = ListArgs {
+        json: true,
+        ..list_args()
+    };
+    let (code, out) = capture(|w| svc.list(&args, w));
+    assert_eq!(code, 0);
+    let arr: Vec<serde_json::Value> = serde_json::from_str(out.trim()).unwrap();
+    assert!(!arr.is_empty());
+    // Each record must expose at, kind, epic, task, payload.
+    for e in &arr {
+        assert!(e["at"].is_string(), "missing `at`: {e}");
+        assert!(e["kind"].is_string(), "missing `kind`: {e}");
+        assert!(e.get("epic").is_some(), "missing `epic` (may be null): {e}");
+        assert!(e.get("task").is_some(), "missing `task` (may be null): {e}");
+        assert!(e.get("payload").is_some(), "missing `payload`: {e}");
+    }
+}
+
+#[test]
+fn events_list_rejects_unknown_kind() {
+    let store = fixture_with_events();
+    let svc = EventsService::new(store.as_ref());
+    let args = ListArgs {
+        kinds: vec!["definitely_not_a_kind".to_string()],
+        ..list_args()
+    };
+    let (code, out) = capture(|w| svc.list(&args, w));
+    assert_eq!(code, 1, "stdout: {out}");
+    assert!(out.contains("unknown event kind"), "stdout: {out}");
+    assert!(out.contains("definitely_not_a_kind"), "stdout: {out}");
+}

--- a/plugins/github-autopilot/cli/tests/suppress_tests.rs
+++ b/plugins/github-autopilot/cli/tests/suppress_tests.rs
@@ -1,0 +1,103 @@
+use std::sync::Arc;
+
+use autopilot::cmd::suppress::SuppressService;
+use autopilot::ports::clock::FixedClock;
+use autopilot::ports::task_store::TaskStore;
+use autopilot::store::InMemoryTaskStore;
+use chrono::{TimeZone, Utc};
+
+// ---------- helpers ----------
+
+fn fixture() -> (Arc<dyn TaskStore>, FixedClock) {
+    let store: Arc<dyn TaskStore> = Arc::new(InMemoryTaskStore::new());
+    let clock = FixedClock::new(Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap());
+    (store, clock)
+}
+
+fn capture<F>(f: F) -> (i32, String)
+where
+    F: FnOnce(&mut Vec<u8>) -> anyhow::Result<i32>,
+{
+    let mut buf: Vec<u8> = Vec::new();
+    let code = f(&mut buf).expect("service call");
+    (code, String::from_utf8(buf).expect("utf-8"))
+}
+
+fn expect_err<F>(f: F) -> String
+where
+    F: FnOnce(&mut Vec<u8>) -> anyhow::Result<i32>,
+{
+    let mut buf: Vec<u8> = Vec::new();
+    format!("{:#}", f(&mut buf).unwrap_err())
+}
+
+// ---------- add ----------
+
+#[test]
+fn suppress_add_persists_until_window() {
+    let (store, clock) = fixture();
+    let svc = SuppressService::new(store.as_ref(), &clock);
+    let (code, out) = capture(|w| svc.add("fp1", "unmatched_watch", "2026-01-02T00:00:00Z", w));
+    assert_eq!(code, 0, "stdout: {out}");
+    assert!(out.contains("fp1"), "stdout: {out}");
+    assert!(out.contains("unmatched_watch"), "stdout: {out}");
+    // still inside the window at fixture's clock (2026-01-01)
+    let (check_code, _) = capture(|w| svc.check("fp1", "unmatched_watch", w));
+    assert_eq!(check_code, 0);
+}
+
+#[test]
+fn suppress_add_rejects_invalid_until_timestamp() {
+    let (store, clock) = fixture();
+    let svc = SuppressService::new(store.as_ref(), &clock);
+    let err = expect_err(|w| svc.add("fp1", "unmatched_watch", "not-a-date", w));
+    assert!(err.contains("--until"), "error: {err}");
+}
+
+// ---------- check ----------
+
+#[test]
+fn suppress_check_returns_exit_0_when_active() {
+    let (store, clock) = fixture();
+    let svc = SuppressService::new(store.as_ref(), &clock);
+    let _ = capture(|w| svc.add("fp1", "unmatched_watch", "2026-01-02T00:00:00Z", w));
+    let (code, out) = capture(|w| svc.check("fp1", "unmatched_watch", w));
+    assert_eq!(code, 0, "stdout: {out}");
+    assert!(out.contains("suppressed"), "stdout: {out}");
+}
+
+#[test]
+fn suppress_check_returns_exit_1_after_window_expires() {
+    let (store, clock) = fixture();
+    let svc = SuppressService::new(store.as_ref(), &clock);
+    let _ = capture(|w| svc.add("fp1", "unmatched_watch", "2026-01-02T00:00:00Z", w));
+    // Advance well past --until.
+    clock.advance(chrono::Duration::days(2));
+    let (code, out) = capture(|w| svc.check("fp1", "unmatched_watch", w));
+    assert_eq!(code, 1, "stdout: {out}");
+    assert!(out.contains("not suppressed"), "stdout: {out}");
+}
+
+#[test]
+fn suppress_check_returns_exit_1_when_never_suppressed() {
+    let (store, clock) = fixture();
+    let svc = SuppressService::new(store.as_ref(), &clock);
+    let (code, out) = capture(|w| svc.check("never-set", "rejected_by_human", w));
+    assert_eq!(code, 1, "stdout: {out}");
+    assert!(out.contains("not suppressed"), "stdout: {out}");
+}
+
+// ---------- clear ----------
+
+#[test]
+fn suppress_clear_removes_entry() {
+    let (store, clock) = fixture();
+    let svc = SuppressService::new(store.as_ref(), &clock);
+    let _ = capture(|w| svc.add("fp1", "unmatched_watch", "2026-01-02T00:00:00Z", w));
+    let (code, out) = capture(|w| svc.clear("fp1", "unmatched_watch", w));
+    assert_eq!(code, 0, "stdout: {out}");
+    assert!(out.contains("cleared"), "stdout: {out}");
+    // After clear, check should report not-suppressed (exit 1).
+    let (check_code, _) = capture(|w| svc.check("fp1", "unmatched_watch", w));
+    assert_eq!(check_code, 1);
+}


### PR DESCRIPTION
## Summary
- `autopilot suppress add|check|clear` over `SuppressionRepo`.
- `autopilot events list` over `EventLog` with filters by epic/task/kind/since/limit.
- `src/config.rs`: `autopilot.toml` with `[storage]`, `[epic]`, `[suppression]`. Sensible defaults when file missing.
- `task fail` now reads `max_attempts` from config; PR-B's `DEFAULT_MAX_ATTEMPTS` constant retired as the live source of truth.
- Follow-up refactor commit dedupes `write_json` (events/epic/task -> `cmd::output`) and the SqliteTaskStore open block in `main.rs` -> `open_store(&Config)`.

## Test plan
- [x] cargo fmt --check
- [x] cargo clippy --lib --bins -- -D warnings
- [x] cargo check
- [x] cargo test (suppress 6 / events 7 / config 4 added; full suite passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)