### PR TITLE
feat(github-autopilot): ledger CLI epic — autopilot task store

### DIFF
--- a/plans/github-autopilot/00-concept.md
+++ b/plans/github-autopilot/00-concept.md
@@ -196,71 +196,111 @@ task_id = sha256(epic_name || ":" || section_path || ":" || requirement_slug)[:1
 
 ## 4. Reconciliation 프로토콜
 
-`epic-start` 또는 `epic-resume` 시 다음 절차로 로컬 DB 를 리모트와 동기화한다.
+Epic 재개 / DB 손실 복구 / 사람의 직접 push 인식 시 사용한다. **Agent 가 정보를 모아 autopilot CLI 에 한 번에 넘긴다** — autopilot 은 받은 plan 을 idempotent 하게 적용할 뿐 git/spec 을 직접 만지지 않는다.
 
 ```
-1. spec 분해 → 기대 task 목록 (결정적 ID 부여)
-2. git fetch origin
-3. 리모트 브랜치 스캔: "epic/<name>" 및 "epic/<name>/*"
-4. 머지된 PR 스캔: target = "epic/<name>"
-5. 매칭하여 status 결정:
-   - PR merged                    → done
-   - feature 브랜치 + open PR     → wip (검토중)
-   - feature 브랜치 + PR 없음    → wip (구현중) 또는 stale 후보
-   - 브랜치 없음                  → ready (deps 만족 시) 또는 pending
-6. 분해 결과에 없는데 DB 에만 남은 task → orphan 으로 표시 (사람 검토 대상)
-7. DB 에 신규 행 insert / 기존 행 update
+[Agent 측]
+  1. monitor 호출 → 기대 task 목록 + 의존성 (결정적 ID 부여)
+  2. git fetch origin
+  3. ls-remote: "epic/<name>" 및 "epic/<name>/*"
+  4. PR 스캔: target = "epic/<name>"
+  5. 매칭하여 RemoteTaskState 빌드:
+     - PR merged                    → done
+     - feature 브랜치 + open PR     → wip (검토중)
+     - feature 브랜치 + PR 없음    → wip (구현중) 또는 stale 후보
+     - 브랜치 없음                  → ready (deps 만족 시) 또는 pending
+  6. 분해 결과에 없는 epic/<name>/* 브랜치 목록 → orphan_branches 로 모음
+
+[Agent → Autopilot CLI]
+  autopilot epic reconcile --name <name> --plan <jsonl>
+    (또는 --tasks-from + --remote-state 분리 옵션)
+
+[Autopilot 측]
+  7. plan 검증 (cycle, 알 수 없는 deps, ...)
+  8. tasks upsert + deps 갱신 + status 적용 + reconciled 이벤트 기록
 ```
 
-이 절차는 **idempotent** 해야 한다. 동일 epic 에 대해 N번 reconcile 해도 결과가 같아야 하며, 재시도 안전하다.
+이 절차는 **idempotent** 해야 한다. 동일 plan 으로 N번 호출해도 결과가 같아야 하며, 재시도 안전하다. attempts 카운터는 보존된다 (DB 손실 시는 0 으로 초기화 — 허용 손실).
 
-## 5. 명령 / 에이전트 변화 매트릭스
+## 5. 책임 분리 — Ledger 모델
 
-### 5.1 신규
+autopilot 은 **상태 관리 + CLI 표면** 만 책임진다. 탐지 / 결정 / 구현은 **외부 에이전트 (Agent)** 가 수행하고, autopilot 은 그 에이전트가 호출하는 도구로 위치한다.
+
+```
+┌─ Agent (Claude Code 세션, GitHub Actions, autodev 등) ─┐
+│  - monitor 호출 (gap 탐지)                              │
+│  - autopilot CLI 호출 (task 적재 / claim / 결과 보고)   │
+│  - 직접 구현 + git/PR 조작                              │
+│  - escalation 이슈 발행 / 알림                          │
+└────────────────────────────────────────────────────────┘
+                        ↓ CLI
+┌─ Autopilot ────────────────────────────────────────────┐
+│  - state.db 관리 (epics / tasks / events / suppression)│
+│  - 결정적 상태 전이 (claim 원자성, deps 재평가, ...)   │
+│  - 헬퍼 명령 (worktree, label, issue, watch, ...)      │
+└────────────────────────────────────────────────────────┘
+```
+
+### 5.1 Autopilot 의 책임 표면
+
+**A. Ledger CLI** (신규 — Round 2 이후 추가)
+
+| 그룹 | 명령 (요지) | 역할 |
+|------|------------|------|
+| epic | `epic create / list / get / status / complete / abandon / reconcile` | epic 행 CRUD + 라이프사이클 전이 |
+| task | `task add / list / get / claim / release / complete / fail / escalate / force-status / find-by-pr` | task 행 CRUD + 상태 전이 (원자성 보장) |
+| suppress | `suppress add / check / clear` | escalation fingerprint 억제 |
+| events | `events list` | audit 로그 조회 |
+
+**B. 헬퍼 명령** (기존 유지 — 의사결정 없는 순수 도구)
 
 | 명령 | 역할 |
 |------|------|
-| `/github-autopilot:epic-start <spec-path>` | epic 브랜치 생성 + spec 분해 + task 적재 + 그 epic 스코프 루프 시작 |
-| `/github-autopilot:epic-resume <epic-name>` | 기존 epic 의 상태를 리모트 기준으로 reconcile 후 루프 재개 |
-| `/github-autopilot:epic-status [epic-name]` | epic / task 상태 대시보드 (사람용) |
-| `/github-autopilot:epic-stop <epic-name>` | 해당 epic 의 루프 종료 (수동) |
+| `worktree` | git worktree CRUD |
+| `simhash` | fingerprint 해싱 |
+| `labels` | GitHub 라벨 CRUD |
+| `issue`, `issue list` | GitHub 이슈 CRUD (gh wrapping) |
+| `preflight` | 환경 검증 |
+| `stats`, `check` | 읽기 전용 분석 |
+| `pipeline idle` | 라벨 기반 idle 판정 (count 기반) |
+| `watch run` | 외부 변화를 JSON 이벤트로 stdout 에 emit (long-poll, 의사결정 없음) |
 
-### 5.2 변경
+이 헬퍼들은 **에이전트의 도구** 로 분류한다. 에이전트가 필요할 때 호출하고, 출력을 보고 결정한다.
 
-| 명령 / 에이전트 | 변경점 |
-|----------------|--------|
-| `gap-watch` | 발견 시 활성 epic 매칭 → task append. 매칭 실패 시 HITL 이슈 escalate |
-| `qa-boost` | 동일 (활성 epic 매칭 → task append, 실패 시 escalate) |
-| `ci-watch` | epic 브랜치 / task 브랜치의 CI 실패는 해당 task 의 attempts 증가. main 의 CI 실패는 escalate |
-| `build-issues` → `build-tasks` | 입력 소스 변경: `:ready` 라벨 쿼리 → SQLite `WHERE status='ready'` |
-| `branch-promoter` | PR target: main → 해당 epic 브랜치 |
-| `analyze-issue` | HITL 이슈 분석 후 ready 판정 시: 이슈를 활성 epic 의 task 로 흡수 (이슈 번호를 task 메타에 기록) |
-| `merge-prs` | 동작 동일 (`:auto` 라벨 PR 머지). 단 머지 후 task status 업데이트 추가 |
+### 5.2 Agent 의 책임 (autopilot 외부)
 
-### 5.3 제거 / 폐기
+| 책임 | 설명 |
+|------|------|
+| **갭 탐지** | monitor (예: `gap-detector`, `qa-boost`) 호출. 결과를 autopilot CLI 로 task 화 |
+| **분해 정책** | spec-kit 재사용 / 자체 markdown 파서 / LLM prompt 등 — 에이전트 측 결정 |
+| **claim → 구현 → PR** | task claim 후 코드 작성 / 브랜치 push / PR 생성 |
+| **결과 보고** | 성공 시 `task complete --pr N`, push reject 시 `task release`, 실패 시 `task fail` |
+| **Escalation 발행** | `task fail` 결과가 `Escalated` 면 GitHub 이슈 발행 + `task escalate` |
+| **Escalation 해소 감지** | 주기적으로 escalated task 의 issue 상태 폴링 → close 시 `epic reconcile` 또는 `task force-status` |
+| **알림** | epic 완료 / escalation 시 사용자 알림 |
 
-- `:ready` 라벨 — task store 의 status 컬럼이 대체. autopilot 은 더 이상 라벨로 작업을 큐잉하지 않음.
-- `:wip` 라벨 — 동일 (status='wip' 가 대체)
-- `autopilot issue create` 의 watch-source 호출 경로 — task store insert 로 대체
+### 5.3 라벨 / 호환성
 
-`:auto`, `:ci-failure` 라벨은 PR / 사람 이슈에서 계속 의미를 가지므로 유지한다.
+- `:auto`, `:ci-failure` 라벨은 PR / 사람 이슈에서 그대로 의미를 가짐 (변경 없음)
+- `:ready`, `:wip` 라벨은 `tasks.status` 컬럼이 의미를 대체. **단 autopilot 자체는 라벨을 큐로 쓰지 않음** — 에이전트가 라벨 기반 흐름을 유지하고 싶으면 별도 매핑 가능
+- `autopilot issue create` 의 watch-source 호출 경로 → task store insert 로 대체
 
 ## 6. HITL Escalation
 
-### 6.1 Escalation 트리거
+### 6.1 Escalation 트리거 (모두 Agent 가 발행)
 
-| 조건 | 동작 |
-|------|------|
-| watch 가 발견했지만 활성 epic 에 매칭되지 않음 | "어느 epic 에 붙일지 결정해주세요" 이슈 발행 |
-| task 가 max_attempts 초과 | "구현 반복 실패, 검토 필요" 이슈 발행 |
-| task 의존성 사이클 또는 unresolvable | "의존성 문제 해결 필요" 이슈 발행 |
-| 충돌 자동 해결 실패 | 기존 충돌 알림 흐름 유지 |
+| 조건 | Agent 동작 |
+|------|----------|
+| 갭이 어떤 활성 epic 에도 매칭되지 않음 | autopilot `suppress check` 로 중복 차단 검사 → 신규면 이슈 발행 + `suppress add fingerprint reason="unmatched_watch"` |
+| `task fail` 결과가 `Escalated` | 이슈 발행 + `task escalate <id> --issue <n>` (의존 task 들은 autopilot 이 자동으로 `blocked`) |
+| 의존성 사이클 / unresolvable | epic 적재 시 autopilot 이 거부. agent 가 그 에러를 받고 이슈 발행 |
+| 충돌 자동 해결 실패 | agent 의 기존 충돌 알림 흐름 유지 |
 
 ### 6.2 Escalation 이슈 포맷
 
 ```yaml
 title: "[autopilot] <짧은 요약>"
-labels: ["autopilot:hitl-needed"]   # 새 라벨
+labels: ["autopilot:hitl-needed"]
 body: |
   <!-- autopilot-escalation -->
   <!-- epic: <epic-name or "none"> -->
@@ -270,29 +310,35 @@ body: |
   ## 상황
   ...
 
-  ## autopilot 이 시도한 것
+  ## Agent 가 시도한 것
   ...
 
   ## 사람이 결정해야 할 것
   - [ ] ...
 ```
 
-사람이 이 이슈를 처리하면 (close / 새 epic 시작 / 기존 epic 에 attach) autopilot 은 다음 cycle 에서 status 를 갱신한다.
+사람이 이 이슈를 close 하면, **agent 가 다음 cycle 에서 close 를 감지** 하여:
+- 사람이 직접 코드를 푸시했고 PR 머지된 경우 → `epic reconcile` 호출 → task 가 done 으로 인식
+- 그렇지 않으면 → `suppress add reason="rejected_by_human"` 로 동일 fingerprint 의 재 escalation 차단
 
 ## 7. Epic 라이프사이클
 
 ```
-[사람] /epic-start spec/auth.md
+[사람]  agent 에게 "spec/auth.md 로 epic 시작" 요청
   ↓
-[autopilot] epic 브랜치 생성 + spec 분해 + task 적재 + 루프 시작
+[Agent] monitor 호출 → spec 분해 결과 획득
+        autopilot epic create --name auth-token-refresh --spec spec/auth.md
+        autopilot task add --epic ... (각 task 별 또는 batch)
+        git checkout -b epic/auth-token-refresh && git push
   ↓
-[autopilot] task 단위 구현 → PR (target = epic 브랜치) → :auto 라벨 → merge
+[Agent] (cron / loop 마다 반복)
+        autopilot task claim --epic ...   → ready task 1건
+        구현 → push → PR 생성
+        autopilot task complete --id <id> --pr <n>   (또는 fail / release)
   ↓ (모든 task done)
-[autopilot] notification 설정대로 완료 알림 + 해당 epic 의 루프 종료
+[Agent] autopilot epic status 가 all-done 보고 → epic complete + 사용자 알림
   ↓
-[사람] epic 브랜치에서 추가 검증 / 수동 보완
-  ↓
-[사람] epic → main PR 직접 생성 (이 단계는 자동화하지 않음)
+[사람]  epic 브랜치 검증 + main 으로 PR 직접 생성 (자동화 안 함)
 ```
 
 main 으로의 promote 가 자동화되지 않는 이유: epic 단위는 큰 변경이라 사람의 최종 검토가 안전판으로 필요하다.
@@ -326,19 +372,23 @@ hitl_label: "autopilot:hitl-needed"
 
 ## 9. 미해결 / 후속 검토 항목
 
-설계 단계에서 명시적으로 결정을 미룬 사항. Phase 2 (REVIEW) 또는 구현 시 결정한다.
+설계 단계에서 명시적으로 결정을 미룬 사항.
 
-1. **Spec 분해 주체** — 기존 `spec-kit` 플러그인을 재사용할 것인지, github-autopilot 이 자체 분해 에이전트를 둘 것인지.
-2. **Stale 브랜치 정책** — feature 브랜치는 있으나 PR 도 없고 일정 시간 변경도 없는 task 를 어떻게 처리할지.
-3. **여러 epic 동시 활성** 시 자원 한도 — `max_parallel_agents` 가 epic 간에 어떻게 분배될지.
-4. **Schema 마이그레이션** — 향후 스키마 변경 시 사용자 로컬 DB 를 업데이트할 절차 (단순 버전 컬럼 + 마이그레이션 스크립트가 무난).
-5. **이벤트 로그 보존 기간** — `events` 테이블 무한 증가 방지 정책 (epic completed 후 N일 후 prune 등).
+1. **Stale 브랜치 정책** — feature 브랜치는 있으나 PR 도 없고 일정 시간 변경도 없는 task 를 어떻게 처리할지. (Agent 측 정책)
+2. **여러 epic 동시 활성** 시 자원 한도 — `max_parallel_agents` 같은 한도는 **agent 측** 의 결정. autopilot 은 임의 다중 epic 을 그냥 수용.
+3. **Schema 마이그레이션** — 향후 스키마 변경 시 사용자 로컬 DB 를 업데이트할 절차. V1→V2 자동 적용 패턴 채택 (이미 구현). 다운그레이드는 비지원.
+4. **이벤트 로그 보존 기간** — `events` 테이블 무한 증가 방지 정책 (단일 cron `DELETE` 로 N일 prune 권장).
+5. **`escalation_suppression` TTL 정리** — 만료된 행을 lazy 또는 주기적으로 cleanup.
+
+> **해소된 항목**: "spec 분해 주체" — Ledger 모델 채택으로 autopilot 의 결정 사항이 아님. Agent (또는 monitor) 가 자유롭게 선택.
 
 ## 10. 다음 단계
 
-- [ ] 본 문서 리뷰 (Phase 2)
-- [ ] 결정 사항 수렴 후 라운드별 구현 계획 (Phase 3 분할)
-  - Round 1: SQLite 스키마 + autopilot CLI 의 task store 명령 (DB 단독 동작)
-  - Round 2: `epic-start` / 분해 / reconcile
-  - Round 3: 기존 watch / build / promote 의 배선 변경
-  - Round 4: HITL escalation + epic 완료 알림 + 마이그레이션
+- [x] PR #646 — 도메인 타입 + 인메모리/SQLite 어댑터 골격
+- [x] PR #648 — spec 정제 1차 (트레이트 시그니처)
+- [x] PR #649 — TaskStore 트레이트 + V2 schema + conformance suite
+- [ ] **현재 PR** — Ledger 모델로 spec rework (orchestration 제거)
+- [ ] **Round 2-A**: `cmd/epic.rs` (epic CRUD CLI)
+- [ ] **Round 2-B**: `cmd/task.rs` 확장 (claim / complete / fail / escalate)
+- [ ] **Round 2-C**: `cmd/suppress.rs` + `cmd/events.rs` + `main.rs` wiring + autopilot.toml
+- [ ] **Round 3**: 기존 헬퍼 (`pipeline`, `watch`, ...) 와 새 ledger CLI 의 정합성 점검 / 필요 시 deprecate

--- a/plans/github-autopilot/01-use-cases.md
+++ b/plans/github-autopilot/01-use-cases.md
@@ -1,12 +1,12 @@
 # 01. Use Cases
 
-> Epic 기반 Task Store 가 만족해야 하는 시나리오를 페르소나 관점에서 정의한다. 본 문서는 02 (아키텍처) 와 03 (상세 스펙) 의 인터페이스 도출 출발점이며, 04 (테스트) 의 fixture 원본이 된다.
+> Epic 기반 Task Store 가 만족해야 하는 시나리오를 페르소나 관점에서 정의한다. Ledger 모델에서 autopilot 은 상태 관리만 담당하고, 탐지 / 결정 / 구현은 외부 **Agent** 가 한다. 본 문서는 그 책임 분리를 전제로 시나리오를 기술한다.
 >
 > 각 시나리오는 다음 항목으로 구성된다:
 >
 > - **트리거** — 시나리오를 시작시키는 외부 이벤트
 > - **선행 조건** — 시나리오 시작 시점의 시스템 상태
-> - **주 흐름** — 정상 경로의 단계
+> - **주 흐름** — 정상 경로의 단계 (Agent ↔ Autopilot CLI)
 > - **대안 흐름** — 분기 / 실패 경로
 > - **사후 조건** — 시나리오 종료 시점에 보장되어야 하는 상태
 > - **관찰 가능 결과** — 외부에서 검증 가능한 부수 효과 (DB 행, git ref, GitHub 이슈/PR)
@@ -15,268 +15,271 @@
 
 | 코드 | 이름 | 역할 |
 |------|------|------|
-| **OP** | 운영자 (Operator) | autopilot 을 호스트하고 epic 을 시작/감독하는 사람 |
-| **ML** | 메인 루프 (Main Loop) | epic 단위로 도는 부모 에이전트. DB 의 단일 writer |
-| **IM** | 구현자 (Implementer) | worktree 안에서 코드를 작성하고 push 하는 자식 에이전트 |
-| **CO** | 협업자 (Collaborator) | 같은 레포에서 일하는 다른 사람. autopilot 을 직접 다루지 않을 수도 있음 |
+| **OP** | 운영자 (Operator) | autopilot 을 호스트하고 Agent 를 트리거하는 사람 |
+| **AG** | 에이전트 (Agent) | Claude Code 세션 / autodev / GitHub Actions 등. monitor 호출 / autopilot CLI 호출 / 구현 / PR 을 직접 수행 |
+| **MN** | 모니터 (Monitor) | spec ↔ code 갭을 탐지하는 외부 도구 (예: gap-detector, qa-boost, ci-watch). Agent 가 호출 |
+| **AP** | 오토파일럿 (Autopilot) | ledger + CLI. CRUD + 결정적 상태 전이만 담당 |
+| **CO** | 협업자 (Collaborator) | 같은 레포에서 일하는 다른 사람 |
 | **RV** | 리뷰어 (Reviewer) | PR 을 검토하는 사람 |
 
-페르소나 간 직접 통신은 다음 경로로만 일어난다:
+페르소나 간 통신 경로:
 
 ```
-OP → ML : CLI 명령 (/github-autopilot:epic-start 등)
-ML → OP : escalation 이슈, 완료 알림
-ML → IM : task 사양 + 격리된 worktree
-IM → ML : 브랜치 push (성공/실패) — DB 는 직접 안 만짐
-ML ↔ git remote / GitHub : PR / 이슈 / branch
-CO → GitHub : 이슈, PR 코멘트
-CO ← ML : escalation 이슈 (CO 도 처리 가능)
+OP → AG : 자연어 요청 ("auth.md 로 epic 시작해줘")
+AG → MN : 도구 호출 (spec 분해 / 갭 탐지)
+AG → AP : CLI 호출 (epic create / task add / claim / complete / fail / ...)
+AP → AG : 종료 코드 + JSON 출력 (claim 한 task / fail 의 outcome / ...)
+AG ↔ git remote / GitHub : 직접 git 조작 + gh CLI / API
+AG → OP : 알림 (epic 완료 / escalation 필요)
+CO → GitHub : 이슈, PR 코멘트 (사람의 통상 흐름)
+CO ← AG : escalation 이슈
 ```
+
+**중요**: AP 는 git / GitHub 를 직접 만지지 않는다. MN 호출도 하지 않는다. 모든 외부 효과는 AG 의 책임.
 
 ## UC-1. Epic 시작
 
 > 운영자가 새 spec 으로부터 자율 작업 권한을 부여한다.
 
-- **트리거**: OP 가 `autopilot epic start --spec spec/auth.md --name auth-token-refresh` 실행
+- **트리거**: OP 가 AG 에게 "spec/auth.md 로 epic 시작" 요청
 - **선행 조건**:
-  - 현재 working tree 가 main 브랜치에 깨끗하게 위치
+  - 현재 working tree 가 깨끗 (default branch 위치)
   - `spec/auth.md` 파일이 존재
   - 같은 이름의 active epic 이 없음
 - **주 흐름**:
-  1. ML 이 `epic/auth-token-refresh` 브랜치를 main 에서 분기하여 push
-  2. spec 분해 결과로부터 결정적 task_id 들을 부여
-  3. tasks 테이블에 status=pending 으로 모두 insert
-  4. 의존성 그래프를 `task_deps` 에 insert
-  5. 진입점 task (deps 없음) 들의 status=ready 로 전이
-  6. epics 테이블에 (name, branch, status=active) insert
-  7. ML 이 epic 스코프 cron 루프를 시작
+  1. AG 가 MN 호출 → 결정적 task_id + 의존성 정보 획득
+  2. AG 가 git checkout -b epic/auth-token-refresh && git push
+  3. AG 가 `autopilot epic create --name auth-token-refresh --spec spec/auth.md --branch epic/auth-token-refresh`
+  4. AG 가 `autopilot task add-batch --epic auth-token-refresh --from <jsonl>` (task + deps 일괄 적재)
+  5. AP 가 의존성 검증 (cycle / unknown target) + 진입점 task 들의 status=ready 자동 승격
 - **대안 흐름**:
-  - 같은 이름 epic 이 active → 에러 종료, OP 에게 `epic-resume` 안내
-  - spec 분해 실패 → epic 행도 만들지 않고 에러 종료 (rollback)
-  - main 이 dirty → 에러 종료, OP 에게 정리 요청
+  - 같은 이름 epic 이 active → AP 가 `EpicAlreadyExists` 반환. AG 는 OP 에게 `epic resume` 안내
+  - 분해 실패 → AG 가 epic create 호출 전에 중단. AP 상태 변경 없음
+  - working tree dirty → AG 의 git 단계에서 실패. AG 가 OP 에게 정리 요청
+  - cycle 감지 → AP 의 `add-batch` 가 `DepCycle` 반환. AG 는 epic 을 abandon 하거나 사람에게 escalate
 - **사후 조건**:
   - 리모트에 `epic/<name>` 브랜치 존재
   - DB 에 epic 1개 + task N개 (≥1 ready) 존재
 - **관찰 가능 결과**:
   - `git ls-remote origin "refs/heads/epic/auth-token-refresh"` 결과 1줄
-  - `events` 테이블에 kind='epic_started' 1행
+  - `autopilot events list --epic auth-token-refresh --kind epic_started` 1행
 
 ## UC-2. Task 자동 구현 사이클
 
 > 활성 epic 에서 ready task 가 PR 머지까지 진행된다.
 
-- **트리거**: ML 의 `build-tasks` sub-loop tick
+- **트리거**: AG 의 build cycle tick (cron / loop / 수동)
 - **선행 조건**:
   - 활성 epic ≥1
   - 해당 epic 에 status=ready task ≥1
-  - 동시 구현 한도 (`max_parallel_agents`) 미만
+  - AG 가 자체 정한 동시 구현 한도 미만
 - **주 흐름**:
-  1. ML 이 `claim_next_task` 로 ready 한 task 1건을 원자적으로 wip 전환
-  2. ML 이 worktree 를 만들어 IM 을 띄움. task 사양 + 작업 브랜치명 (`epic/<name>/<task_id>`) 을 전달
-  3. IM 이 코드 작성 후 작업 브랜치 push
-  4. ML 이 `branch-promoter` 로 PR 생성 (target=epic 브랜치, `:auto` 라벨)
-  5. ML 이 `merge-prs` sub-loop 에서 CI 통과한 `:auto` PR 머지
-  6. 머지 성공 → ML 이 task.status=done, pr_number 기록
-  7. ML 이 이 task 에 의존하던 blocked/pending 들의 deps 를 재평가, ready 로 승격
+  1. AG 가 `autopilot task claim --epic <name> --json` → ready task 1건 (원자적 wip 전환)
+  2. AG 가 worktree 생성 + 코드 작성 + `epic/<name>/<task_id>` 브랜치 push
+  3. AG 가 PR 생성 (target=epic 브랜치, 라벨 자유)
+  4. AG 가 `autopilot task complete <id> --pr <n>` (또는 PR 머지 후 호출)
+  5. AP 가 task.status=done, pr_number 기록 + 의존하던 blocked/pending 의 deps 재평가하여 ready 승격
 - **대안 흐름**:
-  - claim 시 다른 sub-loop 가 먼저 가져감 → 다음 tick 까지 skip
-  - IM 이 push 실패 → ML 이 task.status=ready 로 되돌리고 attempts 증가 (UC-8 진입 가능)
-  - PR CI 실패 → 기존 `ci-watch` 흐름 적용, 일정 시도 후 escalation (UC-8)
+  - claim 시 동시에 다른 호출자가 가져감 → AP 가 None 반환, AG 는 다음 tick 으로 skip
+  - push 실패 (UC-11 reject) → AG 가 `autopilot task release <id>` (attempts 차감)
+  - 구현/CI 실패 → AG 가 `autopilot task fail <id>` → outcome=Retried 면 다시 ready, Escalated 면 UC-8
 - **사후 조건**: 해당 task.status=done, epic 브랜치에 코드 반영
 - **관찰 가능 결과**:
-  - `events`: claimed → started → completed
-  - GitHub PR closed-merged 상태
+  - `events`: task_claimed → task_completed (+ task_unblocked × N)
+  - GitHub PR closed-merged
 
 ## UC-3. 의존성 있는 Task
 
 > Task B 가 Task A 에 의존할 때, A 완료 전에는 B 가 claim 되지 않는다.
 
-- **트리거**: spec 분해 결과 deps 가 있음
+- **트리거**: 분해 결과 deps 가 있음
 - **선행 조건**: A.status=ready, B.status=pending, B → A 의존성 등록
 - **주 흐름**:
-  1. ML 이 ready 후보 조회 시 B 는 deps 미충족으로 제외 — A 만 claim 가능
-  2. A 가 done 으로 전이됨
-  3. ML 의 `unblock_dependents` 가 B 의 deps 를 재평가 → 모두 done 이면 B.status=ready
-  4. 다음 tick 에서 B claim 가능
+  1. AG 가 `task claim --epic <name>` → AP 가 deps 미충족인 B 는 후보에서 제외, A 만 반환
+  2. A 가 done 으로 전이됨 (UC-2)
+  3. AP 의 `complete_task_and_unblock` 이 B 의 deps 를 재평가 → 모두 done 이면 B.status=ready (자동, 같은 트랜잭션)
+  4. 다음 claim 에서 B 반환 가능
 - **대안 흐름**:
-  - A 가 escalated → B 는 blocked 로 전이 (사람 개입 대기)
-  - A → B → A 사이클 발견 → epic-start 시 검증 단계에서 거부 (UC-1 의 선행 조건 추가)
+  - A 가 escalated → AP 가 자동으로 B 를 blocked 로 전이 (mark_task_failed 의 escalate 분기에서 처리)
+  - A → B → A 사이클 발견 → AP 가 `add-batch` 시점에 `DepCycle` 반환
 - **사후 조건**: 모든 task 가 deps 순서대로만 wip 진입
-- **관찰 가능 결과**: `events` 의 시간순으로 A.completed 가 B.claimed 보다 먼저
+- **관찰 가능 결과**: `events` 의 시간순으로 task_completed(A) 가 task_claimed(B) 보다 먼저
 
 ## UC-4. Epic 이어받기 (다른 사람 / 다른 머신)
 
 > CO 가 OP 의 휴가 중에 같은 epic 을 이어서 진행한다.
 
-- **트리거**: CO 가 `autopilot epic resume auth-token-refresh` 실행
+- **트리거**: CO 의 AG 가 epic 재개를 시도
 - **선행 조건**:
   - 리모트에 `epic/auth-token-refresh` 브랜치 존재
   - CO 의 로컬 DB 에는 해당 epic 행이 없음 (또는 stale)
 - **주 흐름**:
-  1. ML 이 origin 에서 epic 브랜치 fetch
-  2. spec 을 epic 브랜치 시점 기준으로 다시 분해 → 동일한 결정적 task_id 도출
-  3. 리모트의 `epic/<name>/*` 브랜치 + 머지된 PR 을 스캔 (Reconciliation, 03 spec)
-  4. 매칭 결과로 DB 를 idempotent 하게 재구성:
+  1. AG 가 git fetch origin
+  2. AG 가 MN 호출 → 결정적 task_id 재도출 (= 동일 ID)
+  3. AG 가 ls-remote 로 `epic/<name>` + `epic/<name>/*` 브랜치 스캔
+  4. AG 가 PR 스캔 (target=epic 브랜치)
+  5. AG 가 plan.jsonl 작성: tasks + deps + remote_state + orphan_branches
+  6. AG 가 `autopilot epic reconcile --name auth-token-refresh --plan plan.jsonl`
+  7. AP 가 plan 을 idempotent 하게 적용:
      - PR merged → done
      - feature 브랜치 + open PR → wip
-     - feature 브랜치만 있고 PR 없음 → wip (stale 후보)
-     - 브랜치 없음 → ready (deps OK 시) / pending
-  5. epics 행을 active 로 upsert, ML 루프 시작
+     - feature 브랜치만 + PR 없음 → wip (stale 후보, events 기록)
+     - 브랜치 없음 → ready (deps 만족) / pending
 - **대안 흐름**:
-  - 분해 결과에 없는 task_id 의 브랜치/PR 이 발견됨 → orphan 으로 표시, OP/CO 에게 알림
-  - epic 브랜치 자체가 없음 → 에러 종료, `epic-start` 안내
+  - 분해 결과에 없는 task_id 의 브랜치 → orphan_branches 로 plan 에 포함, AP 가 reconciled.payload 에 기록
+  - epic 브랜치 자체가 없음 → AG 가 epic 시작 (UC-1) 안내
 - **사후 조건**: CO 의 로컬 DB 가 OP 의 직전 상태와 의미적으로 동일 (캐시 무손실 복구)
-- **관찰 가능 결과**: `epic-resume` 직후 `epic-status` 출력이 직전 OP 의 출력과 일치
+- **관찰 가능 결과**: `epic status` 출력이 OP 와 일치
 
 ## UC-5. 로컬 DB 손실 후 복구
 
 > OP 의 머신에서 `.autopilot/state.db` 가 삭제됐다.
 
-- **트리거**: DB 파일 부재 상태에서 다음 ML tick 또는 OP 가 `epic resume` 실행
+- **트리거**: DB 파일 부재 상태에서 AG 의 다음 tick
 - **선행 조건**: 리모트의 epic 브랜치/PR 은 그대로 존재
-- **주 흐름**: UC-4 와 동일 (`resume` 이 단일 진입점)
-- **사후 조건**: DB 가 재구성되어 ML 루프가 재개됨. 진행 중이던 task 의 attempts 카운터는 0 으로 초기화 (캐시 손실의 허용 손실)
+- **주 흐름**: UC-4 와 동일 (`epic reconcile` 이 단일 진입점)
+- **사후 조건**: DB 가 재구성. 진행 중이던 task 의 attempts 카운터는 0 으로 초기화 (캐시 손실의 허용 손실)
 - **관찰 가능 결과**: `events` 에 kind='reconciled' 1행, 직전 attempts 정보는 손실됨
 
-## UC-6. Watch 가 발견한 갭 (활성 epic 매칭 가능)
+## UC-6. 갭 발견 (활성 epic 매칭 가능)
 
-> `gap-watch` 가 spec ↔ 코드 갭을 발견했고, 그 spec 은 활성 epic 의 spec 과 일치한다.
+> AG 가 호출한 MN 이 spec ↔ 코드 갭을 발견했고, 그 spec 은 활성 epic 의 spec 과 일치.
 
-- **트리거**: `gap-watch` sub-loop 가 갭 1건 발견
+- **트리거**: AG 의 watch tick 에서 MN 호출
 - **선행 조건**: 발견된 갭의 spec 경로가 활성 epic 의 `spec_path` 와 일치
 - **주 흐름**:
-  1. ML 이 갭의 fingerprint 로 기존 task 중복 검사
-  2. 중복 없으면 새 task 행 (epic_name=매칭 epic, source='gap-watch', status=pending) insert
-  3. deps 가 없으면 즉시 ready 로 승격
+  1. AG 가 `autopilot epic find-by-spec-path <path>` → 매칭 epic 획득
+  2. AG 가 `autopilot task add --epic <name> --id <det_id> --fingerprint <fp> --source gap-watch ...`
+  3. AP 가 fingerprint 중복 검사 → 신규면 insert, 중복이면 `DuplicateFingerprint(existing_id)` 반환
 - **대안 흐름**:
-  - 동일 fingerprint task 가 이미 존재 → skip (멱등성)
-  - 갭의 spec 이 어떤 활성 epic 에도 매칭되지 않음 → UC-7 진입
-- **사후 조건**: 매칭 epic 산하 task 1건 추가
-- **관찰 가능 결과**: `tasks` 행 추가, GitHub 이슈는 발행되지 않음
+  - 동일 fingerprint task 존재 → AG 가 결과 보고 skip (멱등)
+  - spec 이 어떤 활성 epic 에도 매칭 안 됨 → UC-7
+- **사후 조건**: 매칭 epic 산하 task 1건 추가 (또는 멱등 skip)
+- **관찰 가능 결과**: `tasks` 행 추가, GitHub 이슈 미발행
 
-## UC-7. Watch 가 발견한 갭 (활성 epic 없음)
+## UC-7. 갭 발견 (활성 epic 없음)
 
 > 발견된 갭이 어떤 활성 epic 에도 속하지 않는다.
 
-- **트리거**: `gap-watch` / `qa-boost` / `ci-watch` 가 갭 1건 발견
-- **선행 조건**: 갭의 spec 경로가 활성 epic 의 `spec_path` 와 매칭 안 됨
+- **트리거**: AG 의 watch tick 에서 MN 호출
+- **선행 조건**: 갭의 spec 경로가 활성 epic 의 spec_path 와 매칭 안 됨
 - **주 흐름**:
-  1. ML 이 escalation 이슈 발행 (UC-9 의 후처리 대상)
-  2. 이슈 본문에 발견 컨텍스트 + 가능한 epic 후보 (있다면) 명시
-  3. tasks 테이블에는 행을 만들지 않음 — 에픽 미할당 task 는 존재할 수 없다
-- **대안 흐름**: 동일 fingerprint 의 escalation 이슈가 24h 이내 이미 발행됨 → 신규 발행 skip
-- **사후 조건**: GitHub 이슈 1건 신규 (label=`autopilot:hitl-needed`)
-- **관찰 가능 결과**: `events` 에 kind='escalated', target='unmatched_watch', issue_number 기록
+  1. AG 가 `autopilot suppress check --fingerprint <fp> --reason unmatched_watch`
+  2. exit 1 (미억제) 이면 AG 가 GitHub 이슈 발행 (`autopilot:hitl-needed` 라벨)
+  3. AG 가 `autopilot suppress add --fingerprint <fp> --reason unmatched_watch --until <now+24h>`
+  4. AP 는 task 생성 안 함 — epic 미할당 task 는 존재할 수 없다
+- **대안 흐름**: suppress check exit 0 (억제 중) → AG 가 이슈 발행 skip
+- **사후 조건**: GitHub 이슈 1건 신규, suppression 행 1건 신규
+- **관찰 가능 결과**: `events` 에 kind='escalated' (선택), GitHub 이슈 / suppression 테이블
 
 ## UC-8. Task 반복 실패 → Escalate
 
 > 한 task 가 max_attempts 까지 실패했다.
 
-- **트리거**: ML 이 IM 의 push 실패 / PR CI 실패를 N회 누적 관찰
+- **트리거**: AG 가 IM 의 push 실패 / PR CI 실패를 인지
 - **선행 조건**: task.attempts == max_attempts (직전 실패 처리 시점)
 - **주 흐름**:
-  1. ML 이 `mark_task_failed` 호출 → `TaskFailureOutcome::Escalated` 응답 받음
-  2. ML 이 escalation 이슈 발행 (task_id, 시도 로그 요약 포함)
-  3. task.status=escalated, escalated_issue=이슈번호 기록
-  4. 이 task 에 의존하던 다른 task 들은 blocked 로 전이
-- **대안 흐름**:
-  - attempts < max → status=ready 로 되돌리고 다음 cycle 재시도
-  - 동일 task 가 이미 escalated → 추가 이슈 발행 안 함
+  1. AG 가 `autopilot task fail <id>` → AP 가 outcome 결정:
+     - attempts < max → `Retried`. AP 가 status=ready 로 복귀, attempts 보존
+     - attempts ≥ max → `Escalated`. AP 가 status=escalated 로 전이 + 의존 task 들 자동 blocked
+  2. outcome=Escalated 면 AG 가 GitHub 이슈 발행
+  3. AG 가 `autopilot task escalate <id> --issue <n>` → AP 가 escalated_issue 기록 + event
+- **대안 흐름**: attempts < max → AG 는 다음 tick 에 재시도
 - **사후 조건**: task.status=escalated, 의존 task 들 blocked
-- **관찰 가능 결과**: `events`: failed → escalated, GitHub 이슈 1건
+- **관찰 가능 결과**: `events`: task_failed → task_escalated, GitHub 이슈 1건
 
 ## UC-9. 사람이 Escalation 이슈 처리
 
 > OP/CO 가 escalation 이슈를 받고 결정을 내린다.
 
-- **트리거**: 사람이 GitHub 에서 escalation 이슈에 결정 코멘트 또는 라벨 변경
+- **트리거**: 사람이 GitHub 에서 escalation 이슈를 close 또는 라벨 변경
 - **선행 조건**: 이슈 label=`autopilot:hitl-needed` + 본문에 epic/task 메타 포함
 - **주 흐름** (이슈 처리 패턴별):
-  - **(a) 새 epic 으로 승격**: 사람이 이슈에 `/autopilot epic-start <spec>` 코멘트 또는 운영자가 CLI 실행
-  - **(b) 기존 epic 에 흡수**: `analyze-issue` 가 이슈 본문에서 spec 매칭 후 task 행 신규 insert (UC-6 와 동일 흐름)
-  - **(c) 거부 / 무시**: 사람이 이슈 close → ML 은 더 이상 해당 fingerprint 를 escalate 하지 않도록 suppression 기록
-  - **(d) max-attempts 후 사람이 직접 수정**: 사람이 코드를 직접 작성하고 task 의 escalated_issue 이슈를 close → ML 은 reconcile 시 해당 task 가 done 으로 전이된 것으로 인식
+  - **(a) 새 epic 으로 승격**: 사람이 OP 에게 요청 → AG 가 UC-1 흐름. 기존 escalation 이슈는 사람이 close
+  - **(b) 기존 epic 에 흡수**: AG 가 issue 분석 후 spec 매칭 → `task add --source human` (UC-6 와 같은 흐름). 이슈 close + 코멘트
+  - **(c) 거부 / 무시**: 사람이 close → AG 의 다음 escalation polling 에서 close 감지:
+    - reconcile 시도 → status 변화 없음 → AG 가 `autopilot suppress add --reason rejected_by_human --until <now+30d>`
+  - **(d) 사람이 직접 코드 수정**: 사람이 코드 push + PR merge + escalation 이슈 close → AG 의 polling 이 close 감지 → `epic reconcile` 호출 → AP 가 task.status=done 으로 전이
 - **사후 조건**: 이슈 closed, 결과에 따라 새 task / 기존 task 상태 갱신
-- **관찰 가능 결과**: `events` 에 kind='escalation_resolved', resolution=(a|b|c|d)
+- **관찰 가능 결과**: `events` 에 kind='escalation_resolved', payload.resolution=(a|b|c|d 에 해당하는 값)
 
 ## UC-10. Epic 완료 → main 머지 (반자동)
 
 > 한 epic 의 모든 task 가 done 이 되었다.
 
-- **트리거**: 마지막 task 가 done 으로 전이된 직후 ML 의 cycle
-- **선행 조건**: epic 산하 task 의 status 가 모두 (done | escalated 중 사람이 close 한 것)
+- **트리거**: AG 의 cycle 에서 `autopilot epic status` 가 all-done 보고
+- **선행 조건**: epic 산하 task 의 status 가 모두 done (escalated 가 남아 있으면 UC-9 의 처리 후 done 또는 force-status 필요)
 - **주 흐름**:
-  1. ML 이 epic.status=completed, completed_at 기록
-  2. ML 의 epic 스코프 cron 루프 종료
-  3. 사용자 알림 발송 (notification 설정 사용)
-  4. **OP 가 직접** epic → main PR 생성 — 자동화하지 않음
+  1. AG 가 `autopilot epic complete <name>` → AP 가 status=completed, completed_at 기록
+  2. AG 가 사용자 알림 (notification 채널은 AG 의 책임)
+  3. **OP 가 직접** epic → main PR 생성 — 자동화 안 함
 - **대안 흐름**:
-  - 일부 task 가 escalated 인 채로 남아 있으나 사람이 모두 close → done 으로 reconcile 후 완료 처리
-- **사후 조건**: epic.status=completed, ML 의 해당 epic 루프 부재
-- **관찰 가능 결과**: `events`: epic_completed, 알림 송신 로그
+  - 일부 task 가 escalated 인 채로 남아 있고 사람이 close 만 했음 → AG 가 reconcile 또는 `task force-status <id> --to done --reason "rejected resolved"` 후 epic complete
+- **사후 조건**: epic.status=completed
+- **관찰 가능 결과**: `events`: epic_completed, AG 의 알림 송신 로그
 
 ## UC-11. 두 머신에서 같은 Epic 동시 진행 (충돌 자연 차단)
 
 > OP 와 CO 가 모르는 사이에 같은 epic 을 동시에 resume 하여 같은 task 를 구현하려 한다.
 
-- **트리거**: 두 머신에서 거의 동시에 동일 task_id 를 claim
+- **트리거**: 두 머신의 AG 가 거의 동시에 동일 task 를 claim
 - **선행 조건**: 둘 다 reconcile 후 동일 task 가 ready 로 보임
 - **주 흐름**:
-  1. 머신 A 의 IM 이 `epic/<name>/<task_id>` 브랜치 push 성공
-  2. 머신 B 의 IM 이 같은 이름 브랜치 push 시도 → non-fast-forward reject
-  3. 머신 B 의 ML 이 push 실패를 감지 → 해당 task.status=ready 로 되돌리고 다음 reconcile 에서 wip (다른 머신이 가져감) 으로 재인식
+  1. AP 의 `claim_next_task` 의 원자적 UPDATE 가 한 쪽만 winner — 다른 쪽은 None 반환 (같은 머신 내 race)
+  2. 다른 머신 케이스에선 둘 다 winner 처럼 보일 수 있음 → 하지만 git push 단계에서 한 쪽이 reject
+  3. reject 받은 머신의 AG 가 `autopilot task release <id>` 호출 (attempts 차감)
   4. 동일 task 의 PR 은 머신 A 의 것 1개만 존재
-- **대안 흐름**:
-  - 두 IM 의 코드가 다른 경우에도 git 차원에서 한 쪽만 살아남음. 머신 B 는 작업 결과 폐기
+- **대안 흐름**: 두 IM 의 코드가 다른 경우에도 git 차원에서 한 쪽만 살아남음. 머신 B 는 작업 결과 폐기
 - **사후 조건**: task 1건 = PR 1건. 중복 PR 없음
-- **관찰 가능 결과**: 머신 B 의 `events` 에 kind='claim_lost', upstream_existed=true
+- **관찰 가능 결과**: 머신 B 의 `events` 에 kind='claim_lost'
 
 ## UC-12. 운영자가 Epic 강제 중단
 
 > OP 가 진행 중 epic 을 더 이상 진행하지 않기로 결정한다.
 
-- **트리거**: OP 가 `autopilot epic stop <name>` 실행
+- **트리거**: OP → AG 에게 중단 요청
 - **선행 조건**: epic.status=active
 - **주 흐름**:
-  1. ML 이 epic.status=abandoned 로 전이
-  2. 진행 중이던 task 들 중 wip 상태는 그대로 둠 (현재 push 된 코드는 보존)
-  3. epic 스코프 ML 루프 종료
-  4. 새 task claim 중단
+  1. AG 가 `autopilot epic abandon <name>` → AP 가 status=abandoned 로 전이
+  2. AG 는 다음 cycle 부터 해당 epic 에 대해 task claim 시도 안 함
+  3. 진행 중이던 task 들 중 wip 상태는 그대로 둠 (현재 push 된 코드는 보존)
 - **대안 흐름**:
-  - `--purge-branches` 플래그가 주어지면 머지되지 않은 feature 브랜치 정리 옵션 (기본 OFF)
+  - OP 가 `--purge-branches` 같은 정책을 원하면 AG 가 ls-remote + `git push --delete` 직접 수행 (autopilot 은 git 미관여)
 - **사후 조건**: 해당 epic 의 새 작업이 진행되지 않음. 리모트의 코드는 보존
 - **관찰 가능 결과**: `events`: epic_abandoned
 
 ## UC-13. 라벨 기반 → DB 기반 마이그레이션
 
-> 기존 `:ready` 라벨 기반으로 운영하던 레포에서 epic 기반으로 전환한다.
+> 기존 `:ready` 라벨 기반으로 운영하던 레포에서 ledger 기반으로 전환한다.
 
-- **트리거**: OP 가 `epic_based: true` 설정 후 `autopilot migrate import-issue <#>` 실행
+- **트리거**: OP → AG 에게 마이그레이션 요청
 - **선행 조건**: 활성 epic ≥1, 대상 이슈가 `:ready` 상태
 - **주 흐름**:
-  1. ML 이 이슈 본문/제목에서 spec 매칭 시도
-  2. 매칭된 epic 의 task 로 신규 insert (source='human', body에 원래 이슈 번호 메타로 기록)
-  3. 이슈에는 자동으로 코멘트 추가: "task <id> 로 흡수됨, label `:ready` 제거"
-  4. 이슈에서 `:ready` 라벨 제거 (autopilot 이 더 이상 큐로 보지 않게)
+  1. AG 가 `gh issue view <#>` 로 본문 / 제목 분석
+  2. AG 가 spec 매칭 (어느 epic 에 속할지)
+  3. 매칭 epic 의 `task add --source human --body "<원본 issue #N>"`
+  4. AG 가 이슈에 코멘트 추가: "task <id> 로 흡수됨"
+  5. AG 가 `:ready` 라벨 제거
 - **대안 흐름**:
   - 매칭 실패 → UC-7 의 escalation 형태로 유지 또는 사람이 수동 mapping
 - **사후 조건**: 이슈는 살아 있되 라벨이 정리됨, 새 task 행 1건
-- **관찰 가능 결과**: `events`: kind='migrated_from_issue', issue_number 기록
+- **관찰 가능 결과**: 새 task 의 source='human', body 에 원본 이슈 번호 메타
 
-## 시나리오 ↔ 인터페이스 매핑 (요약)
+## 시나리오 ↔ Autopilot 트레이트 메서드 매핑 (요약)
 
-| UC | 도출되는 핵심 인터페이스 / 동작 |
-|----|------------------------------|
-| 1 | `EpicManager::start`, `TaskStore::insert_epic_with_tasks` (트랜잭션) |
-| 2 | `TaskStore::claim_next_task` (원자성), `TaskStore::mark_task_done` |
-| 3 | `TaskStore::list_ready_tasks` 의 deps 필터, `unblock_dependents` |
-| 4-5 | `Reconciler::reconcile_epic`, 결정적 `task_id` 함수 |
-| 6 | `TaskStore::find_by_fingerprint`, watch 측의 epic 매칭 함수 |
-| 7-9 | `Escalator::escalate`, suppression 기록, `analyze-issue` 의 흡수 경로 |
-| 8 | `mark_task_failed` → `TaskFailureOutcome` 분기 |
-| 10 | epic 완료 판정 + 알림. main 머지는 자동화 대상 아님 |
-| 11 | claim 의 원자성 + git push reject 자연 처리 |
-| 12 | `EpicManager::stop`, abandoned 상태 |
-| 13 | 마이그레이션 CLI + 이슈 → task 흡수 |
+| UC | Agent CLI 호출 | Autopilot 트레이트 메서드 |
+|----|--------------|------------------------|
+| 1 | `epic create`, `task add-batch` | `EpicRepo::upsert_epic`, `TaskRepo::insert_epic_with_tasks` |
+| 2 | `task claim`, `task complete \| fail \| release`, `task escalate` | `claim_next_task`, `complete_task_and_unblock`, `mark_task_failed`, `release_claim`, `escalate_task` |
+| 3 | (UC-2 와 동일) | `claim_next_task` 의 deps 필터, `complete_task_and_unblock` 의 unblock |
+| 4-5 | `epic reconcile --plan ...` | `apply_reconciliation` |
+| 6 | `epic find-by-spec-path`, `task add` | `find_active_by_spec_path`, `upsert_watch_task` |
+| 7 | `suppress check`, `suppress add` | `is_suppressed`, `suppress` |
+| 8 | `task fail`, `task escalate` | `mark_task_failed`, `escalate_task` |
+| 9 | `epic reconcile`, `suppress add`, `task force-status` | `apply_reconciliation`, `suppress`, `force_status` |
+| 10 | `epic status`, `epic complete` | `list_epics`, `set_epic_status` |
+| 11 | `task release` | `release_claim` |
+| 12 | `epic abandon` | `set_epic_status` |
+| 13 | `task add --source human` | `upsert_watch_task` (source=Human) |
 
-이 매핑은 02 (아키텍처) 의 모듈 경계와 03 (상세 스펙) 의 trait 시그니처가 충족해야 하는 최소 요구사항이다.
+이 매핑은 02 (아키텍처) 의 모듈 경계와 03 (상세 스펙) 의 trait 시그니처가 충족해야 하는 최소 요구사항이다. **Agent 측의 워크플로 통합 검증은 본 spec 의 책임이 아니다** — 04 §1 참조.

--- a/plans/github-autopilot/02-architecture.md
+++ b/plans/github-autopilot/02-architecture.md
@@ -23,7 +23,7 @@
 +----------------------------v---------------------------+
 |                    Orchestration                       |
 |  EpicManager  BuildLoop  WatchDispatcher  Reconciler   |
-|              MergeLoop   Escalator                     |
+|  MergeLoop    Escalator  EscalationWatcher             |
 +----------------------------+---------------------------+
                              |
 +----------------------------v---------------------------+
@@ -94,9 +94,10 @@ plugins/github-autopilot/cli/src/
 │   ├── epic_manager.rs              # start / resume / stop / status
 │   ├── build_loop.rs                # claim → IM 호출 → push 결과 처리
 │   ├── watch_dispatcher.rs          # watch 결과 → epic 매칭 / append / escalate
-│   ├── merge_loop.rs                # PR 머지 + task done 전이
+│   ├── merge_loop.rs                # PR 머지 + task done 전이 + epic 완료 판정
 │   ├── reconciler.rs                # git remote ↔ DB
-│   └── escalator.rs                 # escalation 이슈 + suppression
+│   ├── escalator.rs                 # escalation 이슈 + suppression
+│   └── escalation_watcher.rs        # escalated task 의 issue close 폴링 → reconcile
 │
 └── cmd/                             # CLI 핸들러 (clap subcommand 매핑)
     ├── mod.rs
@@ -289,9 +290,9 @@ src/store/migrations/
 | 3 | TaskStore | claim 시 deps 필터, complete 시 unblock_dependents |
 | 4-5 | TaskStore + GitClient + SpecDecomposer + GitHubClient | Reconciler::reconcile_epic → fetch + ls-remote + PR 스캔 → apply_reconciliation |
 | 6 | TaskStore | WatchDispatcher::dispatch → epic 매칭 → upsert task |
-| 7-9 | GitHubClient + TaskStore | Escalator::escalate → 이슈 발행 + escalated_issue 기록 |
+| 7-9 | GitHubClient + TaskStore | Escalator::escalate → 이슈 발행 + escalated_issue 기록. EscalationWatcher → 사람이 close 한 이슈 자동 인식 → reconcile |
 | 8 | TaskStore | mark_task_failed → outcome 분기 |
-| 10 | TaskStore + Notifier | EpicManager::check_completion → notifier.send |
+| 10 | TaskStore + Notifier | MergeLoop::tick → all_tasks_done 판정 → notifier.send. escalated 잔류 시 EpicCompleted 미발송 (사람이 force-status 또는 코드 push 로 해소해야 함) |
 | 11 | GitClient | BuildLoop 의 push reject 처리 (DB 변경 없음) |
 | 12 | TaskStore | EpicManager::stop → epic.status=abandoned |
 | 13 | TaskStore + GitHubClient | MigrateCommand → import_issue → upsert task + 이슈 라벨 정리 |

--- a/plans/github-autopilot/02-architecture.md
+++ b/plans/github-autopilot/02-architecture.md
@@ -6,112 +6,108 @@
 
 | 원칙 | 본 시스템에서의 의미 |
 |------|------------------|
-| **SRP** | 도메인 / 포트 / 어댑터 / 오케스트레이션 / CLI 레이어를 분리. 한 모듈은 하나의 변경 이유만 갖는다 |
-| **OCP** | 새 watch 종류, 새 알림 채널, 새 spec 분해기 추가 시 기존 코드 수정 없이 어댑터만 추가 |
+| **SRP** | autopilot 은 ledger + CLI 만 담당. 탐지 / 결정 / 구현은 외부 Agent |
+| **OCP** | 새 EventKind / 새 TaskStatus 추가 시 도메인 enum 확장만으로 흡수 |
 | **LSP** | 인메모리 TaskStore 와 SQLite TaskStore 가 동일 계약 (트랜잭션 의미 포함) 을 만족 |
-| **ISP** | 큰 단일 trait 대신 `EpicRepo`, `TaskRepo`, `EventLog` 등 역할별 분리. `TaskStore` 는 이들의 슈퍼트레이트 형태 |
-| **DIP** | 오케스트레이션은 포트(trait)에만 의존. CLI 진입점이 컴포지션 루트로서 어댑터를 wiring |
+| **ISP** | 큰 단일 trait 대신 `EpicRepo` / `TaskRepo` / `EventLog` / `SuppressionRepo` 로 분리. `TaskStore` 는 슈퍼트레이트 |
+| **DIP** | CLI 진입점은 trait 에만 의존. 어댑터는 컴포지션 루트에서 주입 |
 
 ## 2. 레이어와 의존성 방향
 
+autopilot 자체는 단일 프로세스 / 단일 책임이다. **Agent 는 외부** 요소로, autopilot 의 의존 그래프 밖에 있다.
+
 ```
+                 ┌────────────────────────────────────┐
+                 │  Agent (Claude Code 세션, autodev,  │
+                 │   GitHub Actions, ...)              │
+                 │  - monitor 호출 / 분해 / 구현 / PR │
+                 │  - escalation 이슈 발행            │
+                 └─────────────┬──────────────────────┘
+                               │ CLI 호출 (autopilot ...)
+                               ▼
 +--------------------------------------------------------+
-|                     cmd / CLI 진입점                    |  <- 컴포지션 루트
-|         (epic_start, epic_resume, watch, build, ...)   |
-+----------------------------+---------------------------+
-                             |
-+----------------------------v---------------------------+
-|                    Orchestration                       |
-|  EpicManager  BuildLoop  WatchDispatcher  Reconciler   |
-|  MergeLoop    Escalator  EscalationWatcher             |
+|                cmd / CLI 진입점                         |  <- 컴포지션 루트
+|  (epic, task, suppress, events, worktree, labels, ...) |
 +----------------------------+---------------------------+
                              |
 +----------------------------v---------------------------+
 |                       Ports (trait)                    |
-|  TaskStore  GitClient  GitHubClient  SpecDecomposer    |
-|             Notifier   Clock         IdGenerator       |
+|  TaskStore (= EpicRepo + TaskRepo + EventLog +         |
+|              SuppressionRepo)         Clock            |
 +----------------------------+---------------------------+
-                             |  (구현 의존성은 오직 한 방향)
+                             |
 +----------------------------v---------------------------+
 |                       Adapters                         |
-|  SqliteTaskStore  GitCli  GitHubMcpClient              |
-|                   SpecKitDecomposer  StdClock          |
+|  InMemoryTaskStore   SqliteTaskStore   StdClock        |
 +--------------------------------------------------------+
                              ^
                              |
 +----------------------------+---------------------------+
 |                   Domain (pure)                        |
 |  Epic  Task  TaskId  TaskStatus  TaskSource            |
-|  TaskFailureOutcome  Event  TaskGraph (deps)           |
+|  TaskFailureOutcome  Event  EventKind  TaskGraph       |
+|  DomainError                                           |
 +--------------------------------------------------------+
 ```
 
 엄격한 규칙:
 
-- **Domain 모듈은 어떤 외부 의존성도 갖지 않는다** — std + serde 만 허용
-- **Orchestration 은 어댑터를 직접 import 하지 않는다** — 오직 `ports` 의 trait 만
-- **Adapter 는 다른 adapter 를 직접 호출하지 않는다** — 필요하면 orchestration 으로 끌어올린다
-- **CLI cmd 는 orchestration 을 호출하지 직접 store/git 를 호출하지 않는다** — 단순 출력 변환과 wiring 만
+- **Domain 모듈은 어떤 외부 의존성도 갖지 않는다** — std + serde + chrono 만 허용
+- **CLI cmd 는 trait 만 호출** — adapter 를 직접 생성하지 않음 (`main.rs` 가 wiring)
+- **Adapter 는 다른 adapter 를 직접 호출하지 않는다**
+- **autopilot 코드는 git/github/Claude Code/spec-kit 을 직접 호출하지 않는다** — 그 책임은 agent 의 영역
+
+기존 헬퍼 명령 (`worktree`, `pipeline idle`, `watch run`, `issue`, `labels`, ...) 은 이 다이어그램의 **CLI 진입점** 에 함께 위치한다. 그들은 ledger 와 무관하게 자체 어댑터 (`GhOps`, `GitOps`, `FsOps`) 를 사용하며, agent 가 호출하는 도구 모음으로 분류된다.
 
 ## 3. 모듈 배치 (Rust)
 
-기존 `plugins/github-autopilot/cli/` 단일 crate 를 유지한다. 워크스페이스로 분할하지 않는 이유: 현재 외부 재사용 요구가 없고, 단일 crate 안에서 mod 경계만으로도 위 규칙을 강제할 수 있다.
-
 ```
 plugins/github-autopilot/cli/src/
-├── main.rs
-├── lib.rs                           # pub mod 선언만
+├── main.rs                          # 컴포지션 루트
+├── lib.rs                           # pub mod 선언
 │
-├── domain/                          # pure, no I/O
+├── domain/                          # pure
 │   ├── mod.rs
-│   ├── epic.rs                      # Epic, EpicStatus
-│   ├── task.rs                      # Task, TaskId, TaskStatus, TaskSource
-│   ├── task_id.rs                   # 결정적 ID 함수
-│   ├── deps.rs                      # TaskGraph, cycle detection
-│   └── event.rs                     # Event, EventKind
+│   ├── epic.rs
+│   ├── task.rs
+│   ├── task_id.rs
+│   ├── deps.rs
+│   ├── event.rs
+│   └── error.rs
 │
 ├── ports/                           # trait only
 │   ├── mod.rs
-│   ├── task_store.rs                # TaskStore (= EpicRepo + TaskRepo + EventLog)
-│   ├── git.rs                       # GitClient
-│   ├── github.rs                    # GitHubClient (이슈/PR)
-│   ├── decompose.rs                 # SpecDecomposer
-│   ├── notifier.rs                  # Notifier
-│   └── clock.rs                     # Clock
+│   ├── task_store.rs                # TaskStore = EpicRepo + TaskRepo
+│   │                                #             + EventLog + SuppressionRepo
+│   └── clock.rs
 │
 ├── store/
-│   └── sqlite.rs                    # SqliteTaskStore impl TaskStore
-│
-├── git.rs                           # (기존) GitCli impl GitClient
-├── github.rs                        # (기존) impl GitHubClient via gh
-├── gh.rs                            # (기존) gh CLI helper
-│
-├── decompose/
-│   └── speckit.rs                   # SpecKitDecomposer
-│
-├── orchestration/
 │   ├── mod.rs
-│   ├── epic_manager.rs              # start / resume / stop / status
-│   ├── build_loop.rs                # claim → IM 호출 → push 결과 처리
-│   ├── watch_dispatcher.rs          # watch 결과 → epic 매칭 / append / escalate
-│   ├── merge_loop.rs                # PR 머지 + task done 전이 + epic 완료 판정
-│   ├── reconciler.rs                # git remote ↔ DB
-│   ├── escalator.rs                 # escalation 이슈 + suppression
-│   └── escalation_watcher.rs        # escalated task 의 issue close 폴링 → reconcile
+│   ├── memory.rs                    # InMemoryTaskStore
+│   ├── sqlite.rs                    # SqliteTaskStore
+│   └── migrations/                  # V1, V2, ...
 │
-└── cmd/                             # CLI 핸들러 (clap subcommand 매핑)
-    ├── mod.rs
-    ├── epic.rs                      # start / resume / stop / status
-    ├── watch/                       # (기존, 일부 변경)
-    ├── pipeline.rs                  # (기존, build-tasks/merge-prs 진입)
-    └── ...
+├── cmd/
+│   ├── mod.rs
+│   ├── epic.rs                      # ledger CLI (신규)
+│   ├── task.rs                      # ledger CLI (확장)
+│   ├── suppress.rs                  # ledger CLI (신규)
+│   ├── events.rs                    # ledger CLI (신규)
+│   │
+│   ├── pipeline.rs                  # 기존 헬퍼 (idle 등 유지)
+│   ├── watch/                       # 기존 헬퍼 (이벤트 emitter)
+│   ├── worktree.rs                  # 기존 헬퍼
+│   ├── issue.rs, issue_list.rs      # 기존 헬퍼
+│   ├── labels.rs                    # 기존 헬퍼
+│   ├── preflight.rs, simhash.rs     # 기존 헬퍼
+│   ├── stats.rs, check/             # 기존 헬퍼
+│   └── ...
+│
+├── git.rs, github.rs, gh.rs, fs.rs  # 기존 헬퍼 어댑터 (GitOps/GhOps/...)
+└── ...
 ```
 
-기존 파일과의 관계:
-
-- `git.rs`, `github.rs`, `gh.rs` 는 그대로 두되, 새 `ports` 의 trait 을 구현하도록 시그니처를 정리한다 (어댑터화)
-- `cmd/issue.rs`, `cmd/issue_list.rs`, `cmd/labels.rs` 는 epic 기반 전환 후 일부 사용. 04 watch-integration 에서 다룸
-- `cmd/pipeline.rs` 의 build-issues 흐름은 build-tasks 흐름으로 대체 (UC-2 매핑)
+기존 `git.rs`, `github.rs`, `gh.rs`, `fs.rs` 와 `cmd/pipeline.rs`, `cmd/watch/`, `cmd/worktree.rs`, `cmd/issue*.rs`, `cmd/labels.rs`, `cmd/check/`, `cmd/preflight.rs`, `cmd/simhash.rs`, `cmd/stats.rs` 는 그대로 유지한다. **그들은 ledger 와 결합되지 않으며**, agent 가 자기 워크플로에서 자유롭게 호출한다.
 
 ## 4. 핵심 포트 (인터페이스 윤곽)
 
@@ -119,65 +115,47 @@ plugins/github-autopilot/cli/src/
 
 ### 4.1 TaskStore
 
-DB 의 epic / task / dep / event 행에 대한 CRUD + 상태 전이.
+DB 의 epic / task / dep / event / suppression 행에 대한 CRUD + 상태 전이.
 
-- **책임**: 원자적 상태 전이, 결정적 ID 보존, 이벤트 기록
-- **비책임**: spec 분해, git 호출, 이슈 발행
+- **책임**: 원자적 상태 전이, 결정적 ID 보존, 이벤트 기록, fingerprint 억제
+- **비책임**: spec 분해, git 호출, 이슈 발행, 알림, 의사결정
 - **분할 trait** (ISP):
-  - `EpicRepo`: epic 행
-  - `TaskRepo`: task 행 + deps + claim/done/fail
+  - `EpicRepo`: epic 행 + spec_path 매칭
+  - `TaskRepo`: task 행 + deps + claim/release/complete/fail/escalate/force-status + reconcile 적용
   - `EventLog`: event 행 append/query
-- 슈퍼트레이트 `TaskStore: EpicRepo + TaskRepo + EventLog` 로 통합
+  - `SuppressionRepo`: fingerprint × reason → until 매핑
+- 슈퍼트레이트 `TaskStore: EpicRepo + TaskRepo + EventLog + SuppressionRepo` 로 통합
 
-### 4.2 GitClient
+### 4.2 Clock
 
-git 명령어의 추상.
+테스트 격리용 시간 주입. autopilot 자체가 직접 의존하는 유일한 외부 포트.
 
-- **책임**: branch 생성/삭제/push/fetch, ls-remote 스캔, working tree 상태 조회
-- **비책임**: GitHub API (PR/이슈)
-- 구현체: `GitCli` (subprocess), 테스트용 `InMemoryGit`
+- 구현체: `StdClock`, `FixedClock` (테스트)
 
-### 4.3 GitHubClient
+### 4.3 외부 의존 도구 (autopilot 내부 포트가 아님)
 
-GitHub API 의 추상.
+다음은 **agent 의 책임 영역** 으로, autopilot 의 trait 시스템에 들어가지 않는다:
 
-- **책임**: PR / 이슈 / 라벨 / 코멘트
-- **비책임**: git 자체 동작
-- 구현체: `GitHubMcpClient` (MCP 도구 경유 / 또는 기존 `gh` CLI), 테스트용 `FakeGitHub`
+- spec 분해기 (spec-kit / 자체 markdown 파서 / LLM prompt — agent 가 채택)
+- git/GitHub 클라이언트 (agent 가 사용. autopilot 의 기존 헬퍼 명령은 그 위에서 동작)
+- 알림 (notification — agent 가 자기 알림 채널 사용)
+- 분해 결과 캐시 / artifact 저장 — agent 가 책임
 
-### 4.4 SpecDecomposer
-
-spec 마크다운을 task 후보 목록으로 분해.
-
-- **책임**: spec 파일 읽기 + 결정적 task_id 부여 + 의존성 추출
-- **비책임**: DB insert (호출자가 함)
-- 구현체: `SpecKitDecomposer` (기존 spec-kit 플러그인 호출), 테스트용 `FakeDecomposer`
-
-### 4.5 Notifier
-
-epic 완료 / escalation 등 사용자 알림.
-
-- **책임**: 메시지 송신
-- **비책임**: 메시지 내용 결정 (호출자가 정함)
-- 구현체: `NotificationConfigured` (기존 notification 설정 사용), `FakeNotifier`
-
-### 4.6 Clock / IdGenerator
-
-테스트 격리용 시간 / 외부 ID (escalation 시 fingerprint suppression key 등) 주입.
-
-- 구현체: `StdClock`, `FixedClock` (테스트), `Sha256IdGen` 등
+이 분리 덕분에 autopilot 은 단일 의존성 (SQLite + Clock) 만 가지며, 테스트 / 배포 / 마이그레이션이 단순하다.
 
 ## 5. 트랜잭션 경계
 
-DB 의 일관성 보장은 `TaskStore` 의 메서드 단위에서 보장된다. 호출자(orchestration)는 트랜잭션을 직접 열지 않는다.
+DB 의 일관성 보장은 `TaskStore` 의 메서드 단위에서 보장된다. 호출자(CLI)는 트랜잭션을 직접 열지 않는다.
 
 | 메서드 | 트랜잭션 범위 |
 |--------|------------|
 | `insert_epic_with_tasks` | epic + 모든 task + 모든 dep + 진입점 ready 승격을 한 tx |
 | `claim_next_task` | 후보 SELECT + UPDATE WHERE status='ready' + claimed event INSERT 한 tx (changes()==1 검증) |
 | `complete_task_and_unblock` | task done UPDATE + 이 task 에 의존하던 blocked 들의 deps 재평가 + ready 승격 + completed event 한 tx |
-| `mark_task_failed` | attempts 증가 + (재시도 가능이면) ready 복귀 / (max 도달이면) escalated 전이 + event 한 tx. 반환값으로 outcome 알림 |
-| `escalate_task` | escalated 전이 + escalated_issue 기록 + 의존 task 들 blocked 전이 + event 한 tx |
+| `mark_task_failed` | attempts 증가 + (재시도 가능이면) ready 복귀 / (max 도달이면) escalated 전이 + 의존 task 들 blocked + event 한 tx. 반환값으로 outcome 알림 |
+| `escalate_task` | escalated 전이 + escalated_issue 기록 + event 한 tx |
+| `release_claim` | wip → ready + attempts -1 한 tx |
+| `force_status` | 임의 상태 → target + force_status event 한 tx (자식 unblock 안 함) |
 | `apply_reconciliation` | reconcile 결과 (변경 행들) 을 한 tx 로 반영. orphan 처리 포함 |
 | `append_event` (단일) | 자동 commit |
 
@@ -185,11 +163,9 @@ DB 의 일관성 보장은 `TaskStore` 의 메서드 단위에서 보장된다. 
 
 ## 6. 동시성 정책
 
-### 6.1 단일 writer 가정
+### 6.1 단일 머신 — 다중 CLI 호출
 
-DB 는 메인 autopilot 프로세스 (ML) 만 쓴다. 같은 머신의 다른 프로세스가 DB 를 직접 만지지 않으며, 자식 IM 도 DB 미접근. 다른 머신은 `epic-resume` 으로 reconcile 후 자기 DB 를 가짐.
-
-이 가정 하에 동시 접근자는 메인 프로세스 안의 sub-loop 들 (`gap-watch`, `build-tasks`, `merge-prs`, `qa-boost`, `ci-watch`, `epic_manager`) 뿐이다.
+배포 모델은 **머신당 `.autopilot/state.db` 1개**. autopilot 은 **장수 데몬을 안 만든다**. 매 호출이 별도 프로세스 — cron tick 의 `autopilot task claim` 과 운영자의 `autopilot task force-status` 가 동시 실행될 수 있다.
 
 ### 6.2 SQLite 모드
 
@@ -201,18 +177,20 @@ PRAGMA foreign_keys = ON;
 ```
 
 - WAL: 다중 reader / 단일 writer 동시 동작
-- BUSY 5s: sub-loop 간 짧은 충돌 자연 해소
+- BUSY 5s: 짧은 충돌 자연 해소
 - FK: deps / events 의 무결성
 
-### 6.3 sub-loop 직렬화
+이 셋만으로 다중 프로세스 호출이 안전하다. 데이터 손상은 없다.
 
-Rust 차원에서는 단일 `Arc<dyn TaskStore>` 를 공유한다. SqliteTaskStore 내부에 `Mutex<Connection>` (단일 connection) 또는 `r2d2::Pool` (multi-conn + WAL) 중 후자를 선택한다. 사유: 읽기 다중 + 쓰기 BUSY 대기로 단순.
+### 6.3 Race window 와 정책
 
-쓰기 메서드는 짧게 유지하여 BUSY 충돌을 최소화한다 (특히 reconcile 같은 큰 작업은 staged commit 으로 분할 — 03 에서 다룸).
+상태 전이 메서드의 SELECT-then-UPDATE 가 별 트랜잭션이면 race 시 audit payload 에 약간의 부정확이 가능 (예: `force_status` 의 `from` 이 직전 값과 어긋남). 이 정도는 **운영 모델에서 수용** — autopilot 은 spec 의 단일 작가 가정 하에 잘 동작하며, multi-process 도 데이터 무결성 위반 없이 동작.
+
+`claim_next_task` 의 원자성 (단일 UPDATE WHERE) 만은 엄격히 보장한다 — task 가 두 caller 에 동시 할당되면 git push reject 로 자연 차단되긴 하나, DB 차원에서도 한 명만 winner 가 되도록 한다 (UC-11).
 
 ### 6.4 git push 차원의 동시성
 
-UC-11 의 두 머신 케이스는 git remote 에서 자연 차단된다 (non-fast-forward reject). orchestration 의 BuildLoop 는 IM 의 push 결과를 항상 검사하고 reject 시 task 를 ready 로 되돌린다.
+UC-11 (두 머신 / 두 프로세스가 같은 task 를 동시에 claim 후 push) 은 git remote 가 자연 차단 (non-fast-forward reject). agent 는 push 결과를 검사하고 reject 시 `autopilot task release` 호출.
 
 ## 7. 에러 처리 정책
 
@@ -220,51 +198,44 @@ UC-11 의 두 머신 케이스는 git remote 에서 자연 차단된다 (non-fas
 
 | 분류 | 예시 | 처리 |
 |------|------|------|
-| **Domain error** | invalid status transition, dep cycle | 호출자에게 `Result::Err`. 발생 시 작업 중단 |
-| **Storage error** | DB 락, 디스크 full | 재시도 (BUSY) → 그래도 실패 시 sub-loop 종료 + 알림 |
-| **Network error** | git fetch 실패, GitHub API 타임아웃 | exponential backoff 재시도 (4회). 그래도 실패 시 다음 cycle 까지 대기 |
-| **Configuration error** | 설정 누락 | 시작 시 검증, 즉시 에러 종료 |
-| **Inconsistency** | DB 와 git remote 가 모순 (예: DB 는 done 인데 PR 미존재) | reconcile 으로 자동 해소 / 해소 안 되면 escalation |
+| **Domain error** | invalid status transition, dep cycle, inconsistency | 호출자 (agent) 에게 `Result::Err`. CLI 가 사용자용 메시지 + non-zero exit code 로 변환 |
+| **Storage error** | DB 락, 디스크 full, schema mismatch | BUSY 재시도 후 실패 시 에러 종료. agent 가 retry 결정 |
+| **CLI usage error** | 잘못된 인자, 누락 옵션 | clap 이 처리. exit 1 |
+
+autopilot 자체는 네트워크 / git / GitHub 에러를 다루지 않는다 — agent 의 영역.
 
 ### 7.2 에러 타입
 
 `thiserror` 기반 enum 을 도메인 / 포트별로 분리:
 
-- `domain::DomainError`
-- `ports::TaskStoreError`, `GitError`, `GitHubError`, `DecomposeError`
-- orchestration 에서는 `OrchestrationError` 로 wrap
+- `domain::DomainError` (DepCycle, IllegalTransition, EpicAlreadyExists, UnknownDepTarget, DuplicateTaskId, Inconsistency)
+- `ports::TaskStoreError` (Busy, Backend, SchemaMismatch, NotFound, Domain)
 
 CLI 진입점에서 사용자용 메시지로 변환.
 
 ## 8. 설정 / 컴포지션 루트
 
-`AutopilotConfig` 가 모든 외부 입력을 한 곳에 모은다 (파일 + 환경변수 + CLI 플래그 우선순위 적용).
+`autopilot.toml` (기존 위치 유지) 의 ledger 관련 항목은 단순:
 
-```
+```toml
 [storage]
 db_path = ".autopilot/state.db"
 
 [epic]
-branch_prefix = "epic/"
-max_attempts = 3
-
-[hitl]
-label = "autopilot:hitl-needed"
-escalation_suppression_window_hours = 24
-
-[concurrency]
-max_parallel_agents = 4
+max_attempts = 3                        # task fail 시 escalate 임계
+hitl_label   = "autopilot:hitl-needed"  # 정보용; agent 가 사용
 ```
+
+기존 헬퍼 (gh / git / watch / pipeline ...) 의 설정은 별도 섹션이며 ledger 와 독립.
 
 `main.rs` 가 컴포지션 루트로서 다음을 수행:
 
 1. 설정 로드 + 검증
-2. SQLite 연결 + 마이그레이션 적용
-3. 어댑터들 인스턴스화 (SqliteTaskStore, GitCli, GitHubMcpClient, ...)
-4. orchestration 컴포넌트 인스턴스화 (포트 주입)
-5. clap 서브커맨드 디스패치
+2. SQLite 연결 + 마이그레이션 적용 (V1 → V2 → ...)
+3. `StdClock` 인스턴스화
+4. clap 서브커맨드 디스패치 (각 cmd 핸들러에 store + clock 주입)
 
-테스트는 4번에서 fake 어댑터를 주입한다.
+테스트는 4번에서 `InMemoryTaskStore` + `FixedClock` 주입.
 
 ## 9. 마이그레이션 정책
 
@@ -273,38 +244,38 @@ max_parallel_agents = 4
 ```
 src/store/migrations/
 ├── V1__initial.sql
-├── V2__...
+├── V2__lookup_indexes.sql
 └── ...
 ```
 
-`meta(key='schema_version')` 행으로 적용 상태 추적. 시작 시 누락된 버전 적용. 다운그레이드는 비지원 (사용자에게 DB 삭제 + resume 안내).
+`meta(key='schema_version')` 행으로 적용 상태 추적. 시작 시 누락된 버전 적용. 다운그레이드는 비지원 (사용자에게 DB 삭제 + reconcile 안내).
 
 ## 10. 인터페이스 ↔ UC 매핑
 
-본 문서의 포트가 01 의 시나리오를 어떻게 충족하는지:
+각 UC 의 핵심은 "agent 가 호출하는 CLI 시퀀스" 와 "autopilot 이 트리거하는 trait 메서드" 로 표현된다.
 
-| UC | 사용 포트 | 핵심 호출 경로 |
-|----|----------|--------------|
-| 1 | TaskStore + GitClient + SpecDecomposer | EpicManager::start → decompose → insert_epic_with_tasks → git push epic branch |
-| 2 | TaskStore + GitClient + GitHubClient | BuildLoop::tick → claim_next_task → IM 호출 → push 결과 → branch_promoter (PR) → MergeLoop::tick → complete_task_and_unblock |
-| 3 | TaskStore | claim 시 deps 필터, complete 시 unblock_dependents |
-| 4-5 | TaskStore + GitClient + SpecDecomposer + GitHubClient | Reconciler::reconcile_epic → fetch + ls-remote + PR 스캔 → apply_reconciliation |
-| 6 | TaskStore | WatchDispatcher::dispatch → epic 매칭 → upsert task |
-| 7-9 | GitHubClient + TaskStore | Escalator::escalate → 이슈 발행 + escalated_issue 기록. EscalationWatcher → 사람이 close 한 이슈 자동 인식 → reconcile |
-| 8 | TaskStore | mark_task_failed → outcome 분기 |
-| 10 | TaskStore + Notifier | MergeLoop::tick → all_tasks_done 판정 → notifier.send. escalated 잔류 시 EpicCompleted 미발송 (사람이 force-status 또는 코드 push 로 해소해야 함) |
-| 11 | GitClient | BuildLoop 의 push reject 처리 (DB 변경 없음) |
-| 12 | TaskStore | EpicManager::stop → epic.status=abandoned |
-| 13 | TaskStore + GitHubClient | MigrateCommand → import_issue → upsert task + 이슈 라벨 정리 |
+| UC | Agent CLI 호출 시퀀스 | Autopilot trait 메서드 |
+|----|--------------------|----------------------|
+| 1 (epic-start) | `epic create` → `task add` × N (또는 batch) → `git push` (헬퍼) | `EpicRepo::upsert_epic`, `TaskRepo::insert_epic_with_tasks` |
+| 2 (task 자동 구현) | `task claim` → 구현 → `task complete --pr N` (또는 fail / release) | `TaskRepo::claim_next_task`, `complete_task_and_unblock`, `mark_task_failed`, `release_claim` |
+| 3 (deps) | (UC-2 와 동일) | `claim_next_task` 의 deps 필터, `complete_task_and_unblock` 의 unblock 로직 |
+| 4-5 (resume / 복구) | monitor 호출 → git scan → `epic reconcile --plan ...` | `TaskRepo::apply_reconciliation` |
+| 6 (watch 매칭) | monitor 호출 → `epic find-by-spec-path` → `task add` | `EpicRepo::find_active_by_spec_path`, `TaskRepo::upsert_watch_task` |
+| 7 (watch 미매칭) | `suppress check` → 신규면 GitHub 이슈 발행 → `suppress add` | `SuppressionRepo::is_suppressed`, `suppress` |
+| 8 (반복 실패) | `task fail` → outcome=Escalated 면 GitHub 이슈 + `task escalate` | `TaskRepo::mark_task_failed`, `escalate_task` |
+| 9 (escalation 해소) | issue close 감지 → `epic reconcile` 또는 `suppress add reason='rejected_by_human'` | `apply_reconciliation`, `SuppressionRepo::suppress` |
+| 10 (epic 완료) | `epic status` 가 all-done → `epic complete` + 알림 | `EpicRepo::set_epic_status` |
+| 11 (동시 push 차단) | push reject 감지 → `task release` | `TaskRepo::release_claim` (attempts -1) |
+| 12 (epic 중단) | `epic abandon` | `EpicRepo::set_epic_status` |
+| 13 (마이그레이션) | 사람 이슈 본문 → spec 매칭 → `task add --source=human` + 라벨 정리 | `TaskRepo::upsert_watch_task` (source=Human) |
 
 ## 11. 테스트 가능성
 
 각 어댑터는 LSP 를 만족하는 인메모리 / fake 구현을 가진다:
 
-- `InMemoryTaskStore`: HashMap 기반, 동일 트랜잭션 의미 (단일 mutex)
-- `FakeGitClient`: 가상 ref 그래프 + push reject 시뮬레이션
-- `FakeGitHubClient`: 이슈/PR 가상 저장소
-- `FakeDecomposer`: 사전 정의된 task 목록 반환
-- `FakeNotifier`: 송신 메시지 캡처
+- `InMemoryTaskStore`: HashMap/BTreeMap 기반, 동일 트랜잭션 의미 (단일 mutex)
+- `FixedClock`: 테스트 시 시간 고정
 
-블랙박스 테스트는 orchestration 컴포넌트 단위로 fake 들을 wiring 하여 04 의 시나리오를 검증한다.
+orchestration 어댑터 (FakeGit, FakeGitHub, FakeDecomposer, FakeNotifier) 는 **본 spec 의 책임이 아니다** — agent 측에서 자기 워크플로에 맞춰 격리한다.
+
+블랙박스 테스트는 `TaskStore` 의 conformance suite 로 양 어댑터에 동일 검증을 적용 (04 §4).

--- a/plans/github-autopilot/03-detailed-spec.md
+++ b/plans/github-autopilot/03-detailed-spec.md
@@ -89,6 +89,7 @@ pub enum EventKind {
     TaskInserted, TaskClaimed, TaskStarted, TaskCompleted, TaskFailed,
     TaskEscalated, TaskBlocked, TaskUnblocked,
     Reconciled, ClaimLost, MigratedFromIssue, EscalationResolved,
+    TaskForceStatus,    // 운영자 force_status (payload: {target, reason})
 }
 ```
 
@@ -117,6 +118,12 @@ pub trait EpicRepo {
     fn get_epic(&self, name: &str) -> Result<Option<Epic>>;
     fn list_epics(&self, status: Option<EpicStatus>) -> Result<Vec<Epic>>;
     fn set_epic_status(&self, name: &str, status: EpicStatus, at: DateTime<Utc>) -> Result<()>;
+
+    /// 활성 epic 중 spec_path 가 일치하는 것을 반환. WatchDispatcher 가 갭 발견 시
+    /// "이 spec 이 어느 활성 epic 에 속하는지" 매칭에 사용 (UC-6).
+    /// 동일 spec_path 의 active epic 은 최대 1개라는 invariant 가정 — 2개 이상 발견 시
+    /// `Err(DomainError::Inconsistency)` 반환.
+    fn find_active_by_spec_path(&self, spec_path: &Path) -> Result<Option<Epic>>;
 }
 
 pub trait TaskRepo {
@@ -124,6 +131,10 @@ pub trait TaskRepo {
     fn get_task(&self, id: &TaskId) -> Result<Option<Task>>;
     fn list_tasks_by_epic(&self, epic: &str, status: Option<TaskStatus>) -> Result<Vec<Task>>;
     fn find_by_fingerprint(&self, epic: &str, fp: &str) -> Result<Option<Task>>;
+
+    /// 머지된 PR 번호로 task 역조회. MergeLoop 가 PR 머지 후 task.status='done' 전이
+    /// 대상을 찾기 위해 사용 (UC-2, §5.8).
+    fn find_task_by_pr(&self, pr_number: u64) -> Result<Option<Task>>;
 
     fn upsert_watch_task(&self, task: NewWatchTask, now: DateTime<Utc>) -> Result<UpsertOutcome>;
 
@@ -141,11 +152,23 @@ pub trait TaskRepo {
         &self, id: &TaskId, issue_number: u64, now: DateTime<Utc>
     ) -> Result<()>;
 
-    fn revert_to_ready(&self, id: &TaskId, now: DateTime<Utc>) -> Result<()>;
+    /// 시도조차 실패한 claim 을 되돌린다 (UC-11 의 push reject = claim_lost).
+    /// `claim_next_task` 에서 +1 된 attempts 를 차감하여 max_attempts 카운트에 영향이
+    /// 없도록 한다. 상태 wip → ready, 변화량 != 1 이면 IllegalTransition.
+    /// 주의: push 후 CI 실패 / 구현 실패는 `mark_task_failed` 사용 (attempts 보존).
+    fn release_claim(&self, id: &TaskId, now: DateTime<Utc>) -> Result<()>;
 
     fn apply_reconciliation(&self, plan: ReconciliationPlan, now: DateTime<Utc>) -> Result<()>;
 
     fn list_deps(&self, task_id: &TaskId) -> Result<Vec<TaskId>>;
+
+    /// 운영자 오버라이드 (CLI `task force-status`). 일반 상태 전이 검증을 우회하지만,
+    /// (a) 도메인 enum 에 정의된 상태로만 전이 가능, (b) reason 을 events 에 기록한다.
+    /// 의존성 재평가 / 자식 unblock 은 수행하지 않는다 — 필요하면 호출자가 reconcile
+    /// 또는 후속 메서드를 명시적으로 호출.
+    fn force_status(
+        &self, id: &TaskId, target: TaskStatus, reason: &str, now: DateTime<Utc>
+    ) -> Result<()>;
 }
 
 pub trait EventLog {
@@ -153,8 +176,20 @@ pub trait EventLog {
     fn list_events(&self, filter: EventFilter) -> Result<Vec<Event>>;
 }
 
-pub trait TaskStore: EpicRepo + TaskRepo + EventLog + Send + Sync {}
-impl<T: EpicRepo + TaskRepo + EventLog + Send + Sync> TaskStore for T {}
+/// HITL escalation 의 fingerprint 기반 중복 발행 억제 (UC-7).
+/// 동일 fingerprint + reason 조합이 suppress_until 시점까지 escalate 되지 않게 한다.
+pub trait SuppressionRepo {
+    fn suppress(
+        &self, fingerprint: &str, reason: &str, suppress_until: DateTime<Utc>
+    ) -> Result<()>;
+    fn is_suppressed(
+        &self, fingerprint: &str, reason: &str, now: DateTime<Utc>
+    ) -> Result<bool>;
+    fn clear(&self, fingerprint: &str, reason: &str) -> Result<()>;
+}
+
+pub trait TaskStore: EpicRepo + TaskRepo + EventLog + SuppressionRepo + Send + Sync {}
+impl<T: EpicRepo + TaskRepo + EventLog + SuppressionRepo + Send + Sync> TaskStore for T {}
 ```
 
 보조 타입:
@@ -253,6 +288,7 @@ pub trait GitHubClient: Send + Sync {
     fn add_issue_labels(&self, number: u64, labels: &[String]) -> Result<()>;
     fn remove_issue_labels(&self, number: u64, labels: &[String]) -> Result<()>;
     fn list_issues(&self, filter: IssueFilter) -> Result<Vec<IssueRef>>;
+    fn get_issue(&self, number: u64) -> Result<Option<IssueRef>>;
 
     fn create_pr(&self, req: CreatePr) -> Result<u64>;
     fn merge_pr(&self, number: u64, method: MergeMethod) -> Result<()>;
@@ -263,7 +299,13 @@ pub trait GitHubClient: Send + Sync {
 pub struct CreateIssue { pub title: String, pub body: String, pub labels: Vec<String> }
 pub struct CreatePr { pub head: String, pub base: String, pub title: String, pub body: String, pub labels: Vec<String> }
 pub struct PrRef { pub number: u64, pub head: String, pub base: String, pub merged: bool, pub closed: bool, pub labels: Vec<String> }
-pub struct IssueRef { pub number: u64, pub title: String, pub labels: Vec<String>, pub body_meta: Option<EscalationMeta> }
+pub struct IssueRef {
+    pub number: u64,
+    pub title: String,
+    pub closed: bool,
+    pub labels: Vec<String>,
+    pub body_meta: Option<EscalationMeta>,
+}
 pub struct IssueFilter { pub labels: Vec<String>, pub state: IssueState }
 pub enum IssueState { Open, Closed, All }
 pub enum MergeMethod { Squash, Merge, Rebase }
@@ -391,9 +433,16 @@ CREATE TABLE escalation_suppression (
 
 CREATE INDEX idx_tasks_epic_status ON tasks(epic_name, status);
 CREATE INDEX idx_tasks_fingerprint ON tasks(fingerprint);
+CREATE INDEX idx_tasks_pr_number   ON tasks(pr_number) WHERE pr_number IS NOT NULL;
+CREATE INDEX idx_epics_active_spec ON epics(spec_path) WHERE status='active';
 CREATE INDEX idx_events_epic_at ON events(epic_name, at);
 CREATE INDEX idx_events_task_at ON events(task_id, at);
 ```
+
+신규 인덱스 사유:
+
+- `idx_tasks_pr_number` — `find_task_by_pr` 의 O(1) 조회 (대부분 task 가 PR 미할당이므로 partial index 로 크기 절감).
+- `idx_epics_active_spec` — `find_active_by_spec_path` 가 watch 빈번 호출이라 partial index 권장. 동일 spec_path 의 active epic 은 1개라는 invariant 와 일치.
 
 마이그레이션 적용: 시작 시 `meta.schema_version` 을 읽고 누락된 V_n 을 순서대로 실행. 단일 트랜잭션 안에서 적용.
 
@@ -564,7 +613,7 @@ idempotency: 동일 plan 으로 N번 호출해도 결과 동일. attempts 카운
 
 ```
 fn dispatch_finding(finding: WatchFinding):
-  match epic_for_spec(finding.spec_path):
+  match task_store.find_active_by_spec_path(finding.spec_path):
     Some(epic):
       task_id = TaskId::new_deterministic(epic.name, finding.section, finding.requirement)
       outcome = task_store.upsert_watch_task(NewWatchTask{
@@ -577,10 +626,14 @@ fn dispatch_finding(finding: WatchFinding):
       }, now)
       log event accordingly
     None:
-      if escalation_suppressed(finding.fingerprint): return
+      if task_store.is_suppressed(finding.fingerprint, "unmatched_watch", now): return
       issue_number = github.create_issue(escalation_template(finding))
       task_store.append_event(kind='escalated', payload={...})
-      task_store.suppress(finding.fingerprint, reason='unmatched_watch', until = now + 24h)
+      task_store.suppress(
+        finding.fingerprint,
+        reason="unmatched_watch",
+        suppress_until = now + Duration::hours(escalation_suppression_window_hours),
+      )
 ```
 
 `upsert_watch_task` 는 fingerprint 충돌 시 `DuplicateFingerprint(existing_id)` 반환, orchestration 에서 이를 보고 신규 발행 skip.
@@ -595,29 +648,77 @@ fn tick():
       if task is None: break
       branch = format!("{prefix}/{epic.name}/{task.id}", prefix=epic_branch_prefix)
       spawn_implementer(epic, task, branch)
-        on_success(pr_number) -> task_store.complete_task_and_unblock(...)
-        on_push_rejected     -> task_store.revert_to_ready(task.id, now)
-                                  task_store.append_event(kind='claim_lost', ...)
-        on_other_failure     -> outcome = task_store.mark_task_failed(task.id, max_attempts, now)
-                                  if Escalated: escalator.escalate(...)
+        on_pr_created(pr_number) ->
+            -- PR 생성 성공. 머지는 MergeLoop 가 후속 처리.
+            task_store.append_event(kind='task_started', task=task.id, payload={pr: pr_number})
+        on_push_rejected         ->
+            -- UC-11: 다른 머신 / 다른 sub-loop 가 먼저 가져감. 시도 회복.
+            task_store.release_claim(task.id, now)
+            task_store.append_event(kind='claim_lost', task=task.id)
+        on_implementation_failed ->
+            -- 코드 작성 실패 / push 후 PR 생성 실패 / CI 실패 등. 시도는 보존.
+            outcome = task_store.mark_task_failed(task.id, max_attempts, now)
+            if Escalated: escalator.escalate(task)
 ```
+
+`release_claim` 과 `mark_task_failed` 의 선택 기준: **시도조차 못 했으면** `release_claim`, **시도했으나 실패** 면 `mark_task_failed`.
 
 ### 5.8 MergeLoop tick (UC-2, UC-10)
 
 ```
 fn tick():
-  prs = github.list_prs_targeting(epic.branch, labels=[":auto"], state=open)
-  for pr in prs:
-    if pr 의 ci 상태 통과 + 충돌 없음:
-      github.merge_pr(pr.number, MergeMethod::Squash)
-      task = task_store.find_by_pr(pr.number)
-      task_store.complete_task_and_unblock(task.id, pr.number, now)
+  for epic in active_epics:
+    prs = github.list_prs_targeting(epic.branch, labels=[":auto"], state=open)
+    for pr in prs:
+      if pr 의 ci 상태 통과 + 충돌 없음:
+        github.merge_pr(pr.number, MergeMethod::Squash)
+        task = task_store.find_task_by_pr(pr.number)
+        if task is Some: task_store.complete_task_and_unblock(task.id, pr.number, now)
 
-  -- epic 완료 판정
-  if all_tasks_terminal(epic):       -- done | (escalated AND issue_closed)
-    epic_manager.complete(epic.name)
-    notifier.send(EpicCompleted { epic: epic.name })
+    -- epic 완료 판정
+    -- "사람이 close 한 escalated" 의 자동 인식은 §5.9 EscalationWatcher 가 별도로 처리.
+    -- 본 루프에서는 task.status ∈ {done} 여부만 본다.
+    if all_tasks_done(epic):
+      epic_manager.complete(epic.name)
+      notifier.send(EpicCompleted { epic: epic.name })
 ```
+
+### 5.9 EscalationWatcher tick (UC-9, UC-10)
+
+`EscalationWatcher` 는 escalated task 의 GitHub 이슈 close 를 주기 폴링하여 사람의 직접 해소를
+자동 인식한다. MergeLoop 와 분리한 이유: SRP — MergeLoop 는 PR 머지 흐름만, 본 루프는
+escalation 해소 흐름만 담당. 폴링 주기는 MergeLoop 보다 길게 (예: 5분).
+
+```
+fn tick():
+  for epic in active_epics:
+    escalated = task_store.list_tasks_by_epic(epic.name, status=Escalated)
+    for task in escalated:
+      if task.escalated_issue is None: continue
+      issue = github.get_issue(task.escalated_issue)
+      if issue is None or !issue.closed: continue
+
+      -- 사람이 issue 를 close 했음. 두 케이스:
+      -- (a) 사람이 직접 코드를 작성하여 epic 브랜치에 PR 머지 → reconcile 이 done 으로 인식
+      -- (b) 단순 거부 / 무시 close → suppression 등록 (해당 fingerprint 추가 escalate 차단)
+      reconciler.reconcile_epic(epic.name, now)
+      task_after = task_store.get_task(task.id)
+      if task_after.status != Done:
+        -- (b) 케이스. 사람이 코드 작업 없이 close 한 것으로 간주.
+        if task.fingerprint is Some:
+          task_store.suppress(
+            task.fingerprint, reason="rejected_by_human",
+            suppress_until = now + Duration::days(30),
+          )
+        task_store.append_event(kind='escalation_resolved',
+                                payload={resolution: 'rejected'}, task=task.id)
+      else:
+        task_store.append_event(kind='escalation_resolved',
+                                payload={resolution: 'human_fixed'}, task=task.id)
+```
+
+**중요한 invariant**: 본 루프는 `force_status` 를 직접 호출하지 않는다. 상태 전이는 reconcile
+(idempotent) 또는 다른 정상 경로를 통해서만 일어난다.
 
 ## 6. CLI 시그니처 (clap)
 
@@ -666,6 +767,10 @@ pub enum DomainError {
     IllegalTransition(TaskId, TaskStatus, TaskStatus),
     #[error("epic '{0}' already exists with status {1:?}")]
     EpicAlreadyExists(String, EpicStatus),
+    /// 데이터 불변식 위반 (예: 동일 spec_path 의 active epic 이 2개 이상).
+    /// 정상 흐름에서는 발생할 수 없으며, 발생 시 사람 개입 필요.
+    #[error("inconsistency: {0}")]
+    Inconsistency(String),
 }
 
 // ports/task_store.rs

--- a/plans/github-autopilot/03-detailed-spec.md
+++ b/plans/github-autopilot/03-detailed-spec.md
@@ -257,89 +257,7 @@ pub struct EventFilter {
 }
 ```
 
-### 2.2 GitClient
-
-```rust
-// ports/git.rs
-pub trait GitClient: Send + Sync {
-    fn current_branch(&self) -> Result<String>;
-    fn working_tree_clean(&self) -> Result<bool>;
-
-    fn fetch_origin(&self, refspec: Option<&str>) -> Result<()>;
-    fn ls_remote_branches(&self, prefix: &str) -> Result<Vec<String>>;
-    fn create_branch_from(&self, new_branch: &str, base: &str) -> Result<()>;
-    fn push_branch(&self, branch: &str) -> Result<PushOutcome>;
-    fn delete_remote_branch(&self, branch: &str) -> Result<()>;
-
-    fn rev_parse(&self, refname: &str) -> Result<Option<String>>;
-}
-
-pub enum PushOutcome { Created, FastForward, Rejected(String) }
-```
-
-### 2.3 GitHubClient
-
-```rust
-// ports/github.rs
-pub trait GitHubClient: Send + Sync {
-    fn create_issue(&self, req: CreateIssue) -> Result<u64>;
-    fn close_issue(&self, number: u64) -> Result<()>;
-    fn add_issue_comment(&self, number: u64, body: &str) -> Result<()>;
-    fn add_issue_labels(&self, number: u64, labels: &[String]) -> Result<()>;
-    fn remove_issue_labels(&self, number: u64, labels: &[String]) -> Result<()>;
-    fn list_issues(&self, filter: IssueFilter) -> Result<Vec<IssueRef>>;
-    fn get_issue(&self, number: u64) -> Result<Option<IssueRef>>;
-
-    fn create_pr(&self, req: CreatePr) -> Result<u64>;
-    fn merge_pr(&self, number: u64, method: MergeMethod) -> Result<()>;
-    fn list_prs_targeting(&self, base_branch: &str) -> Result<Vec<PrRef>>;
-    fn get_pr(&self, number: u64) -> Result<Option<PrRef>>;
-}
-
-pub struct CreateIssue { pub title: String, pub body: String, pub labels: Vec<String> }
-pub struct CreatePr { pub head: String, pub base: String, pub title: String, pub body: String, pub labels: Vec<String> }
-pub struct PrRef { pub number: u64, pub head: String, pub base: String, pub merged: bool, pub closed: bool, pub labels: Vec<String> }
-pub struct IssueRef {
-    pub number: u64,
-    pub title: String,
-    pub closed: bool,
-    pub labels: Vec<String>,
-    pub body_meta: Option<EscalationMeta>,
-}
-pub struct IssueFilter { pub labels: Vec<String>, pub state: IssueState }
-pub enum IssueState { Open, Closed, All }
-pub enum MergeMethod { Squash, Merge, Rebase }
-```
-
-### 2.4 SpecDecomposer
-
-```rust
-// ports/decompose.rs
-pub trait SpecDecomposer: Send + Sync {
-    fn decompose(&self, spec_path: &Path, epic_name: &str) -> Result<DecomposeOutput>;
-}
-
-pub struct DecomposeOutput {
-    pub tasks: Vec<NewTask>,            // id 는 결정적
-    pub deps: Vec<(TaskId, TaskId)>,
-}
-```
-
-### 2.5 Notifier
-
-```rust
-// ports/notifier.rs
-pub trait Notifier: Send + Sync {
-    fn send(&self, event: NotificationEvent) -> Result<()>;
-}
-
-pub enum NotificationEvent {
-    EpicCompleted { epic: String },
-    EscalationOpened { epic: Option<String>, task: Option<TaskId>, issue: u64 },
-}
-```
-
-### 2.6 Clock
+### 2.2 Clock
 
 ```rust
 // ports/clock.rs
@@ -609,151 +527,132 @@ fn apply_reconciliation(plan: ReconciliationPlan, now):
 
 idempotency: 동일 plan 으로 N번 호출해도 결과 동일. attempts 카운터는 보존되며 status 는 리모트 기준으로 권위적으로 재설정.
 
-### 5.6 WatchDispatcher (UC-6, UC-7)
+### 5.6 Agent 측 흐름 (의사코드, 참고용)
+
+본 §5 의 알고리즘은 모두 autopilot 내부 (TaskStore 메서드) 의 것이다. Agent 는 이들을 CLI 로
+호출하며 자기 흐름은 자유롭게 설계한다. 권장 패턴:
 
 ```
-fn dispatch_finding(finding: WatchFinding):
-  match task_store.find_active_by_spec_path(finding.spec_path):
-    Some(epic):
-      task_id = TaskId::new_deterministic(epic.name, finding.section, finding.requirement)
-      outcome = task_store.upsert_watch_task(NewWatchTask{
-        id: task_id,
-        epic_name: epic.name,
-        source: finding.source,
-        fingerprint: finding.fingerprint,
-        title: finding.title,
-        body: finding.body,
-      }, now)
-      log event accordingly
-    None:
-      if task_store.is_suppressed(finding.fingerprint, "unmatched_watch", now): return
-      issue_number = github.create_issue(escalation_template(finding))
-      task_store.append_event(kind='escalated', payload={...})
-      task_store.suppress(
-        finding.fingerprint,
-        reason="unmatched_watch",
-        suppress_until = now + Duration::hours(escalation_suppression_window_hours),
-      )
-```
+# Watch dispatch (UC-6, UC-7)
+fn agent_dispatch_finding(finding):
+  let epic = `autopilot epic find-by-spec-path <finding.spec_path>` (JSON)
+  if epic is Some:
+    `autopilot task add --epic <epic.name> --id <det_id>
+                       --section <finding.section> --requirement <finding.req>
+                       --fingerprint <finding.fp> --source gap-watch`
+    # autopilot 이 fingerprint 중복 시 DuplicateFingerprint 로 응답 → no-op
+  else:
+    if `autopilot suppress check --fingerprint <fp> --reason unmatched_watch`:
+      return
+    issue_n = `gh issue create --label autopilot:hitl-needed ...`
+    `autopilot suppress add --fingerprint <fp> --reason unmatched_watch --until <now+24h>`
 
-`upsert_watch_task` 는 fingerprint 충돌 시 `DuplicateFingerprint(existing_id)` 반환, orchestration 에서 이를 보고 신규 발행 skip.
+# Build cycle (UC-2, UC-11)
+fn agent_build_tick():
+  for epic in `autopilot epic list --status active` (JSON):
+    while parallel_count < max_parallel:
+      let task = `autopilot task claim --epic <epic.name>` or break
+      let branch = format!("epic/{}/{}", epic.name, task.id)
+      result = implement_and_push(branch, task)
+      match result:
+        PrCreated(n)   -> `autopilot task complete --id <task.id> --pr <n>`
+        PushRejected   -> `autopilot task release --id <task.id>`   # UC-11
+        OtherFailure   ->
+          let outcome = `autopilot task fail --id <task.id>`
+          if outcome == Escalated:
+            issue_n = `gh issue create --label autopilot:hitl-needed ...`
+            `autopilot task escalate --id <task.id> --issue <issue_n>`
 
-### 5.7 BuildLoop tick (UC-2, UC-11)
-
-```
-fn tick():
+# Escalation resolution polling (UC-9)
+fn agent_escalation_tick():
   for epic in active_epics:
-    while parallel_agents < max_parallel_agents:
-      task = task_store.claim_next_task(epic.name, now)
-      if task is None: break
-      branch = format!("{prefix}/{epic.name}/{task.id}", prefix=epic_branch_prefix)
-      spawn_implementer(epic, task, branch)
-        on_pr_created(pr_number) ->
-            -- PR 생성 성공. 머지는 MergeLoop 가 후속 처리.
-            task_store.append_event(kind='task_started', task=task.id, payload={pr: pr_number})
-        on_push_rejected         ->
-            -- UC-11: 다른 머신 / 다른 sub-loop 가 먼저 가져감. 시도 회복.
-            task_store.release_claim(task.id, now)
-            task_store.append_event(kind='claim_lost', task=task.id)
-        on_implementation_failed ->
-            -- 코드 작성 실패 / push 후 PR 생성 실패 / CI 실패 등. 시도는 보존.
-            outcome = task_store.mark_task_failed(task.id, max_attempts, now)
-            if Escalated: escalator.escalate(task)
-```
-
-`release_claim` 과 `mark_task_failed` 의 선택 기준: **시도조차 못 했으면** `release_claim`, **시도했으나 실패** 면 `mark_task_failed`.
-
-### 5.8 MergeLoop tick (UC-2, UC-10)
-
-```
-fn tick():
-  for epic in active_epics:
-    prs = github.list_prs_targeting(epic.branch, labels=[":auto"], state=open)
-    for pr in prs:
-      if pr 의 ci 상태 통과 + 충돌 없음:
-        github.merge_pr(pr.number, MergeMethod::Squash)
-        task = task_store.find_task_by_pr(pr.number)
-        if task is Some: task_store.complete_task_and_unblock(task.id, pr.number, now)
-
-    -- epic 완료 판정
-    -- "사람이 close 한 escalated" 의 자동 인식은 §5.9 EscalationWatcher 가 별도로 처리.
-    -- 본 루프에서는 task.status ∈ {done} 여부만 본다.
-    if all_tasks_done(epic):
-      epic_manager.complete(epic.name)
-      notifier.send(EpicCompleted { epic: epic.name })
-```
-
-### 5.9 EscalationWatcher tick (UC-9, UC-10)
-
-`EscalationWatcher` 는 escalated task 의 GitHub 이슈 close 를 주기 폴링하여 사람의 직접 해소를
-자동 인식한다. MergeLoop 와 분리한 이유: SRP — MergeLoop 는 PR 머지 흐름만, 본 루프는
-escalation 해소 흐름만 담당. 폴링 주기는 MergeLoop 보다 길게 (예: 5분).
-
-```
-fn tick():
-  for epic in active_epics:
-    escalated = task_store.list_tasks_by_epic(epic.name, status=Escalated)
-    for task in escalated:
+    for task in `autopilot task list --epic <epic.name> --status escalated`:
       if task.escalated_issue is None: continue
-      issue = github.get_issue(task.escalated_issue)
-      if issue is None or !issue.closed: continue
-
-      -- 사람이 issue 를 close 했음. 두 케이스:
-      -- (a) 사람이 직접 코드를 작성하여 epic 브랜치에 PR 머지 → reconcile 이 done 으로 인식
-      -- (b) 단순 거부 / 무시 close → suppression 등록 (해당 fingerprint 추가 escalate 차단)
-      reconciler.reconcile_epic(epic.name, now)
-      task_after = task_store.get_task(task.id)
-      if task_after.status != Done:
-        -- (b) 케이스. 사람이 코드 작업 없이 close 한 것으로 간주.
-        if task.fingerprint is Some:
-          task_store.suppress(
-            task.fingerprint, reason="rejected_by_human",
-            suppress_until = now + Duration::days(30),
-          )
-        task_store.append_event(kind='escalation_resolved',
-                                payload={resolution: 'rejected'}, task=task.id)
-      else:
-        task_store.append_event(kind='escalation_resolved',
-                                payload={resolution: 'human_fixed'}, task=task.id)
+      let issue = gh.get_issue(task.escalated_issue)
+      if not issue.closed: continue
+      # 사람이 close 했음. reconcile 시도 → done 이면 자연 흡수, 아니면 suppress 등록
+      let plan = build_reconcile_plan(epic, monitor, git)
+      `autopilot epic reconcile --name <epic.name> --plan <plan.jsonl>`
+      let task_after = `autopilot task get <task.id>`
+      if task_after.status != "done":
+        `autopilot suppress add --fingerprint <task.fingerprint>
+                                --reason rejected_by_human --until <now+30d>`
 ```
 
-**중요한 invariant**: 본 루프는 `force_status` 를 직접 호출하지 않는다. 상태 전이는 reconcile
-(idempotent) 또는 다른 정상 경로를 통해서만 일어난다.
+이 흐름은 단지 권장 구현일 뿐 — agent 는 자유롭게 구성할 수 있다. autopilot 의 트레이트 메서드
+계약 (§2, §5.1-§5.5) 만 만족하면 된다.
 
 ## 6. CLI 시그니처 (clap)
 
-`autopilot epic <subcommand>`:
+전 명령은 `--json` 출력 옵션을 지원하며, 기본은 사람용 요약. exit code: 0 정상 / 1 사용자 에러 / 2 일시적 시스템 에러 (재시도 가치 있음) / 3 영구적 시스템 에러.
+
+### 6.1 `autopilot epic` (Ledger CLI)
 
 ```
-autopilot epic start   --spec <PATH> --name <NAME> [--from-branch <REF>] [--dry-run]
-autopilot epic resume  <NAME> [--reset-attempts]
-autopilot epic stop    <NAME> [--purge-branches]
-autopilot epic status  [<NAME>] [--json]
-autopilot epic list    [--status active|completed|abandoned|all]
+autopilot epic create     --name <NAME> --spec <PATH> [--branch <REF>]
+                          [--from-branch <REF>]                              # branch 기본값: epic/<NAME>
+autopilot epic list       [--status active|completed|abandoned|all] [--json]
+autopilot epic get        <NAME> [--json]
+autopilot epic status     [<NAME>] [--json]                                  # task 상태 카운트
+autopilot epic complete   <NAME>                                             # status='completed' + 알림은 agent 책임
+autopilot epic abandon    <NAME>
+autopilot epic reconcile  --name <NAME> --plan <FILE>                        # JSONL: tasks + deps + remote_state + orphan_branches
+
+autopilot epic find-by-spec-path <PATH> [--json]                             # invariant 위반 시 exit 3 + Inconsistency 메시지
 ```
 
-`autopilot task <subcommand>` (운영자용 진단/오버라이드):
+### 6.2 `autopilot task` (Ledger CLI)
 
 ```
-autopilot task list    --epic <NAME> [--status <STATUS>] [--json]
-autopilot task show    <TASK_ID> [--json]
-autopilot task force-status <TASK_ID> --to <STATUS> [--reason <TEXT>]
+autopilot task add        --epic <NAME> --id <TASK_ID>
+                          [--section <PATH>] [--requirement <TEXT>]
+                          [--title <TEXT>] [--body <TEXT>]
+                          [--fingerprint <FP>]
+                          [--source decompose|gap-watch|qa-boost|ci-watch|human]
+autopilot task add-batch  --epic <NAME> --from <FILE>                        # JSONL: NewTask 한 줄에 1건
+autopilot task list       --epic <NAME> [--status <STATUS>] [--json]
+autopilot task get        <TASK_ID> [--json]
+autopilot task find-by-pr <PR_NUMBER> [--json]
+
+autopilot task claim      --epic <NAME> [--json]                             # 다음 ready task 원자적 wip 전환
+autopilot task release    <TASK_ID>                                          # UC-11 claim_lost (attempts -1)
+autopilot task complete   <TASK_ID> --pr <NUMBER>
+autopilot task fail       <TASK_ID>                                          # exit 0 + Retried | Escalated 출력
+autopilot task escalate   <TASK_ID> --issue <NUMBER>
+autopilot task force-status <TASK_ID> --to <STATUS> [--reason <TEXT>]        # 운영자 override
 ```
 
-`autopilot migrate <subcommand>`:
+### 6.3 `autopilot suppress` (Ledger CLI)
 
 ```
-autopilot migrate import-issue <ISSUE_NUMBER> [--epic <NAME>]
-autopilot migrate scan-issues  [--label <LABEL>=":ready"]      # 후보 목록만 출력
+autopilot suppress add    --fingerprint <FP> --reason <TEXT> --until <ISO8601>
+autopilot suppress check  --fingerprint <FP> --reason <TEXT>                 # exit 0=억제 중 / exit 1=아님
+autopilot suppress clear  --fingerprint <FP> --reason <TEXT>
 ```
 
-기존 명령 변화 (04 watch-integration 에서 자세히):
+### 6.4 `autopilot events` (Ledger CLI)
 
-- `autopilot pipeline build-tasks` (build-issues 대체)
-- `autopilot pipeline merge-prs` (의미 동일, task store 업데이트 추가)
-- `autopilot watch run` (gap/qa/ci 통합 진입, 기존 유지)
+```
+autopilot events list     [--epic <NAME>] [--task <TASK_ID>] [--kind <KIND>...]
+                          [--since <ISO8601>] [--limit <N>] [--json]
+```
 
-출력 포맷: 기본은 사람용 표/요약, `--json` 일 때 stable schema. exit code: 0 정상 / 1 사용자 에러 / 2 일시적 시스템 에러 (재시도 가치 있음) / 3 영구적 시스템 에러.
+### 6.5 기존 헬퍼 명령
+
+`watch run`, `pipeline idle`, `worktree`, `issue`, `issue list`, `labels`, `preflight`, `simhash`, `stats`, `check` 는 기존 시그니처 그대로. **ledger 와 결합되지 않음** — agent 가 자기 흐름에서 자유롭게 호출.
+
+### 6.6 입출력 형식 (JSONL)
+
+`epic reconcile --plan` 의 JSONL 한 줄 예시:
+
+```json
+{"kind":"task","id":"a1b2c3d4e5f6","title":"...","section":"## 인증","requirement":"토큰 갱신","fingerprint":null}
+{"kind":"dep","task":"b2c3d4e5f6a1","depends_on":"a1b2c3d4e5f6"}
+{"kind":"remote_state","task_id":"a1b2c3d4e5f6","branch_exists":true,"pr":{"number":42,"merged":true,"closed":true}}
+{"kind":"orphan_branch","ref":"epic/auth/old-task-id"}
+```
+
+`task add-batch --from` 의 JSONL: 각 줄이 NewTask (`id`, `title`, `body?`, `section?`, `requirement?`, `fingerprint?`, `source`).
 
 ## 7. 에러 타입
 
@@ -767,6 +666,10 @@ pub enum DomainError {
     IllegalTransition(TaskId, TaskStatus, TaskStatus),
     #[error("epic '{0}' already exists with status {1:?}")]
     EpicAlreadyExists(String, EpicStatus),
+    #[error("dep references unknown task: {0}")]
+    UnknownDepTarget(TaskId),
+    #[error("duplicate task id in plan: {0}")]
+    DuplicateTaskId(TaskId),
     /// 데이터 불변식 위반 (예: 동일 spec_path 의 active epic 이 2개 이상).
     /// 정상 흐름에서는 발생할 수 없으며, 발생 시 사람 개입 필요.
     #[error("inconsistency: {0}")]
@@ -780,52 +683,30 @@ pub enum TaskStoreError {
     #[error("storage backend: {0}")]        Backend(String),
     #[error("schema mismatch: at v{found}, expected v{expected}")]
     SchemaMismatch { found: u32, expected: u32 },
+    #[error("not found: {0}")]              NotFound(String),
     #[error(transparent)]                   Domain(#[from] DomainError),
-}
-
-// 동일 패턴으로:
-pub enum GitError      { NotARepo, FetchFailed(String), PushRejected(String), Other(String) }
-pub enum GitHubError   { Network(String), NotFound, Unauthorized, RateLimited, Other(String) }
-pub enum DecomposeError{ SpecNotFound(PathBuf), Parse(String), Other(String) }
-
-// orchestration/error.rs
-#[derive(Debug, thiserror::Error)]
-pub enum OrchestrationError {
-    #[error(transparent)] Store(#[from] TaskStoreError),
-    #[error(transparent)] Git(#[from] GitError),
-    #[error(transparent)] GitHub(#[from] GitHubError),
-    #[error(transparent)] Decompose(#[from] DecomposeError),
-    #[error(transparent)] Domain(#[from] DomainError),
-    #[error("inconsistency: {0}")] Inconsistency(String),
 }
 ```
 
-CLI 진입점은 `OrchestrationError` 를 받아 사용자 메시지 + exit code 매핑.
+git / GitHub / 분해 실패 / 알림 실패 등 외부 도구 에러는 **agent 의 영역** 으로 autopilot 의 트레이트 시스템에 들어가지 않는다. CLI 진입점은 `TaskStoreError` 를 사용자 메시지 + exit code 로 매핑한다.
 
 ## 8. 설정 스키마
 
-`autopilot.toml` (기본 위치는 기존 설정 컨벤션 유지):
+`autopilot.toml` (기본 위치는 기존 설정 컨벤션 유지). Ledger 관련 항목만 정의:
 
 ```toml
 [storage]
 db_path = ".autopilot/state.db"
 
 [epic]
-branch_prefix       = "epic/"
-max_attempts        = 3
-deps_cycle_check    = true
+max_attempts = 3                   # task fail → outcome=Escalated 임계
+hitl_label   = "autopilot:hitl-needed"   # 정보용; agent 측이 사용
 
-[hitl]
-label                                = "autopilot:hitl-needed"
-escalation_suppression_window_hours  = 24
-
-[concurrency]
-max_parallel_agents = 4
-sqlite_busy_timeout_ms = 5000
-
-[migration]
-epic_based = true                  # false 면 기존 라벨 기반 동작 유지 (06 spec)
+[suppression]
+default_window_hours = 24          # suppress add 의 --until 기본 (선택)
 ```
+
+다른 헬퍼 명령 (gh / git / watch / pipeline ...) 의 설정은 별도 섹션으로 유지되며 ledger 와 독립.
 
 설정 우선순위: CLI 플래그 > 환경변수 (`AUTOPILOT_*`) > 파일 > 기본값. 시작 시 유효성 검사 실패면 즉시 종료 (exit 1).
 

--- a/plans/github-autopilot/04-test-scenarios.md
+++ b/plans/github-autopilot/04-test-scenarios.md
@@ -4,38 +4,32 @@
 
 ## 1. 테스트 레이어와 격리
 
+Ledger 모델에서 autopilot 의 책임은 TaskStore + CLI 까지다. 그 위의 워크플로 (UC-1~13 의 시나리오 통합) 검증은 **agent 측의 책임** 이다 — 본 spec 의 범위 밖.
+
 | 레이어 | 대상 | 어댑터 | 격리 단위 |
 |--------|------|--------|----------|
 | **L1. Domain** | pure 함수 / 타입 (TaskId, TaskGraph, deps cycle) | 없음 | 함수별 단위 |
 | **L2. Store conformance** | TaskStore 의 트랜잭션 의미 (LSP) | `InMemoryTaskStore` + `SqliteTaskStore` 양쪽에 동일 suite 실행 | 메서드 + tx 경계 |
-| **L3. Orchestration** | EpicManager / BuildLoop / WatchDispatcher / MergeLoop / Reconciler / Escalator | 모든 포트는 fake (InMemoryTaskStore, FakeGit, FakeGitHub, FakeDecomposer, FakeNotifier, FixedClock) | UC 1건 = 1 시나리오 |
-| **L4. Property** | 결정적 ID 충돌, reconcile 멱등성, 동시 claim 의 원자성 | proptest 기반 임의 입력 | 불변식별 |
+| **L3. CLI 통합** | clap 진입점 ↔ TaskStore 연결, JSON 출력 / exit code | `InMemoryTaskStore` + `FixedClock` 주입 | 명령 1건 |
+| **L4. Property** | 결정적 ID 충돌, attempts 단조성, reconcile 멱등성, 동시 claim 원자성 | proptest 기반 임의 입력 | 불변식별 |
 
-CLI 진입점 / SQLite 어댑터의 실 SQL 동작은 L2 가 담당한다. 별도 e2e (실제 git/GitHub) 테스트는 본 문서 범위 밖 — CI 환경에서 수동 smoke 만 수행.
+E2E (실제 git / GitHub) 테스트와 agent 측 워크플로 통합은 본 문서 범위 밖.
 
 ## 2. 공통 fixture 형식
 
-각 시나리오는 다음 YAML-like 구조로 표기한다 (실제 구현에서는 builder 함수 권장):
+L2 / L3 / L4 모두 in-memory store 와 fixed clock 을 기본 fixture 로 사용. agent 와의 통합 fixture (FakeGit / FakeGitHub / FakeDecomposer / FakeNotifier) 는 더 이상 본 spec 의 책임이 아니다.
 
 ```yaml
 fixture:
   clock:
     now: "2026-04-28T09:00:00Z"
-  epic:
-    name: "auth-token-refresh"
-    spec_path: "spec/auth.md"
-    branch: "epic/auth-token-refresh"
-  decomposer:
-    tasks:
-      - { section: "## 인증", req: "토큰 갱신",   id: "<derived>" }
-      - { section: "## 인증", req: "401 재시도", id: "<derived>" }
-    deps: []
-  git:
-    initial_branches: ["main"]
-    push_rejects: []
-  github:
-    issues: []
-    prs: []
+  store: in-memory   # 또는 sqlite (conformance 비교)
+  epics:
+    - { name: "auth-token-refresh", spec_path: "spec/auth.md", status: "active" }
+  tasks:
+    - { id: "<derived>", epic: "auth-token-refresh", status: "ready", title: "..." }
+  deps: []
+  events: []
 ```
 
 `<derived>` 는 결정적 ID 함수의 결과 (테스트 setup 에서 계산하여 매칭).
@@ -318,282 +312,64 @@ test: sqlite_rejects_unknown_higher_version
   then:  Err(SchemaMismatch{found:999, expected:1})
 ```
 
-## 5. L3: Orchestration 시나리오 (UC ↔ 테스트)
 
-각 시나리오는 fake 어댑터로 wiring 한 orchestration 컴포넌트를 호출하고 외부 관찰점 (DB, FakeGit ref 그래프, FakeGitHub 이슈/PR, FakeNotifier 메시지) 으로 사후 조건을 검증한다.
+## 5. L3: CLI 통합
 
-### UC-1. Epic 시작
-
-```
-test: uc1_epic_start_creates_branch_and_seeds_tasks
-  fixture:
-    git: branches=[main], working_tree_clean=true
-    decomposer: tasks=[(s1,r1), (s2,r2)], deps=[]
-  when:  EpicManager::start({ name:"e", spec:"spec/auth.md" })
-  then:
-    git.branches contains "epic/e"
-    git.pushed contains "epic/e"
-    store.list_epics() == [Epic{name:"e", status='active', ...}]
-    store.list_tasks_by_epic("e") -> 2 tasks, 둘 다 status='ready'
-    store.events: epic_started + 2x task_inserted
-
-test: uc1_epic_start_rolls_back_on_decomposer_failure
-  fixture: decomposer.fail = SpecNotFound
-  when:  EpicManager::start({ name:"e", spec:"missing.md" })
-  then:  Err(_)
-         store.list_epics() empty
-         git.branches unchanged
-
-test: uc1_epic_start_rejects_dirty_working_tree
-  fixture: git.working_tree_clean=false
-  when:  EpicManager::start(...)
-  then:  Err(GitError::DirtyWorkingTree)
-
-test: uc1_epic_start_rejects_when_active_epic_with_same_name
-  fixture: store has epic "e" with status='active'
-  when:  EpicManager::start({ name:"e" })
-  then:  Err(EpicAlreadyExists)
-```
-
-### UC-2. Task 자동 구현 사이클
+CLI 진입점이 trait 메서드를 올바르게 디스패치하고 JSON 출력 / exit code 가 안정적인지 검증한다. `InMemoryTaskStore` + `FixedClock` 을 직접 주입하고 `assert_cmd` 또는 동등 도구로 stdout / exit code 를 검사한다.
 
 ```
-test: uc2_full_cycle_claim_to_merged
-  fixture:
-    epic "e" with 1 ready task A
-    fake_implementer: on_invoke push branch successfully
-    github: empty
-  when:
-    BuildLoop::tick()           -> claim A, IM push, branch_promoter create PR #100
-    MergeLoop::tick()           -> CI ok 가정, merge PR #100
-  then:
-    A.status == 'done'
-    A.pr_number == 100
-    events sequence: task_claimed, task_started, task_completed
-    github.prs[100].merged == true
+test: cli_epic_create_persists_and_emits_event
+  given: empty store
+  when:  `autopilot epic create --name e --spec spec/e.md`
+  then:  exit 0
+         store.list_epics() == [Epic{name="e", status=active, ...}]
+         events: epic_started
 
-test: uc2_push_failure_returns_task_to_ready
-  fixture: fake_implementer pushes successfully but branch_promoter fails to create PR
-  when:  BuildLoop::tick()
-  then:  A.status == 'ready'
-         events: task_failed (non-final)
+test: cli_task_claim_outputs_next_ready_task_as_json
+  given: epic e with task A(ready)
+  when:  `autopilot task claim --epic e --json`
+  then:  exit 0
+         stdout JSON: {"id":"...A...","status":"wip","attempts":1,...}
+         get_task(A).status == Wip
+
+test: cli_task_claim_signals_no_ready_via_exit_code
+  given: epic e with no ready task
+  when:  `autopilot task claim --epic e`
+  then:  exit 1   # "no ready task" 신호 (사용자 에러 아님)
+
+test: cli_task_complete_updates_pr_and_unblocks
+  given: A(wip), B(pending, deps=[A])
+  when:  `autopilot task complete <A.id> --pr 42`
+  then:  A.status == Done, A.pr_number == 42
+         B.status == Ready
+
+test: cli_task_fail_reports_outcome
+  given: A(wip, attempts=2), max_attempts=3
+  when:  `autopilot task fail <A.id>`
+  then:  exit 0
+         stdout JSON: {"outcome":"retried","attempts":2}
+         A.status == Ready
+
+  when (한번 더 claim → fail): 동일 호출
+  then:  stdout JSON: {"outcome":"escalated","attempts":3}
+         A.status == Escalated
+
+test: cli_suppress_check_returns_proper_exit_code
+  given: suppress(fp="x", reason="r", until=t0+1h)
+  when:  `autopilot suppress check --fingerprint x --reason r`
+  then:  exit 0   # 억제 중
+
+  when (window 만료 후): 동일 호출
+  then:  exit 1   # 억제 안 됨
+
+test: cli_epic_reconcile_applies_plan_idempotently
+  given: empty store
+  when:  `autopilot epic reconcile --name e --plan <plan.jsonl>` 두 번
+  then:  두 번째 호출 후 store 상태 == 첫 번째 호출 후 상태
+         events 에 reconciled 가 2건
 ```
 
-### UC-3. 의존성 있는 Task
-
-```
-test: uc3_dependent_task_not_claimed_until_parent_done
-  fixture: tasks A(ready), B(pending, deps=[A])
-  when:
-    claim_next_task -> A
-    complete_task_and_unblock(A, pr=1)
-    claim_next_task -> ?
-  then:  세 번째 결과는 Some(B)
-         events: A.completed before B.claimed
-
-test: uc3_escalated_parent_blocks_child
-  fixture: A(wip, attempts=max), B(pending, deps=[A])
-  when:  mark_task_failed(A, max_attempts) → Escalated
-  then:  B.status == 'blocked'
-```
-
-### UC-4. Epic 이어받기
-
-```
-test: uc4_resume_reconstructs_state_from_remote
-  fixture:
-    store: empty (다른 머신 또는 DB 손실 가정)
-    git.remote_branches: ["epic/e", "epic/e/<idA>", "epic/e/<idB>"]
-    github.prs: [{head:"epic/e/<idA>", base:"epic/e", merged:true, number:10}]
-    decomposer: tasks=[A,B,C]   # idA,idB,idC 결정적
-  when:  EpicManager::resume("e")
-  then:
-    A.status == 'done', A.pr_number == 10
-    B.status == 'wip'           # 브랜치만 있고 PR 없음
-    C.status == 'ready'         # 브랜치 없음, deps 만족
-    events: kind='reconciled'
-
-test: uc4_resume_reports_orphan_branch
-  fixture: remote has "epic/e/<unknown_id>"
-  when:  EpicManager::resume("e")
-  then:  events 에 reconciled.payload.orphan_branch=="epic/e/<unknown_id>" 1건
-```
-
-### UC-5. DB 손실 후 복구
-
-```
-test: uc5_lost_db_recovers_via_resume
-  fixture: 같은 fixture 를 두 번 실행 — 첫 번째는 실 DB, 두 번째는 DB 파일 삭제 후 resume
-  then:  두 번째 실행 후 store 상태가 첫 번째의 의미적 상태와 일치
-         단, attempts 카운터는 0 으로 재설정 (허용 손실)
-```
-
-### UC-6. Watch 매칭 task append
-
-```
-test: uc6_gap_watch_appends_task_when_spec_matches_active_epic
-  fixture: active epic "e" with spec_path="spec/auth.md"
-  when:  WatchDispatcher::dispatch(GapFinding {
-           spec_path:"spec/auth.md",
-           section:"## 인증", req:"새로운 갭",
-           fingerprint:"fp-1"
-         })
-  then:  store.list_tasks_by_epic("e") 가 1건 증가
-         새 task.source == 'gap-watch'
-         github.issues empty   # 매칭됐으므로 이슈 발행 없음
-
-test: uc6_duplicate_fingerprint_is_no_op
-  fixture: epic "e" 에 이미 fingerprint="fp-1" 인 task
-  when:  WatchDispatcher::dispatch(finding with fp-1)
-  then:  store.tasks count unchanged
-         events kind='watch_duplicate' 1건
-```
-
-### UC-7. Watch 미매칭 escalation
-
-```
-test: uc7_unmatched_watch_creates_escalation_issue
-  fixture: 활성 epic 의 spec_path 와 다른 path
-  when:  WatchDispatcher::dispatch(finding)
-  then:  github.issues count == 1
-         issue.labels contains "autopilot:hitl-needed"
-         store.tasks unchanged (미매칭 watch 는 task 미생성)
-         escalation_suppression 에 fingerprint 기록
-
-test: uc7_suppressed_fingerprint_skips_issue
-  fixture: escalation_suppression 에 fp 가 활성 (now < suppress_until)
-  when:  WatchDispatcher::dispatch(finding with fp)
-  then:  github.issues count unchanged
-```
-
-### UC-8. 반복 실패 escalation
-
-```
-test: uc8_max_attempts_creates_escalation_issue
-  fixture: A(wip, attempts=2), max_attempts=3
-  when:
-    mark_task_failed(A, max=3)        # → Retried{attempts:2}
-    re-claim → mark_task_failed(A, max=3)   # 이제 attempts=3 → Escalated
-    Escalator::escalate(A)             # GitHub 이슈 발행
-  then:  github.issues count == 1
-         A.escalated_issue == issue.number
-         A.status == 'escalated'
-```
-
-### UC-9. 사람이 escalation 처리
-
-```
-test: uc9a_resolved_by_starting_new_epic
-  fixture: open escalation issue with epic="none"
-  when:  사람이 EpicManager::start(...) 로 새 epic 시작
-  then:  새 epic 활성화. 기존 escalation 이슈는 사람이 close 해야 닫힘 (자동 close 안함)
-
-test: uc9b_resolved_by_absorbing_into_existing_epic
-  fixture: 활성 epic "e" + open escalation issue
-  when:  analyze-issue 가 이슈 본문 → spec 매칭 후 task append
-  then:  store 에 새 task 1건, source='human', body 에 issue_number 메타
-         이슈는 코멘트 추가 후 close
-
-test: uc9d_human_fixed_directly_marks_done_on_resume
-  fixture: A.status='escalated', 사람이 직접 코드 push 후 PR merged
-  when:  EpicManager::resume(...)
-  then:  reconcile 로 A.status='done' 으로 전이
-
-test: uc9_escalation_watcher_picks_up_human_close_without_resume
-  fixture:
-    epic "e" active, A.status='escalated', A.escalated_issue=#42
-    github.issues[42].closed = true
-    git.remote: PR head=epic/e/<A_id> base=epic/e merged=true
-    decomposer: tasks 에 A 포함
-  when:  EscalationWatcher::tick()
-  then:  A.status == 'done'
-         events kind='escalation_resolved', payload.resolution=='human_fixed'
-         # resume 호출 없이 자동 인식
-
-test: uc9_escalation_watcher_records_rejection_on_close_without_code
-  fixture:
-    epic "e" active, A.status='escalated', A.escalated_issue=#42, fingerprint='fp-A'
-    github.issues[42].closed = true
-    git.remote: 해당 task 의 feature 브랜치 / PR 없음
-  when:  EscalationWatcher::tick()
-  then:  A.status == 'escalated' 유지   # reconcile 결과 done 아님
-         suppression(fp='fp-A', reason='rejected_by_human') 활성
-         events kind='escalation_resolved', payload.resolution=='rejected'
-```
-
-### UC-10. Epic 완료
-
-```
-test: uc10_all_tasks_done_completes_epic_and_notifies
-  fixture: epic "e" 의 마지막 task A 가 wip → done 으로 전이 직후
-  when:  MergeLoop::tick() 가 마지막 PR 머지 후 epic 완료 판정
-  then:  epic.status == 'completed'
-         notifier.sent contains EpicCompleted{ epic:"e" }
-         no automatic main-merge PR 생성  # main 머지는 사람의 몫
-
-test: uc10_does_not_complete_with_open_escalations
-  fixture: epic 의 task 들 중 하나가 escalated 이고 issue 가 open
-  when:  MergeLoop::tick()
-  then:  epic.status == 'active' 유지
-         notifier.sent 에 EpicCompleted 없음
-```
-
-### UC-11. 동시 진행 자연 차단
-
-```
-test: uc11_push_reject_releases_claim_without_attempt_charge
-  fixture: BuildLoop 가 task A 를 claim, IM 이 push 시도하나 git.push_rejects 로 reject
-  when:  IM 결과 처리
-  then:  A.status == 'ready'
-         events kind='claim_lost'
-         A.attempts == 0   # release_claim 으로 차감되어 다음 cycle 에서 새 시도
-
-test: uc11_concurrent_claim_yields_one_winner
-  given: store 에 ready task A 1건
-  when:  두 BuildLoop 인스턴스가 동시에 claim
-  then:  한 쪽만 Some(A), 다른 쪽 None
-         tasks.attempts == 1
-         events kind='task_claimed' 1건
-```
-
-### UC-12. Epic 강제 중단
-
-```
-test: uc12_stop_marks_abandoned_and_keeps_branches
-  fixture: epic "e" with task A(wip)
-  when:  EpicManager::stop("e", purge_branches=false)
-  then:  epic.status == 'abandoned'
-         A.status == 'wip' (보존)
-         git.remote_branches contains "epic/e" (삭제 안 함)
-
-test: uc12_stop_with_purge_deletes_unmerged_branches
-  fixture: epic with feature branches, 일부 PR merged
-  when:  EpicManager::stop("e", purge_branches=true)
-  then:  머지된 PR 의 feature 브랜치만 삭제
-         미머지 feature 브랜치는 보존 (작업 손실 방지)
-```
-
-### UC-13. 마이그레이션
-
-```
-test: uc13_import_issue_creates_task_and_strips_label
-  fixture:
-    epic "e" active, spec_path="spec/auth.md"
-    github.issues = [{ number:5, title:"...", labels:[":ready"], body:"...spec/auth.md..." }]
-  when:  MigrateCommand::import_issue(5)
-  then:
-    store.list_tasks_by_epic("e") 1건 증가
-    new_task.source == 'human'
-    new_task.body contains "issue #5"
-    github.issues[5].labels does NOT contain ":ready"
-    github.issues[5].comments contains "task <id> 로 흡수됨"
-
-test: uc13_unmatched_issue_falls_back_to_escalation
-  fixture: 이슈의 spec 매칭 실패
-  when:  MigrateCommand::import_issue(5)
-  then:  task 생성 안 됨
-         이슈는 그대로 유지 (사람이 수동 처리)
-```
+L3 의 의도는 **CLI 인자 파싱 / 트레이트 디스패치 / JSON 출력** 의 안정성. 비즈니스 로직 검증은 L2 가 담당하므로 L3 는 가벼운 분량으로 유지.
 
 ## 6. L4: Property 테스트
 
@@ -602,10 +378,13 @@ proptest: deterministic_task_id_no_collision_in_realistic_corpus
   generator: 1000개 spec section/requirement 쌍 (Korean+English mix, 길이 1..200)
   property: { TaskId(...) } 가 모두 unique 하거나 입력이 정규화 후 동일
 
-proptest: claim_invariant_attempts_monotonic
-  for any sequence of (claim → mark_failed | revert) operations:
-    task.attempts 는 단조 증가 (감소하지 않음)
-    final status ∈ {ready, wip, escalated, done}
+proptest: attempts_bounded_by_real_attempts
+  for any sequence of operations from {claim, mark_failed, release_claim, complete}:
+    let real_attempts =
+        (# of claim) - (# of release_claim immediately following the matching claim)
+    final task.attempts == real_attempts
+    final task.attempts 는 결코 0 미만이 되지 않음 (saturating_sub 보장)
+    final status ∈ {Ready, Wip, Escalated, Done, Pending, Blocked}
 
 proptest: reconcile_idempotent_under_arbitrary_remote_state
   generator: 임의 remote_state (브랜치 + PR 조합)
@@ -624,42 +403,40 @@ proptest: dep_graph_topological_order_respects_constraints
 
 | Fake | 보장 동작 |
 |------|----------|
-| `InMemoryTaskStore` | 단일 `Mutex<State>` 로 모든 메서드 atomic. SqliteTaskStore 와 같은 트랜잭션 의미 |
-| `FakeGitClient` | 가상 ref 그래프. `push_rejects` 리스트에 등록된 브랜치는 항상 `Rejected` 반환. push 성공 시 ref 추가 |
-| `FakeGitHubClient` | 이슈/PR 의 in-memory store. PR.merged 는 명시적 `merge_pr` 호출 시에만 true |
-| `FakeDecomposer` | fixture 의 tasks/deps 를 그대로 반환. `fail` 옵션 시 지정된 에러 반환 |
-| `FakeNotifier` | 호출 시 메시지를 `sent: Vec<NotificationEvent>` 에 누적 |
+| `InMemoryTaskStore` | 단일 `Mutex<State>` 로 모든 메서드 atomic. `SqliteTaskStore` 와 같은 트랜잭션 의미 |
 | `FixedClock` | `now()` 가 고정. 테스트가 명시적으로 advance 가능 |
+
+git / github / decompose / notifier 의 fake 는 **본 spec 의 책임이 아니다** — agent 측에서 자기 워크플로 통합 테스트에 필요할 때 만든다.
 
 ### 7.2 Builder 함수 (예)
 
 ```rust
-let world = TestWorld::new()
-    .with_clock_at("2026-04-28T09:00:00Z")
-    .with_active_epic("e", spec="spec/auth.md")
-    .with_tasks(&["A", "B"])
-    .with_deps(&[("B", "A")])
-    .with_remote_branches(&["epic/e", "epic/e/<A_id>"])
-    .with_merged_pr(number=10, head="epic/e/<A_id>", base="epic/e");
+let store = Arc::new(InMemoryTaskStore::new()) as Arc<dyn TaskStore>;
+let clock = FixedClock::at("2026-04-28T09:00:00Z");
 
-let outcome = world.epic_manager().resume("e")?;
-world.assert_task_status("A", TaskStatus::Done);
-world.assert_task_status("B", TaskStatus::Wip);
+store.insert_epic_with_tasks(plan("e", vec![nt("A","a"), nt("B","b")],
+                                  vec![("B","A")]), clock.now())?;
+store.claim_next_task("e", clock.now())?;       // A → Wip
+store.complete_task_and_unblock(&id("A"), 42, clock.now())?;
+assert_eq!(store.get_task(&id("A"))?.unwrap().status, TaskStatus::Done);
+assert_eq!(store.get_task(&id("B"))?.unwrap().status, TaskStatus::Ready);
 ```
 
-빌더는 03 의 도메인 타입 + 결정적 ID 함수를 사용하여 fixture 의 `<A_id>` 를 자동 계산한다.
+빌더는 03 의 도메인 타입 + 결정적 ID 함수를 사용한다. CLI L3 테스트에서는 `assert_cmd::Command` 같은 도구로 실행 + stdout / exit code 검사.
 
 ## 8. 카버리지 목표
 
 - L1: 100% (pure 함수 — 작성 즉시 모두 다룰 수 있음)
 - L2: TaskStore trait 의 모든 public 메서드에 ≥1 시나리오 + LSP suite 전체 양 구현체 통과
-- L3: 01 의 13개 UC 마다 ≥1 happy path + ≥1 대안 흐름
+- L3: 03 §6 의 ledger CLI 명령마다 ≥1 happy path 시나리오. 에러 / 빈 결과 / JSON 형식 검증 포함
 - L4: 본 문서에 명시된 4개 property 모두 통과
 
 CI 게이트: 위 목표 미달 시 PR 차단.
 
+UC-1~13 시나리오 (01 의 사용자 흐름 통합 검증) 는 **agent 측의 책임** — 본 문서의 카버리지 항목 아님.
+
 ## 9. 본 문서의 변경 정책
 
-- UC 가 추가/변경되면 (01 갱신) 본 문서의 L3 시나리오도 함께 추가
-- 03 의 시그니처가 변경되면 본 문서의 코드 단편도 함께 갱신
-- 신규 시나리오는 가능한 한 기존 fixture builder 를 재사용
+- 03 의 시그니처가 변경되면 본 문서의 L2 / L3 / L4 코드 단편도 함께 갱신
+- ledger CLI 명령이 추가되면 L3 에 happy path 시나리오 추가
+- 신규 property 가 도출되면 L4 에 추가

--- a/plans/github-autopilot/04-test-scenarios.md
+++ b/plans/github-autopilot/04-test-scenarios.md
@@ -144,10 +144,18 @@ test: claim_is_atomic_under_concurrent_callers
   then:  정확히 한쪽만 Some(A) 를 받고 다른 쪽은 None
          get_task(A).attempts == 1   # 한 번만 증가
 
-test: claim_increments_attempts_on_each_call
+test: claim_increments_attempts_only_on_real_attempt
   given: 1 ready task A
-  when:  claim → revert_to_ready → claim
+  when:  claim → release_claim → claim
+  then:  attempts == 1
+         -- release_claim 은 시도조차 못 한 경우(UC-11)에 사용되며,
+         -- claim 의 +1 을 차감하여 max_attempts 카운트에 영향 없음
+
+test: mark_task_failed_preserves_attempts_for_retry
+  given: 1 ready task A, max_attempts=3
+  when:  claim → mark_task_failed (Retried) → claim → mark_task_failed (Retried)
   then:  attempts == 2
+         -- 시도 후 실패는 attempts 보존 (escalation 카운트에 반영)
 ```
 
 ### 4.3 complete_task_and_unblock
@@ -226,7 +234,77 @@ test: upsert_watch_task_returns_duplicate_on_existing_fingerprint
          no new task inserted
 ```
 
-### 4.7 schema_version 일관성 (SQLite 전용)
+### 4.7 lookup helpers
+
+```
+test: find_task_by_pr_returns_owning_task
+  given: A(done, pr_number=42), B(wip, pr_number=None)
+  when:  find_task_by_pr(42)
+  then:  Ok(Some(A))
+
+test: find_task_by_pr_returns_none_when_unknown
+  when:  find_task_by_pr(9999)
+  then:  Ok(None)
+
+test: find_active_by_spec_path_matches_active_only
+  given: epic e1(active, spec="spec/auth.md"), e2(abandoned, spec="spec/auth.md")
+  when:  find_active_by_spec_path("spec/auth.md")
+  then:  Ok(Some(e1))   # abandoned 는 제외
+
+test: find_active_by_spec_path_returns_none_when_no_match
+  given: epic e1(active, spec="spec/payments.md")
+  when:  find_active_by_spec_path("spec/auth.md")
+  then:  Ok(None)
+
+test: find_active_by_spec_path_rejects_invariant_violation
+  given: epic e1(active, spec="spec/auth.md"), e2(active, spec="spec/auth.md")
+         # 정상 흐름에서는 만들 수 없으나 직접 삽입했다고 가정
+  when:  find_active_by_spec_path("spec/auth.md")
+  then:  Err(DomainError::Inconsistency(_))
+```
+
+### 4.8 force_status
+
+```
+test: force_status_bypasses_normal_transition
+  given: A(escalated)
+  when:  force_status(A, target=Pending, reason="manual reset")
+  then:  A.status == 'pending'
+         events kind 에 reason 이 payload 로 기록됨
+
+test: force_status_does_not_unblock_dependents
+  given: A(escalated), B(blocked, deps=[A])
+  when:  force_status(A, target=Done, reason="human fixed")
+  then:  A.status == 'done'
+         B.status == 'blocked'   # force_status 는 자식 unblock 안 함
+         # → 호출자가 별도로 reconcile / 메서드를 호출해야 함
+
+test: force_status_records_event_with_reason
+  given: A(wip)
+  when:  force_status(A, target=Ready, reason="rollback")
+  then:  events 에 force_status 기록, payload.reason == "rollback"
+```
+
+### 4.9 suppression
+
+```
+test: suppression_blocks_until_window_expires
+  fixture: clock at t0
+  when:  suppress(fp="fp-1", reason="unmatched_watch", until=t0+1h)
+         is_suppressed(fp-1, "unmatched_watch", at=t0+30m) -> true
+         is_suppressed(fp-1, "unmatched_watch", at=t0+2h)  -> false
+
+test: suppression_is_scoped_by_reason
+  when:  suppress(fp="fp-1", reason="unmatched_watch", ...)
+         is_suppressed(fp-1, "rejected_by_human", now) -> false
+
+test: suppression_clear_unblocks_immediately
+  when:  suppress(fp-1, "r", until=far_future)
+         clear(fp-1, "r")
+         is_suppressed(fp-1, "r", now) -> false
+```
+
+### 4.10 schema_version 일관성 (SQLite 전용)
 
 ```
 test: sqlite_initializes_schema_v1_on_empty_db
@@ -420,6 +498,27 @@ test: uc9d_human_fixed_directly_marks_done_on_resume
   fixture: A.status='escalated', 사람이 직접 코드 push 후 PR merged
   when:  EpicManager::resume(...)
   then:  reconcile 로 A.status='done' 으로 전이
+
+test: uc9_escalation_watcher_picks_up_human_close_without_resume
+  fixture:
+    epic "e" active, A.status='escalated', A.escalated_issue=#42
+    github.issues[42].closed = true
+    git.remote: PR head=epic/e/<A_id> base=epic/e merged=true
+    decomposer: tasks 에 A 포함
+  when:  EscalationWatcher::tick()
+  then:  A.status == 'done'
+         events kind='escalation_resolved', payload.resolution=='human_fixed'
+         # resume 호출 없이 자동 인식
+
+test: uc9_escalation_watcher_records_rejection_on_close_without_code
+  fixture:
+    epic "e" active, A.status='escalated', A.escalated_issue=#42, fingerprint='fp-A'
+    github.issues[42].closed = true
+    git.remote: 해당 task 의 feature 브랜치 / PR 없음
+  when:  EscalationWatcher::tick()
+  then:  A.status == 'escalated' 유지   # reconcile 결과 done 아님
+         suppression(fp='fp-A', reason='rejected_by_human') 활성
+         events kind='escalation_resolved', payload.resolution=='rejected'
 ```
 
 ### UC-10. Epic 완료
@@ -442,12 +541,12 @@ test: uc10_does_not_complete_with_open_escalations
 ### UC-11. 동시 진행 자연 차단
 
 ```
-test: uc11_push_reject_reverts_task_to_ready
+test: uc11_push_reject_releases_claim_without_attempt_charge
   fixture: BuildLoop 가 task A 를 claim, IM 이 push 시도하나 git.push_rejects 로 reject
   when:  IM 결과 처리
   then:  A.status == 'ready'
          events kind='claim_lost'
-         tasks 의 attempts 는 증가했지만 다음 cycle 에 다시 claim 가능
+         A.attempts == 0   # release_claim 으로 차감되어 다음 cycle 에서 새 시도
 
 test: uc11_concurrent_claim_yields_one_winner
   given: store 에 ready task A 1건

--- a/plugins/github-autopilot/cli/Cargo.lock
+++ b/plugins/github-autopilot/cli/Cargo.lock
@@ -99,6 +99,7 @@ dependencies = [
  "sha2",
  "tempfile",
  "thiserror",
+ "toml",
  "unicode-normalization",
 ]
 
@@ -630,6 +631,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -722,6 +732,47 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "typenum"
@@ -931,6 +982,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/plugins/github-autopilot/cli/Cargo.toml
+++ b/plugins/github-autopilot/cli/Cargo.toml
@@ -21,6 +21,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
 thiserror = "1"
+toml = "0.8"
 unicode-normalization = "0.1"
 
 [dev-dependencies]

--- a/plugins/github-autopilot/cli/src/cmd/epic.rs
+++ b/plugins/github-autopilot/cli/src/cmd/epic.rs
@@ -1,0 +1,510 @@
+//! Epic ledger subcommands.
+//!
+//! Pure ledger surface: every operation is a thin adapter over `TaskStore`.
+//! Agents own spec decomposition, git, and GitHub; this module only
+//! persists state.
+
+use std::collections::BTreeMap;
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use clap::{Args, Subcommand, ValueEnum};
+use serde::{Deserialize, Serialize};
+
+use crate::domain::{DomainError, Epic, EpicStatus, TaskId, TaskSource, TaskStatus};
+use crate::ports::clock::Clock;
+use crate::ports::task_store::{
+    EpicPlan, NewTask, ReconciliationPlan, RemotePrState, RemoteTaskState, TaskStore,
+    TaskStoreError,
+};
+
+#[derive(Subcommand)]
+pub enum EpicCommands {
+    /// Begin tracking a new epic
+    Create(CreateArgs),
+    /// List epics
+    List(ListArgs),
+    /// Show a single epic
+    Get(GetArgs),
+    /// Task status counts for an epic (or all active epics)
+    Status(StatusArgs),
+    /// Mark epic as completed
+    Complete(NameArg),
+    /// Mark epic as abandoned
+    Abandon(NameArg),
+    /// Apply a reconciliation plan (JSONL on disk) to an epic
+    Reconcile(ReconcileArgs),
+    /// Look up the active epic owning a spec path
+    FindBySpecPath(FindBySpecPathArgs),
+}
+
+#[derive(Args)]
+pub struct CreateArgs {
+    #[arg(long)]
+    pub name: String,
+    #[arg(long)]
+    pub spec: PathBuf,
+    /// Defaults to `epic/<NAME>` when omitted.
+    #[arg(long)]
+    pub branch: Option<String>,
+}
+
+#[derive(Args)]
+pub struct ListArgs {
+    #[arg(long)]
+    pub status: Option<EpicStatusFilter>,
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Args)]
+pub struct GetArgs {
+    pub name: String,
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Args)]
+pub struct StatusArgs {
+    pub name: Option<String>,
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Args)]
+pub struct NameArg {
+    pub name: String,
+}
+
+#[derive(Args)]
+pub struct ReconcileArgs {
+    #[arg(long)]
+    pub name: String,
+    #[arg(long)]
+    pub plan: PathBuf,
+}
+
+#[derive(Args)]
+pub struct FindBySpecPathArgs {
+    pub spec: PathBuf,
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum, PartialEq, Eq)]
+pub enum EpicStatusFilter {
+    Active,
+    Completed,
+    Abandoned,
+    All,
+}
+
+impl EpicStatusFilter {
+    pub fn to_status(self) -> Option<EpicStatus> {
+        match self {
+            Self::Active => Some(EpicStatus::Active),
+            Self::Completed => Some(EpicStatus::Completed),
+            Self::Abandoned => Some(EpicStatus::Abandoned),
+            Self::All => None,
+        }
+    }
+}
+
+pub struct EpicService<'a> {
+    store: &'a dyn TaskStore,
+    clock: &'a dyn Clock,
+}
+
+impl<'a> EpicService<'a> {
+    pub fn new(store: &'a dyn TaskStore, clock: &'a dyn Clock) -> Self {
+        Self { store, clock }
+    }
+
+    pub fn create(
+        &self,
+        name: &str,
+        spec_path: &Path,
+        branch: Option<&str>,
+        out: &mut dyn Write,
+    ) -> Result<i32> {
+        let now = self.clock.now();
+        let epic = Epic {
+            name: name.to_string(),
+            spec_path: spec_path.to_path_buf(),
+            branch: branch
+                .map(str::to_string)
+                .unwrap_or_else(|| format!("epic/{name}")),
+            status: EpicStatus::Active,
+            created_at: now,
+            completed_at: None,
+        };
+        let plan = EpicPlan {
+            epic,
+            tasks: vec![],
+            deps: vec![],
+        };
+        match self.store.insert_epic_with_tasks(plan, now) {
+            Ok(()) => {
+                writeln!(out, "epic '{name}' created")?;
+                Ok(0)
+            }
+            Err(TaskStoreError::Domain(DomainError::EpicAlreadyExists(n, st))) => {
+                writeln!(out, "epic '{n}' already exists ({})", st.as_str())?;
+                Ok(1)
+            }
+            Err(e) => Err(e).with_context(|| format!("creating epic '{name}'")),
+        }
+    }
+
+    pub fn list(
+        &self,
+        status: Option<EpicStatusFilter>,
+        json: bool,
+        out: &mut dyn Write,
+    ) -> Result<i32> {
+        let filter = status.and_then(EpicStatusFilter::to_status);
+        let epics = self.store.list_epics(filter).context("listing epics")?;
+        if json {
+            return write_json(out, &epics).map(|()| 0);
+        }
+        if epics.is_empty() {
+            writeln!(out, "(no epics)")?;
+            return Ok(0);
+        }
+        writeln!(
+            out,
+            "NAME                STATUS      BRANCH                    SPEC"
+        )?;
+        for e in &epics {
+            writeln!(
+                out,
+                "{:<18}  {:<10}  {:<24}  {}",
+                e.name,
+                e.status.as_str(),
+                e.branch,
+                e.spec_path.display()
+            )?;
+        }
+        Ok(0)
+    }
+
+    pub fn get(&self, name: &str, json: bool, out: &mut dyn Write) -> Result<i32> {
+        let Some(epic) = self
+            .store
+            .get_epic(name)
+            .with_context(|| format!("fetching epic '{name}'"))?
+        else {
+            writeln!(out, "epic '{name}' not found")?;
+            return Ok(1);
+        };
+        render_epic(&epic, json, out)?;
+        Ok(0)
+    }
+
+    pub fn status(&self, name: Option<&str>, json: bool, out: &mut dyn Write) -> Result<i32> {
+        let epics: Vec<Epic> = match name {
+            Some(n) => {
+                let Some(e) = self.store.get_epic(n)? else {
+                    writeln!(out, "epic '{n}' not found")?;
+                    return Ok(1);
+                };
+                vec![e]
+            }
+            None => self.store.list_epics(Some(EpicStatus::Active))?,
+        };
+
+        let mut reports: Vec<EpicStatusReport> = Vec::with_capacity(epics.len());
+        for e in &epics {
+            let tasks = self.store.list_tasks_by_epic(&e.name, None)?;
+            let mut counts = StatusCounts::default();
+            for t in &tasks {
+                match t.status {
+                    TaskStatus::Pending => counts.pending += 1,
+                    TaskStatus::Ready => counts.ready += 1,
+                    TaskStatus::Wip => counts.wip += 1,
+                    TaskStatus::Blocked => counts.blocked += 1,
+                    TaskStatus::Done => counts.done += 1,
+                    TaskStatus::Escalated => counts.escalated += 1,
+                }
+            }
+            reports.push(EpicStatusReport {
+                epic: e.name.clone(),
+                status: e.status,
+                total: tasks.len(),
+                counts,
+            });
+        }
+
+        if json {
+            return write_json(out, &reports).map(|()| 0);
+        }
+        if reports.is_empty() {
+            writeln!(out, "(no active epics)")?;
+            return Ok(0);
+        }
+        writeln!(
+            out,
+            "EPIC               STATUS     PEND READY  WIP  BLK DONE  ESC TOTAL"
+        )?;
+        for r in &reports {
+            writeln!(
+                out,
+                "{:<18} {:<10} {:>4} {:>5} {:>4} {:>4} {:>4} {:>4} {:>5}",
+                r.epic,
+                r.status.as_str(),
+                r.counts.pending,
+                r.counts.ready,
+                r.counts.wip,
+                r.counts.blocked,
+                r.counts.done,
+                r.counts.escalated,
+                r.total
+            )?;
+        }
+        Ok(0)
+    }
+
+    pub fn complete(&self, name: &str, out: &mut dyn Write) -> Result<i32> {
+        self.set_status(name, EpicStatus::Completed, out)
+    }
+
+    pub fn abandon(&self, name: &str, out: &mut dyn Write) -> Result<i32> {
+        self.set_status(name, EpicStatus::Abandoned, out)
+    }
+
+    fn set_status(&self, name: &str, target: EpicStatus, out: &mut dyn Write) -> Result<i32> {
+        let now = self.clock.now();
+        match self.store.set_epic_status(name, target, now) {
+            Ok(()) => {
+                writeln!(out, "epic '{name}' {}", target.as_str())?;
+                Ok(0)
+            }
+            Err(TaskStoreError::NotFound(_)) => {
+                writeln!(out, "epic '{name}' not found")?;
+                Ok(1)
+            }
+            Err(e) => {
+                Err(e).with_context(|| format!("setting epic '{name}' to {}", target.as_str()))
+            }
+        }
+    }
+
+    pub fn find_by_spec_path(
+        &self,
+        spec_path: &Path,
+        json: bool,
+        out: &mut dyn Write,
+    ) -> Result<i32> {
+        match self.store.find_active_by_spec_path(spec_path) {
+            Ok(Some(e)) => {
+                render_epic(&e, json, out)?;
+                Ok(0)
+            }
+            Ok(None) => {
+                writeln!(out, "(no active epic for {})", spec_path.display())?;
+                Ok(1)
+            }
+            Err(TaskStoreError::Domain(DomainError::Inconsistency(msg))) => {
+                writeln!(out, "inconsistency: {msg}")?;
+                Ok(3)
+            }
+            Err(e) => Err(e)
+                .with_context(|| format!("finding active epic for spec '{}'", spec_path.display())),
+        }
+    }
+
+    pub fn reconcile(&self, name: &str, plan_path: &Path, out: &mut dyn Write) -> Result<i32> {
+        let now = self.clock.now();
+        let existing = match self
+            .store
+            .get_epic(name)
+            .with_context(|| format!("fetching epic '{name}' for reconcile"))?
+        {
+            Some(e) => e,
+            None => {
+                writeln!(
+                    out,
+                    "epic '{name}' not found — run `autopilot epic create` first"
+                )?;
+                return Ok(1);
+            }
+        };
+        let plan = parse_reconcile_jsonl(plan_path, existing)
+            .with_context(|| format!("parsing reconcile plan {}", plan_path.display()))?;
+        match self.store.apply_reconciliation(plan, now) {
+            Ok(()) => {
+                writeln!(out, "epic '{name}' reconciled")?;
+                Ok(0)
+            }
+            Err(TaskStoreError::Domain(DomainError::DepCycle(cycle))) => {
+                writeln!(out, "dependency cycle: {cycle:?}")?;
+                Ok(1)
+            }
+            Err(e) => Err(e).with_context(|| format!("reconciling epic '{name}'")),
+        }
+    }
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize)]
+struct StatusCounts {
+    pending: u32,
+    ready: u32,
+    wip: u32,
+    blocked: u32,
+    done: u32,
+    escalated: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct EpicStatusReport {
+    epic: String,
+    status: EpicStatus,
+    total: usize,
+    counts: StatusCounts,
+}
+
+fn render_epic(e: &Epic, json: bool, out: &mut dyn Write) -> Result<()> {
+    if json {
+        return write_json(out, e);
+    }
+    writeln!(out, "name:         {}", e.name)?;
+    writeln!(out, "status:       {}", e.status.as_str())?;
+    writeln!(out, "branch:       {}", e.branch)?;
+    writeln!(out, "spec_path:    {}", e.spec_path.display())?;
+    writeln!(out, "created_at:   {}", e.created_at.to_rfc3339())?;
+    if let Some(ts) = e.completed_at {
+        writeln!(out, "completed_at: {}", ts.to_rfc3339())?;
+    }
+    Ok(())
+}
+
+fn write_json<T: Serialize>(out: &mut dyn Write, value: &T) -> Result<()> {
+    serde_json::to_writer(&mut *out, value)?;
+    writeln!(out)?;
+    Ok(())
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum PlanLine {
+    Task {
+        id: String,
+        title: String,
+        #[serde(default)]
+        body: Option<String>,
+        #[serde(default)]
+        fingerprint: Option<String>,
+        #[serde(default)]
+        source: Option<String>,
+    },
+    Dep {
+        task: String,
+        depends_on: String,
+    },
+    RemoteState {
+        task_id: String,
+        branch_exists: bool,
+        #[serde(default)]
+        pr: Option<PlanPr>,
+    },
+    OrphanBranch {
+        #[serde(rename = "ref")]
+        branch_ref: String,
+    },
+}
+
+#[derive(Debug, Deserialize)]
+struct PlanPr {
+    number: u64,
+    #[serde(default)]
+    merged: bool,
+    #[serde(default)]
+    closed: bool,
+}
+
+fn parse_reconcile_jsonl(plan_path: &Path, existing: Epic) -> Result<ReconciliationPlan> {
+    let file = std::fs::File::open(plan_path)
+        .with_context(|| format!("opening {}", plan_path.display()))?;
+    let reader = BufReader::new(file);
+
+    let mut tasks: BTreeMap<String, NewTask> = BTreeMap::new();
+    let mut deps: Vec<(TaskId, TaskId)> = Vec::new();
+    let mut remote_state: Vec<RemoteTaskState> = Vec::new();
+    let mut orphan_branches: Vec<String> = Vec::new();
+
+    for (lineno, line) in reader.lines().enumerate() {
+        let line = line.with_context(|| format!("reading line {}", lineno + 1))?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        let parsed: PlanLine = serde_json::from_str(trimmed)
+            .with_context(|| format!("parsing line {}: {trimmed}", lineno + 1))?;
+        match parsed {
+            PlanLine::Task {
+                id,
+                title,
+                body,
+                fingerprint,
+                source,
+            } => {
+                let source = source
+                    .as_deref()
+                    .map(|s| {
+                        TaskSource::parse(s).ok_or_else(|| {
+                            anyhow::anyhow!("unknown source '{s}' on line {}", lineno + 1)
+                        })
+                    })
+                    .transpose()?
+                    .unwrap_or(TaskSource::Decompose);
+                let nt = NewTask {
+                    id: TaskId::from_raw(&id),
+                    source,
+                    fingerprint,
+                    title,
+                    body,
+                };
+                if tasks.insert(id.clone(), nt).is_some() {
+                    anyhow::bail!("duplicate task id '{id}' on line {}", lineno + 1);
+                }
+            }
+            PlanLine::Dep { task, depends_on } => {
+                deps.push((TaskId::from_raw(&task), TaskId::from_raw(&depends_on)));
+            }
+            PlanLine::RemoteState {
+                task_id,
+                branch_exists,
+                pr,
+            } => {
+                remote_state.push(RemoteTaskState {
+                    task_id: TaskId::from_raw(&task_id),
+                    branch_exists,
+                    pr: pr.map(|p| RemotePrState {
+                        number: p.number,
+                        merged: p.merged,
+                        closed: p.closed,
+                    }),
+                });
+            }
+            PlanLine::OrphanBranch { branch_ref } => {
+                orphan_branches.push(branch_ref);
+            }
+        }
+    }
+
+    Ok(ReconciliationPlan {
+        epic: Epic {
+            status: EpicStatus::Active,
+            ..existing
+        },
+        tasks: tasks.into_values().collect(),
+        deps,
+        remote_state,
+        orphan_branches,
+    })
+}
+
+pub fn epic_service<'a>(store: &'a dyn TaskStore, clock: &'a dyn Clock) -> EpicService<'a> {
+    EpicService::new(store, clock)
+}

--- a/plugins/github-autopilot/cli/src/cmd/epic.rs
+++ b/plugins/github-autopilot/cli/src/cmd/epic.rs
@@ -12,6 +12,7 @@ use anyhow::{Context, Result};
 use clap::{Args, Subcommand, ValueEnum};
 use serde::{Deserialize, Serialize};
 
+use crate::cmd::output::write_json;
 use crate::domain::{DomainError, Epic, EpicStatus, TaskId, TaskSource, TaskStatus};
 use crate::ports::clock::Clock;
 use crate::ports::task_store::{
@@ -376,12 +377,6 @@ fn render_epic(e: &Epic, json: bool, out: &mut dyn Write) -> Result<()> {
     if let Some(ts) = e.completed_at {
         writeln!(out, "completed_at: {}", ts.to_rfc3339())?;
     }
-    Ok(())
-}
-
-fn write_json<T: Serialize>(out: &mut dyn Write, value: &T) -> Result<()> {
-    serde_json::to_writer(&mut *out, value)?;
-    writeln!(out)?;
     Ok(())
 }
 

--- a/plugins/github-autopilot/cli/src/cmd/events.rs
+++ b/plugins/github-autopilot/cli/src/cmd/events.rs
@@ -1,0 +1,165 @@
+//! Event log query CLI (spec §6.4).
+//!
+//! Thin adapter over [`EventLog::list_events`]. The CLI does not synthesize
+//! events — it only renders what the store recorded — so filters here mirror
+//! [`EventFilter`] one-to-one.
+
+use std::io::Write;
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use clap::{Args, Subcommand};
+use serde::Serialize;
+
+use crate::cmd::output::write_json;
+use crate::domain::{Event, EventKind, TaskId};
+use crate::ports::task_store::{EventFilter, EventLog};
+
+const PAYLOAD_PREVIEW_LIMIT: usize = 40;
+
+#[derive(Subcommand)]
+pub enum EventsCommands {
+    /// List events in chronological order (oldest first), with filters
+    List(ListArgs),
+}
+
+#[derive(Args)]
+pub struct ListArgs {
+    /// Filter by epic name
+    #[arg(long)]
+    pub epic: Option<String>,
+    /// Filter by task id
+    #[arg(long)]
+    pub task: Option<String>,
+    /// Filter by event kind. Repeatable; unknown kinds cause exit 1.
+    #[arg(long = "kind")]
+    pub kinds: Vec<String>,
+    /// Earliest timestamp (RFC3339); inclusive
+    #[arg(long)]
+    pub since: Option<String>,
+    /// Maximum number of events to return
+    #[arg(long)]
+    pub limit: Option<u32>,
+    /// Output JSON instead of a human-readable table
+    #[arg(long)]
+    pub json: bool,
+}
+
+pub struct EventsService<'a> {
+    store: &'a dyn EventLog,
+}
+
+impl<'a> EventsService<'a> {
+    pub fn new(store: &'a dyn EventLog) -> Self {
+        Self { store }
+    }
+
+    pub fn list(&self, args: &ListArgs, out: &mut dyn Write) -> Result<i32> {
+        let kinds = match parse_kinds(&args.kinds) {
+            Ok(k) => k,
+            Err(unknown) => {
+                writeln!(out, "unknown event kind '{unknown}'")?;
+                return Ok(1);
+            }
+        };
+        let since = match args.since.as_deref().map(parse_since).transpose() {
+            Ok(s) => s,
+            Err(e) => {
+                writeln!(out, "{e}")?;
+                return Ok(1);
+            }
+        };
+
+        let filter = EventFilter {
+            epic: args.epic.clone(),
+            task: args.task.as_deref().map(TaskId::from_raw),
+            kinds,
+            since,
+            limit: args.limit,
+        };
+        let events = self.store.list_events(filter).context("listing events")?;
+
+        if args.json {
+            return write_json(
+                out,
+                &events.iter().map(EventRecord::from).collect::<Vec<_>>(),
+            )
+            .map(|()| 0);
+        }
+        render_table(&events, out)?;
+        Ok(0)
+    }
+}
+
+fn parse_kinds(raw: &[String]) -> Result<Vec<EventKind>, String> {
+    raw.iter()
+        .map(|s| EventKind::parse(s).ok_or_else(|| s.clone()))
+        .collect()
+}
+
+fn parse_since(raw: &str) -> Result<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(raw)
+        .map(|dt| dt.with_timezone(&Utc))
+        .with_context(|| format!("parsing --since '{raw}' as RFC3339"))
+}
+
+fn render_table(events: &[Event], out: &mut dyn Write) -> Result<()> {
+    if events.is_empty() {
+        writeln!(out, "(no events)")?;
+        return Ok(());
+    }
+    writeln!(
+        out,
+        "AT                            KIND                  EPIC                TASK          PAYLOAD-SUMMARY"
+    )?;
+    for e in events {
+        writeln!(
+            out,
+            "{:<28}  {:<20}  {:<18}  {:<12}  {}",
+            e.at.to_rfc3339(),
+            e.kind.as_str(),
+            e.epic_name.as_deref().unwrap_or("-"),
+            e.task_id.as_ref().map(TaskId::as_str).unwrap_or("-"),
+            payload_preview(&e.payload),
+        )?;
+    }
+    Ok(())
+}
+
+fn payload_preview(value: &serde_json::Value) -> String {
+    let s = if value.is_null() {
+        "-".to_string()
+    } else {
+        value.to_string()
+    };
+    if s.chars().count() <= PAYLOAD_PREVIEW_LIMIT {
+        return s;
+    }
+    let truncated: String = s.chars().take(PAYLOAD_PREVIEW_LIMIT).collect();
+    format!("{truncated}…")
+}
+
+#[derive(Debug, Serialize)]
+struct EventRecord<'a> {
+    at: String,
+    kind: &'static str,
+    epic: Option<&'a str>,
+    task: Option<&'a str>,
+    payload: &'a serde_json::Value,
+}
+
+impl<'a> From<&'a Event> for EventRecord<'a> {
+    fn from(e: &'a Event) -> Self {
+        Self {
+            at: e.at.to_rfc3339(),
+            kind: e.kind.as_str(),
+            epic: e.epic_name.as_deref(),
+            task: e.task_id.as_ref().map(TaskId::as_str),
+            payload: &e.payload,
+        }
+    }
+}
+
+pub fn events_service(store: &dyn EventLog) -> EventsService<'_> {
+    EventsService::new(store)
+}

--- a/plugins/github-autopilot/cli/src/cmd/mod.rs
+++ b/plugins/github-autopilot/cli/src/cmd/mod.rs
@@ -1,12 +1,15 @@
 pub mod check;
 pub mod epic;
+pub mod events;
 pub mod issue;
 pub mod issue_list;
 pub mod labels;
+pub mod output;
 pub mod pipeline;
 pub mod preflight;
 pub mod simhash;
 pub mod stats;
+pub mod suppress;
 pub mod task;
 pub mod watch;
 pub mod worktree;
@@ -20,6 +23,10 @@ use clap::{Args, Parser, Subcommand, ValueEnum};
     about = "github-autopilot deterministic CLI"
 )]
 pub struct Cli {
+    /// Path to autopilot.toml; defaults to `./autopilot.toml` if it exists
+    #[arg(long, global = true)]
+    pub config: Option<std::path::PathBuf>,
+
     #[command(subcommand)]
     pub command: Commands,
 }
@@ -64,6 +71,16 @@ pub enum Commands {
     Epic {
         #[command(subcommand)]
         command: epic::EpicCommands,
+    },
+    /// Fingerprint suppression for HITL alerts
+    Suppress {
+        #[command(subcommand)]
+        command: suppress::SuppressCommands,
+    },
+    /// Event log queries
+    Events {
+        #[command(subcommand)]
+        command: events::EventsCommands,
     },
 }
 

--- a/plugins/github-autopilot/cli/src/cmd/mod.rs
+++ b/plugins/github-autopilot/cli/src/cmd/mod.rs
@@ -1,4 +1,5 @@
 pub mod check;
+pub mod epic;
 pub mod issue;
 pub mod issue_list;
 pub mod labels;
@@ -58,6 +59,11 @@ pub enum Commands {
     Task {
         #[command(subcommand)]
         command: TaskCommands,
+    },
+    /// Epic ledger operations
+    Epic {
+        #[command(subcommand)]
+        command: epic::EpicCommands,
     },
 }
 

--- a/plugins/github-autopilot/cli/src/cmd/mod.rs
+++ b/plugins/github-autopilot/cli/src/cmd/mod.rs
@@ -89,6 +89,14 @@ pub enum TaskCommands {
         #[arg(long)]
         json: bool,
     },
+    /// Show details of a single task (alias of `show`, spec-canonical name)
+    Get {
+        /// Task id
+        task_id: String,
+        /// Output JSON
+        #[arg(long)]
+        json: bool,
+    },
     /// Force a task into a specific status (operator override)
     ForceStatus {
         /// Task id
@@ -99,6 +107,79 @@ pub enum TaskCommands {
         /// Optional reason recorded with the override
         #[arg(long)]
         reason: Option<String>,
+    },
+    /// Insert (or detect duplicate of) a watch-style task
+    Add {
+        /// Epic name
+        #[arg(long)]
+        epic: String,
+        /// Task id (deterministic 12-hex-char id)
+        #[arg(long)]
+        id: String,
+        /// Title
+        #[arg(long)]
+        title: String,
+        /// Optional body / description
+        #[arg(long)]
+        body: Option<String>,
+        /// Override fingerprint (hex). When omitted, derived from title+body.
+        #[arg(long)]
+        fingerprint: Option<String>,
+        /// Origin tag (defaults to `human`)
+        #[arg(long, default_value = "human")]
+        source: task::TaskSourceArg,
+    },
+    /// Insert tasks from a JSONL batch file
+    AddBatch {
+        /// Epic name
+        #[arg(long)]
+        epic: String,
+        /// JSONL file. Each line: {"id":"...","title":"...","body?":"...","fingerprint?":"...","source?":"..."}
+        #[arg(long)]
+        from: std::path::PathBuf,
+    },
+    /// Look up a task by the PR number it owns
+    FindByPr {
+        /// PR number
+        pr_number: u64,
+        /// Output JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// Atomically claim the next ready task on an epic (Ready -> Wip)
+    Claim {
+        /// Epic name
+        #[arg(long)]
+        epic: String,
+        /// Output JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// Release a Wip claim back to Ready (UC-11 push-reject path)
+    Release {
+        /// Task id
+        task_id: String,
+    },
+    /// Mark a task as completed and unblock its dependents
+    Complete {
+        /// Task id
+        task_id: String,
+        /// Owning PR number
+        #[arg(long)]
+        pr: u64,
+    },
+    /// Record a failed attempt; outputs JSON {"outcome":"retried|escalated","attempts":N}
+    Fail {
+        /// Task id
+        task_id: String,
+    },
+    /// Attach the HITL escalation issue number to a task
+    Escalate {
+        /// Task id
+        task_id: String,
+        /// HITL issue number
+        #[arg(long)]
+        issue: u64,
     },
 }
 

--- a/plugins/github-autopilot/cli/src/cmd/output.rs
+++ b/plugins/github-autopilot/cli/src/cmd/output.rs
@@ -1,0 +1,14 @@
+//! Shared output helpers for CLI subcommands.
+
+use std::io::Write;
+
+use anyhow::Result;
+use serde::Serialize;
+
+/// Serialize `value` as a single line of compact JSON followed by a newline.
+/// Used by every subcommand that supports `--json`.
+pub fn write_json<T: Serialize>(out: &mut dyn Write, value: &T) -> Result<()> {
+    serde_json::to_writer(&mut *out, value)?;
+    writeln!(out)?;
+    Ok(())
+}

--- a/plugins/github-autopilot/cli/src/cmd/suppress.rs
+++ b/plugins/github-autopilot/cli/src/cmd/suppress.rs
@@ -1,0 +1,118 @@
+//! Fingerprint suppression CLI (spec §6.3).
+//!
+//! Thin adapter over [`SuppressionRepo`]. The CLI never decides what
+//! `reason` strings mean — agents own that vocabulary (`unmatched_watch`,
+//! `rejected_by_human`, ...). This layer only persists `(fingerprint,
+//! reason) -> until` and reports whether `now` is still inside the window.
+
+use std::io::Write;
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use clap::{Args, Subcommand};
+
+use crate::ports::clock::Clock;
+use crate::ports::task_store::SuppressionRepo;
+
+#[derive(Subcommand)]
+pub enum SuppressCommands {
+    /// Suppress alerts for `(fingerprint, reason)` until the given timestamp
+    Add(AddArgs),
+    /// Exit 0 if currently suppressed, exit 1 otherwise (script-friendly)
+    Check(CheckArgs),
+    /// Remove a suppression entry
+    Clear(ClearArgs),
+}
+
+#[derive(Args)]
+pub struct AddArgs {
+    #[arg(long)]
+    pub fingerprint: String,
+    #[arg(long)]
+    pub reason: String,
+    /// RFC3339 / ISO8601 timestamp (e.g. `2026-05-04T12:00:00Z`)
+    #[arg(long)]
+    pub until: String,
+}
+
+#[derive(Args)]
+pub struct CheckArgs {
+    #[arg(long)]
+    pub fingerprint: String,
+    #[arg(long)]
+    pub reason: String,
+}
+
+#[derive(Args)]
+pub struct ClearArgs {
+    #[arg(long)]
+    pub fingerprint: String,
+    #[arg(long)]
+    pub reason: String,
+}
+
+pub struct SuppressService<'a> {
+    store: &'a dyn SuppressionRepo,
+    clock: &'a dyn Clock,
+}
+
+impl<'a> SuppressService<'a> {
+    pub fn new(store: &'a dyn SuppressionRepo, clock: &'a dyn Clock) -> Self {
+        Self { store, clock }
+    }
+
+    pub fn add(
+        &self,
+        fingerprint: &str,
+        reason: &str,
+        until: &str,
+        out: &mut dyn Write,
+    ) -> Result<i32> {
+        let parsed: DateTime<Utc> = parse_until(until)?;
+        self.store
+            .suppress(fingerprint, reason, parsed)
+            .with_context(|| format!("suppressing fingerprint '{fingerprint}'"))?;
+        writeln!(
+            out,
+            "suppressed fingerprint='{fingerprint}' reason='{reason}' until={}",
+            parsed.to_rfc3339()
+        )?;
+        Ok(0)
+    }
+
+    pub fn check(&self, fingerprint: &str, reason: &str, out: &mut dyn Write) -> Result<i32> {
+        let now = self.clock.now();
+        let active = self
+            .store
+            .is_suppressed(fingerprint, reason, now)
+            .with_context(|| format!("checking suppression for '{fingerprint}'"))?;
+        if active {
+            writeln!(out, "suppressed")?;
+            Ok(0)
+        } else {
+            writeln!(out, "not suppressed")?;
+            Ok(1)
+        }
+    }
+
+    pub fn clear(&self, fingerprint: &str, reason: &str, out: &mut dyn Write) -> Result<i32> {
+        self.store
+            .clear(fingerprint, reason)
+            .with_context(|| format!("clearing suppression for '{fingerprint}'"))?;
+        writeln!(out, "cleared fingerprint='{fingerprint}' reason='{reason}'")?;
+        Ok(0)
+    }
+}
+
+fn parse_until(raw: &str) -> Result<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(raw)
+        .map(|dt| dt.with_timezone(&Utc))
+        .with_context(|| format!("parsing --until '{raw}' as RFC3339"))
+}
+
+pub fn suppress_service<'a>(
+    store: &'a dyn SuppressionRepo,
+    clock: &'a dyn Clock,
+) -> SuppressService<'a> {
+    SuppressService::new(store, clock)
+}

--- a/plugins/github-autopilot/cli/src/cmd/task.rs
+++ b/plugins/github-autopilot/cli/src/cmd/task.rs
@@ -12,15 +12,16 @@ use anyhow::{Context, Result};
 use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 
+use crate::cmd::output::write_json;
 use crate::cmd::simhash;
 use crate::domain::{DomainError, Task, TaskFailureOutcome, TaskId, TaskSource, TaskStatus};
 use crate::ports::clock::{Clock, StdClock};
 use crate::ports::task_store::{NewWatchTask, TaskStore, TaskStoreError, UpsertOutcome};
 
-/// Task fail threshold above which `mark_task_failed` escalates instead of
-/// retrying. PR-C will wire this from a config file; for v1 it's fixed.
-// TODO(PR-C): wire from config (`max_attempts` in github-autopilot.local.md).
-const DEFAULT_MAX_ATTEMPTS: u32 = 3;
+/// Default `max_attempts` used when no config / explicit override is present.
+/// `main.rs` now resolves this from `autopilot.toml` (`epic.default_max_attempts`)
+/// and threads it into [`TaskService::with_max_attempts`].
+pub const DEFAULT_MAX_ATTEMPTS: u32 = 3;
 
 #[derive(Clone, Copy, Debug, ValueEnum, PartialEq, Eq)]
 pub enum TaskStatusArg {
@@ -67,11 +68,24 @@ impl From<TaskSourceArg> for TaskSource {
 pub struct TaskService<'a> {
     store: &'a dyn TaskStore,
     clock: &'a dyn Clock,
+    max_attempts: u32,
 }
 
 impl<'a> TaskService<'a> {
     pub fn new(store: &'a dyn TaskStore, clock: &'a dyn Clock) -> Self {
-        Self { store, clock }
+        Self::with_max_attempts(store, clock, DEFAULT_MAX_ATTEMPTS)
+    }
+
+    pub fn with_max_attempts(
+        store: &'a dyn TaskStore,
+        clock: &'a dyn Clock,
+        max_attempts: u32,
+    ) -> Self {
+        Self {
+            store,
+            clock,
+            max_attempts,
+        }
     }
 
     pub fn list(
@@ -331,7 +345,7 @@ impl<'a> TaskService<'a> {
         let now = self.clock.now();
         let outcome = self
             .store
-            .mark_task_failed(&id, DEFAULT_MAX_ATTEMPTS, now)
+            .mark_task_failed(&id, self.max_attempts, now)
             .with_context(|| format!("failing task '{task_id}'"))?;
         write_json(out, &FailReport::from(outcome))?;
         Ok(0)
@@ -402,12 +416,6 @@ fn render_task(t: &Task, json: bool, out: &mut dyn Write) -> Result<()> {
         return write_json(out, t);
     }
     print_task_human(t, out)
-}
-
-fn write_json<T: Serialize>(out: &mut dyn Write, value: &T) -> Result<()> {
-    serde_json::to_writer(&mut *out, value)?;
-    writeln!(out)?;
-    Ok(())
 }
 
 fn derive_fingerprint(title: &str, body: Option<&str>) -> String {

--- a/plugins/github-autopilot/cli/src/cmd/task.rs
+++ b/plugins/github-autopilot/cli/src/cmd/task.rs
@@ -109,7 +109,7 @@ impl<'a> TaskService<'a> {
         let id = TaskId::from_raw(task_id);
         let now = self.clock.now();
         self.store
-            .force_status(&id, TaskStatus::from(to), now)
+            .force_status(&id, TaskStatus::from(to), reason.unwrap_or(""), now)
             .with_context(|| format!("forcing status of task '{task_id}'"))?;
         if let Some(r) = reason {
             writeln!(out, "task '{task_id}' status forced to {:?} ({r})", to)?;

--- a/plugins/github-autopilot/cli/src/cmd/task.rs
+++ b/plugins/github-autopilot/cli/src/cmd/task.rs
@@ -1,15 +1,26 @@
-//! Operator-facing diagnostics for the task store.
+//! Operator-facing diagnostics and lifecycle CLI for the task store.
 //!
-//! These commands read or override the local SQLite cache directly without
-//! touching git or GitHub — useful for debugging stuck epics, but should be
-//! used sparingly because manual force_status bypasses the normal lifecycle.
+//! These commands read, mutate, or override the local SQLite cache without
+//! touching git or GitHub — useful both for the implementer-loop integration
+//! (`add`, `claim`, `complete`, `fail`, `release`, `escalate`) and for
+//! debugging stuck epics (`force-status`).
+
+use std::io::{BufRead, BufReader, Write};
+use std::path::Path;
 
 use anyhow::{Context, Result};
 use clap::ValueEnum;
+use serde::{Deserialize, Serialize};
 
-use crate::domain::{Task, TaskId, TaskStatus};
+use crate::cmd::simhash;
+use crate::domain::{DomainError, Task, TaskFailureOutcome, TaskId, TaskSource, TaskStatus};
 use crate::ports::clock::{Clock, StdClock};
-use crate::ports::task_store::TaskStore;
+use crate::ports::task_store::{NewWatchTask, TaskStore, TaskStoreError, UpsertOutcome};
+
+/// Task fail threshold above which `mark_task_failed` escalates instead of
+/// retrying. PR-C will wire this from a config file; for v1 it's fixed.
+// TODO(PR-C): wire from config (`max_attempts` in github-autopilot.local.md).
+const DEFAULT_MAX_ATTEMPTS: u32 = 3;
 
 #[derive(Clone, Copy, Debug, ValueEnum, PartialEq, Eq)]
 pub enum TaskStatusArg {
@@ -34,6 +45,25 @@ impl From<TaskStatusArg> for TaskStatus {
     }
 }
 
+#[derive(Clone, Copy, Debug, ValueEnum, PartialEq, Eq)]
+pub enum TaskSourceArg {
+    Human,
+    GapWatch,
+    QaBoost,
+    CiWatch,
+}
+
+impl From<TaskSourceArg> for TaskSource {
+    fn from(s: TaskSourceArg) -> TaskSource {
+        match s {
+            TaskSourceArg::Human => TaskSource::Human,
+            TaskSourceArg::GapWatch => TaskSource::GapWatch,
+            TaskSourceArg::QaBoost => TaskSource::QaBoost,
+            TaskSourceArg::CiWatch => TaskSource::CiWatch,
+        }
+    }
+}
+
 pub struct TaskService<'a> {
     store: &'a dyn TaskStore,
     clock: &'a dyn Clock,
@@ -49,16 +79,16 @@ impl<'a> TaskService<'a> {
         epic: &str,
         status: Option<TaskStatusArg>,
         json: bool,
-        out: &mut dyn std::io::Write,
+        out: &mut dyn Write,
     ) -> Result<i32> {
         let tasks = self
             .store
             .list_tasks_by_epic(epic, status.map(TaskStatus::from))
             .with_context(|| format!("listing tasks for epic '{epic}'"))?;
         if json {
-            serde_json::to_writer(&mut *out, &tasks)?;
-            writeln!(out)?;
-        } else if tasks.is_empty() {
+            return write_json(out, &tasks).map(|()| 0);
+        }
+        if tasks.is_empty() {
             writeln!(out, "(no tasks)")?;
         } else {
             writeln!(out, "ID            STATUS     ATTEMPTS  TITLE")?;
@@ -76,7 +106,7 @@ impl<'a> TaskService<'a> {
         Ok(0)
     }
 
-    pub fn show(&self, task_id: &str, json: bool, out: &mut dyn std::io::Write) -> Result<i32> {
+    pub fn show(&self, task_id: &str, json: bool, out: &mut dyn Write) -> Result<i32> {
         let id = TaskId::from_raw(task_id);
         let task = self
             .store
@@ -84,12 +114,7 @@ impl<'a> TaskService<'a> {
             .with_context(|| format!("fetching task '{task_id}'"))?;
         match task {
             Some(t) => {
-                if json {
-                    serde_json::to_writer(&mut *out, &t)?;
-                    writeln!(out)?;
-                } else {
-                    print_task_human(&t, out)?;
-                }
+                render_task(&t, json, out)?;
                 Ok(0)
             }
             None => {
@@ -104,19 +129,263 @@ impl<'a> TaskService<'a> {
         task_id: &str,
         to: TaskStatusArg,
         reason: Option<&str>,
-        out: &mut dyn std::io::Write,
+        out: &mut dyn Write,
     ) -> Result<i32> {
         let id = TaskId::from_raw(task_id);
         let now = self.clock.now();
+        let target = TaskStatus::from(to);
         self.store
-            .force_status(&id, TaskStatus::from(to), reason.unwrap_or(""), now)
+            .force_status(&id, target, reason.unwrap_or(""), now)
             .with_context(|| format!("forcing status of task '{task_id}'"))?;
-        if let Some(r) = reason {
-            writeln!(out, "task '{task_id}' status forced to {:?} ({r})", to)?;
-        } else {
-            writeln!(out, "task '{task_id}' status forced to {:?}", to)?;
+        match reason {
+            Some(r) => writeln!(
+                out,
+                "task '{task_id}' status forced to {} ({r})",
+                target.as_str()
+            )?,
+            None => writeln!(out, "task '{task_id}' status forced to {}", target.as_str())?,
         }
         Ok(0)
+    }
+
+    /// Inserts (or detects duplicate of) a watch-style task on `epic`.
+    /// Auto-derives a fingerprint from `title + body` when `fingerprint` is
+    /// `None`, so callers don't need to mirror the simhash recipe.
+    #[allow(clippy::too_many_arguments)]
+    pub fn add(
+        &self,
+        epic: &str,
+        task_id: &str,
+        title: &str,
+        body: Option<&str>,
+        fingerprint: Option<&str>,
+        source: TaskSourceArg,
+        out: &mut dyn Write,
+    ) -> Result<i32> {
+        let now = self.clock.now();
+        let fp = fingerprint
+            .map(str::to_string)
+            .unwrap_or_else(|| derive_fingerprint(title, body));
+        let nt = NewWatchTask {
+            id: TaskId::from_raw(task_id),
+            epic_name: epic.to_string(),
+            source: source.into(),
+            fingerprint: fp,
+            title: title.to_string(),
+            body: body.map(str::to_string),
+        };
+        match self
+            .store
+            .upsert_watch_task(nt, now)
+            .with_context(|| format!("adding task '{task_id}' to epic '{epic}'"))?
+        {
+            UpsertOutcome::Inserted(id) => {
+                writeln!(out, "inserted task {}", id.as_str())?;
+            }
+            UpsertOutcome::DuplicateFingerprint(id) => {
+                writeln!(out, "duplicate of task {}", id.as_str())?;
+            }
+        }
+        Ok(0)
+    }
+
+    /// Reads `path` as JSONL where each line describes a single watch task.
+    /// Lines that fail to parse return Err (no partial commit guarantee — the
+    /// underlying store still inserts each accepted line individually, which
+    /// matches the spec for `add-batch` per §6.6).
+    pub fn add_batch(&self, epic: &str, path: &Path, out: &mut dyn Write) -> Result<i32> {
+        let file =
+            std::fs::File::open(path).with_context(|| format!("opening {}", path.display()))?;
+        let reader = BufReader::new(file);
+        let now = self.clock.now();
+
+        let mut inserted = 0u32;
+        let mut duplicates = 0u32;
+        for (lineno, line) in reader.lines().enumerate() {
+            let line = line.with_context(|| format!("reading line {}", lineno + 1))?;
+            let trimmed = line.trim();
+            if trimmed.is_empty() || trimmed.starts_with('#') {
+                continue;
+            }
+            let parsed: BatchLine = serde_json::from_str(trimmed)
+                .with_context(|| format!("parsing line {}: {trimmed}", lineno + 1))?;
+            let source = match parsed.source.as_deref() {
+                Some(s) => TaskSource::parse(s).ok_or_else(|| {
+                    anyhow::anyhow!("unknown source '{s}' on line {}", lineno + 1)
+                })?,
+                None => TaskSource::Human,
+            };
+            let title = parsed.title;
+            let body = parsed.body;
+            let fp = parsed
+                .fingerprint
+                .unwrap_or_else(|| derive_fingerprint(&title, body.as_deref()));
+            let nt = NewWatchTask {
+                id: TaskId::from_raw(&parsed.id),
+                epic_name: epic.to_string(),
+                source,
+                fingerprint: fp,
+                title,
+                body,
+            };
+            match self
+                .store
+                .upsert_watch_task(nt, now)
+                .with_context(|| format!("inserting task on line {}", lineno + 1))?
+            {
+                UpsertOutcome::Inserted(_) => inserted += 1,
+                UpsertOutcome::DuplicateFingerprint(_) => duplicates += 1,
+            }
+        }
+        writeln!(out, "inserted: {inserted}, duplicates: {duplicates}")?;
+        Ok(0)
+    }
+
+    pub fn find_by_pr(&self, pr_number: u64, json: bool, out: &mut dyn Write) -> Result<i32> {
+        match self
+            .store
+            .find_task_by_pr(pr_number)
+            .with_context(|| format!("finding task for PR #{pr_number}"))?
+        {
+            Some(t) => {
+                render_task(&t, json, out)?;
+                Ok(0)
+            }
+            None => {
+                writeln!(out, "no task owns PR #{pr_number}")?;
+                Ok(1)
+            }
+        }
+    }
+
+    pub fn claim(&self, epic: &str, json: bool, out: &mut dyn Write) -> Result<i32> {
+        let now = self.clock.now();
+        match self
+            .store
+            .claim_next_task(epic, now)
+            .with_context(|| format!("claiming next task on epic '{epic}'"))?
+        {
+            Some(t) => {
+                render_task(&t, json, out)?;
+                Ok(0)
+            }
+            None => {
+                writeln!(out, "(no ready tasks on epic '{epic}')")?;
+                Ok(1)
+            }
+        }
+    }
+
+    pub fn release(&self, task_id: &str, out: &mut dyn Write) -> Result<i32> {
+        let id = TaskId::from_raw(task_id);
+        let now = self.clock.now();
+        match self.store.release_claim(&id, now) {
+            Ok(()) => {
+                writeln!(out, "released task {task_id}")?;
+                Ok(0)
+            }
+            Err(TaskStoreError::NotFound(_)) => {
+                writeln!(out, "task '{task_id}' not found")?;
+                Ok(1)
+            }
+            Err(TaskStoreError::Domain(DomainError::IllegalTransition(_, from, _))) => {
+                writeln!(
+                    out,
+                    "task '{task_id}' cannot be released from {} (must be wip)",
+                    from.as_str()
+                )?;
+                Ok(1)
+            }
+            Err(e) => Err(e).with_context(|| format!("releasing task '{task_id}'")),
+        }
+    }
+
+    pub fn complete(&self, task_id: &str, pr: u64, out: &mut dyn Write) -> Result<i32> {
+        let id = TaskId::from_raw(task_id);
+        let now = self.clock.now();
+        match self.store.complete_task_and_unblock(&id, pr, now) {
+            Ok(report) => {
+                writeln!(
+                    out,
+                    "completed task {} (PR #{pr})",
+                    report.completed.as_str()
+                )?;
+                if report.newly_ready.is_empty() {
+                    writeln!(out, "newly ready: (none)")?;
+                } else {
+                    let ids: Vec<&str> = report.newly_ready.iter().map(|i| i.as_str()).collect();
+                    writeln!(out, "newly ready: {}", ids.join(", "))?;
+                }
+                Ok(0)
+            }
+            Err(TaskStoreError::NotFound(_)) => {
+                writeln!(out, "task '{task_id}' not found")?;
+                Ok(1)
+            }
+            Err(e) => Err(e).with_context(|| format!("completing task '{task_id}'")),
+        }
+    }
+
+    pub fn fail(&self, task_id: &str, out: &mut dyn Write) -> Result<i32> {
+        let id = TaskId::from_raw(task_id);
+        let now = self.clock.now();
+        let outcome = self
+            .store
+            .mark_task_failed(&id, DEFAULT_MAX_ATTEMPTS, now)
+            .with_context(|| format!("failing task '{task_id}'"))?;
+        write_json(out, &FailReport::from(outcome))?;
+        Ok(0)
+    }
+
+    pub fn escalate(&self, task_id: &str, issue: u64, out: &mut dyn Write) -> Result<i32> {
+        let id = TaskId::from_raw(task_id);
+        let now = self.clock.now();
+        match self.store.escalate_task(&id, issue, now) {
+            Ok(()) => {
+                writeln!(out, "task '{task_id}' escalated to issue #{issue}")?;
+                Ok(0)
+            }
+            Err(TaskStoreError::NotFound(_)) => {
+                writeln!(out, "task '{task_id}' not found")?;
+                Ok(1)
+            }
+            Err(e) => Err(e).with_context(|| format!("escalating task '{task_id}'")),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct BatchLine {
+    id: String,
+    title: String,
+    #[serde(default)]
+    body: Option<String>,
+    #[serde(default)]
+    fingerprint: Option<String>,
+    #[serde(default)]
+    source: Option<String>,
+    // Unknown fields (e.g. section/requirement on watch payloads) are silently
+    // accepted by serde, keeping the JSONL contract forward-compatible.
+}
+
+#[derive(Debug, Serialize)]
+struct FailReport {
+    outcome: &'static str,
+    attempts: u32,
+}
+
+impl From<TaskFailureOutcome> for FailReport {
+    fn from(o: TaskFailureOutcome) -> Self {
+        match o {
+            TaskFailureOutcome::Retried { attempts } => Self {
+                outcome: "retried",
+                attempts,
+            },
+            TaskFailureOutcome::Escalated { attempts } => Self {
+                outcome: "escalated",
+                attempts,
+            },
+        }
     }
 }
 
@@ -128,7 +397,27 @@ pub fn default_clock() -> StdClock {
     StdClock
 }
 
-fn print_task_human(t: &Task, out: &mut dyn std::io::Write) -> Result<()> {
+fn render_task(t: &Task, json: bool, out: &mut dyn Write) -> Result<()> {
+    if json {
+        return write_json(out, t);
+    }
+    print_task_human(t, out)
+}
+
+fn write_json<T: Serialize>(out: &mut dyn Write, value: &T) -> Result<()> {
+    serde_json::to_writer(&mut *out, value)?;
+    writeln!(out)?;
+    Ok(())
+}
+
+fn derive_fingerprint(title: &str, body: Option<&str>) -> String {
+    let composite = format!("{title}\n{}", body.unwrap_or(""));
+    simhash::format_simhash(simhash::weighted_simhash(&simhash::tokenize_weighted(
+        &composite,
+    )))
+}
+
+fn print_task_human(t: &Task, out: &mut dyn Write) -> Result<()> {
     writeln!(out, "id:              {}", t.id.as_str())?;
     writeln!(out, "epic:            {}", t.epic_name)?;
     writeln!(out, "status:          {}", t.status.as_str())?;
@@ -244,5 +533,25 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(task.status, TaskStatus::Done);
+        // Output uses canonical lowercase status (TaskStatus::as_str), matching
+        // the rest of the CLI. Specifically NOT the {:?} debug form (`Done`).
+        let s = String::from_utf8(buf).unwrap();
+        assert!(s.contains("forced to done"), "stdout: {s}");
+        assert!(s.contains("(manual)"), "stdout: {s}");
+    }
+
+    #[test]
+    fn force_status_without_reason_omits_parens() {
+        let (store, clock) = fixture();
+        let svc = TaskService::new(store.as_ref(), &clock);
+        let mut buf: Vec<u8> = Vec::new();
+        svc.force_status("a1b2c3d4e5f6", TaskStatusArg::Wip, None, &mut buf)
+            .unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(s.contains("forced to wip"), "stdout: {s}");
+        assert!(
+            !s.contains('('),
+            "stdout should not contain '(' when reason is None: {s}"
+        );
     }
 }

--- a/plugins/github-autopilot/cli/src/config.rs
+++ b/plugins/github-autopilot/cli/src/config.rs
@@ -1,0 +1,82 @@
+//! `autopilot.toml` config loader.
+//!
+//! Spec §8: tiny ledger-scoped config — `storage.db_path`,
+//! `epic.default_max_attempts`, `suppression.default_window_hours`. Sections are
+//! all optional; missing files yield [`Config::default`]. Field-level defaults
+//! match the values previously hardcoded in `main.rs` / `cmd::task`.
+//!
+//! Precedence (resolved by callers, not here): CLI flag > env var > file > default.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(default)]
+pub struct Config {
+    pub storage: StorageConfig,
+    pub epic: EpicConfig,
+    pub suppression: SuppressionConfig,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(default)]
+pub struct StorageConfig {
+    pub db_path: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(default)]
+pub struct EpicConfig {
+    pub default_max_attempts: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(default)]
+pub struct SuppressionConfig {
+    // TODO: wire into agent suppression flows. Defined here so operators can
+    // tune the default `--until` window, but the autopilot CLI itself never
+    // reads this — consumer agents pick it up from `autopilot.toml`.
+    #[allow(dead_code)]
+    pub default_window_hours: u32,
+}
+
+impl Default for StorageConfig {
+    fn default() -> Self {
+        Self {
+            db_path: PathBuf::from(".autopilot/state.db"),
+        }
+    }
+}
+
+impl Default for EpicConfig {
+    fn default() -> Self {
+        Self {
+            default_max_attempts: 3,
+        }
+    }
+}
+
+impl Default for SuppressionConfig {
+    fn default() -> Self {
+        Self {
+            default_window_hours: 24,
+        }
+    }
+}
+
+impl Config {
+    /// Loads `path` if it exists; otherwise returns [`Config::default`].
+    /// Returns Err only on read or parse failure (not on missing file).
+    pub fn load(path: &Path) -> Result<Self> {
+        if !path.exists() {
+            return Ok(Self::default());
+        }
+        let raw = std::fs::read_to_string(path)
+            .with_context(|| format!("reading config {}", path.display()))?;
+        let cfg: Self =
+            toml::from_str(&raw).with_context(|| format!("parsing config {}", path.display()))?;
+        Ok(cfg)
+    }
+}

--- a/plugins/github-autopilot/cli/src/domain/error.rs
+++ b/plugins/github-autopilot/cli/src/domain/error.rs
@@ -20,4 +20,7 @@ pub enum DomainError {
 
     #[error("duplicate task id in plan: {0}")]
     DuplicateTaskId(TaskId),
+
+    #[error("inconsistency: {0}")]
+    Inconsistency(String),
 }

--- a/plugins/github-autopilot/cli/src/domain/event.rs
+++ b/plugins/github-autopilot/cli/src/domain/event.rs
@@ -31,6 +31,7 @@ pub enum EventKind {
     MigratedFromIssue,
     EscalationResolved,
     WatchDuplicate,
+    TaskForceStatus,
 }
 
 impl EventKind {
@@ -52,6 +53,7 @@ impl EventKind {
             EventKind::MigratedFromIssue => "migrated_from_issue",
             EventKind::EscalationResolved => "escalation_resolved",
             EventKind::WatchDuplicate => "watch_duplicate",
+            EventKind::TaskForceStatus => "task_force_status",
         }
     }
 
@@ -73,6 +75,7 @@ impl EventKind {
             "migrated_from_issue" => EventKind::MigratedFromIssue,
             "escalation_resolved" => EventKind::EscalationResolved,
             "watch_duplicate" => EventKind::WatchDuplicate,
+            "task_force_status" => EventKind::TaskForceStatus,
             _ => return None,
         })
     }

--- a/plugins/github-autopilot/cli/src/lib.rs
+++ b/plugins/github-autopilot/cli/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod cmd;
+pub mod config;
 pub mod domain;
 pub mod fs;
 pub mod gh;

--- a/plugins/github-autopilot/cli/src/main.rs
+++ b/plugins/github-autopilot/cli/src/main.rs
@@ -173,6 +173,37 @@ fn main() {
                 } => svc.force_status(&task_id, to, reason.as_deref(), &mut out),
             }
         }
+        Commands::Epic { command } => {
+            let db_path = task_store_db_path();
+            let store = match SqliteTaskStore::open(&db_path) {
+                Ok(s) => s,
+                Err(e) => {
+                    eprintln!("failed to open task store at {}: {e}", db_path.display());
+                    std::process::exit(2);
+                }
+            };
+            let clock = cmd::task::default_clock();
+            let svc = cmd::epic::epic_service(&store, &clock);
+            let mut out = stdout();
+            match command {
+                cmd::epic::EpicCommands::Create(args) => {
+                    svc.create(&args.name, &args.spec, args.branch.as_deref(), &mut out)
+                }
+                cmd::epic::EpicCommands::List(args) => svc.list(args.status, args.json, &mut out),
+                cmd::epic::EpicCommands::Get(args) => svc.get(&args.name, args.json, &mut out),
+                cmd::epic::EpicCommands::Status(args) => {
+                    svc.status(args.name.as_deref(), args.json, &mut out)
+                }
+                cmd::epic::EpicCommands::Complete(args) => svc.complete(&args.name, &mut out),
+                cmd::epic::EpicCommands::Abandon(args) => svc.abandon(&args.name, &mut out),
+                cmd::epic::EpicCommands::Reconcile(args) => {
+                    svc.reconcile(&args.name, &args.plan, &mut out)
+                }
+                cmd::epic::EpicCommands::FindBySpecPath(args) => {
+                    svc.find_by_spec_path(&args.spec, args.json, &mut out)
+                }
+            }
+        }
     };
 
     match result {

--- a/plugins/github-autopilot/cli/src/main.rs
+++ b/plugins/github-autopilot/cli/src/main.rs
@@ -166,11 +166,39 @@ fn main() {
                     svc.list(&epic, status, json, &mut out)
                 }
                 TaskCommands::Show { task_id, json } => svc.show(&task_id, json, &mut out),
+                TaskCommands::Get { task_id, json } => svc.show(&task_id, json, &mut out),
                 TaskCommands::ForceStatus {
                     task_id,
                     to,
                     reason,
                 } => svc.force_status(&task_id, to, reason.as_deref(), &mut out),
+                TaskCommands::Add {
+                    epic,
+                    id,
+                    title,
+                    body,
+                    fingerprint,
+                    source,
+                } => svc.add(
+                    &epic,
+                    &id,
+                    &title,
+                    body.as_deref(),
+                    fingerprint.as_deref(),
+                    source,
+                    &mut out,
+                ),
+                TaskCommands::AddBatch { epic, from } => svc.add_batch(&epic, &from, &mut out),
+                TaskCommands::FindByPr { pr_number, json } => {
+                    svc.find_by_pr(pr_number, json, &mut out)
+                }
+                TaskCommands::Claim { epic, json } => svc.claim(&epic, json, &mut out),
+                TaskCommands::Release { task_id } => svc.release(&task_id, &mut out),
+                TaskCommands::Complete { task_id, pr } => svc.complete(&task_id, pr, &mut out),
+                TaskCommands::Fail { task_id } => svc.fail(&task_id, &mut out),
+                TaskCommands::Escalate { task_id, issue } => {
+                    svc.escalate(&task_id, issue, &mut out)
+                }
             }
         }
         Commands::Epic { command } => {

--- a/plugins/github-autopilot/cli/src/main.rs
+++ b/plugins/github-autopilot/cli/src/main.rs
@@ -2,6 +2,7 @@ use autopilot::cmd::{
     CheckCommands, Cli, Commands, IssueCommands, ListArgs, PipelineCommands, PreflightArgs,
     StatsCommands, TaskCommands, WorktreeCommands,
 };
+use autopilot::config::Config;
 use autopilot::store::SqliteTaskStore;
 use autopilot::{cmd, fs, gh, git, github};
 use clap::Parser;
@@ -10,6 +11,13 @@ use std::path::{Path, PathBuf};
 
 fn main() {
     let cli = Cli::parse();
+    let config = match load_config(cli.config.as_deref()) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("{e:#}");
+            std::process::exit(2);
+        }
+    };
 
     let result = match cli.command {
         Commands::Issue { command } => match command {
@@ -150,16 +158,13 @@ fn main() {
             )
         }
         Commands::Task { command } => {
-            let db_path = task_store_db_path();
-            let store = match SqliteTaskStore::open(&db_path) {
-                Ok(s) => s,
-                Err(e) => {
-                    eprintln!("failed to open task store at {}: {e}", db_path.display());
-                    std::process::exit(2);
-                }
-            };
+            let store = open_store(&config);
             let clock = cmd::task::default_clock();
-            let svc = cmd::task::task_service(&store, &clock);
+            let svc = cmd::task::TaskService::with_max_attempts(
+                &store,
+                &clock,
+                config.epic.default_max_attempts,
+            );
             let mut out = stdout();
             match command {
                 TaskCommands::List { epic, status, json } => {
@@ -202,14 +207,7 @@ fn main() {
             }
         }
         Commands::Epic { command } => {
-            let db_path = task_store_db_path();
-            let store = match SqliteTaskStore::open(&db_path) {
-                Ok(s) => s,
-                Err(e) => {
-                    eprintln!("failed to open task store at {}: {e}", db_path.display());
-                    std::process::exit(2);
-                }
-            };
+            let store = open_store(&config);
             let clock = cmd::task::default_clock();
             let svc = cmd::epic::epic_service(&store, &clock);
             let mut out = stdout();
@@ -232,6 +230,31 @@ fn main() {
                 }
             }
         }
+        Commands::Suppress { command } => {
+            let store = open_store(&config);
+            let clock = cmd::task::default_clock();
+            let svc = cmd::suppress::suppress_service(&store, &clock);
+            let mut out = stdout();
+            match command {
+                cmd::suppress::SuppressCommands::Add(args) => {
+                    svc.add(&args.fingerprint, &args.reason, &args.until, &mut out)
+                }
+                cmd::suppress::SuppressCommands::Check(args) => {
+                    svc.check(&args.fingerprint, &args.reason, &mut out)
+                }
+                cmd::suppress::SuppressCommands::Clear(args) => {
+                    svc.clear(&args.fingerprint, &args.reason, &mut out)
+                }
+            }
+        }
+        Commands::Events { command } => {
+            let store = open_store(&config);
+            let svc = cmd::events::events_service(&store);
+            let mut out = stdout();
+            match command {
+                cmd::events::EventsCommands::List(args) => svc.list(&args, &mut out),
+            }
+        }
     };
 
     match result {
@@ -243,13 +266,35 @@ fn main() {
     }
 }
 
-fn task_store_db_path() -> PathBuf {
+fn task_store_db_path(config: &Config) -> PathBuf {
     if let Ok(p) = std::env::var("AUTOPILOT_DB_PATH") {
         return PathBuf::from(p);
     }
-    let dir = PathBuf::from(".autopilot");
-    if !dir.exists() {
-        let _ = std::fs::create_dir_all(&dir);
+    let path = config.storage.db_path.clone();
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() && !parent.exists() {
+            let _ = std::fs::create_dir_all(parent);
+        }
     }
-    dir.join("state.db")
+    path
+}
+
+fn load_config(explicit: Option<&Path>) -> anyhow::Result<Config> {
+    let default_path = PathBuf::from("autopilot.toml");
+    let path = explicit.unwrap_or(default_path.as_path());
+    Config::load(path)
+}
+
+/// Opens the SQLite task store at the configured path, exiting with code 2
+/// on failure. Centralizes the error message so every `Commands::*` arm that
+/// needs the store stays a one-liner.
+fn open_store(config: &Config) -> SqliteTaskStore {
+    let db_path = task_store_db_path(config);
+    match SqliteTaskStore::open(&db_path) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("failed to open task store at {}: {e}", db_path.display());
+            std::process::exit(2);
+        }
+    }
 }

--- a/plugins/github-autopilot/cli/src/ports/task_store.rs
+++ b/plugins/github-autopilot/cli/src/ports/task_store.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use chrono::{DateTime, Utc};
 use thiserror::Error;
 
@@ -101,6 +103,12 @@ pub trait EpicRepo: Send + Sync {
     fn get_epic(&self, name: &str) -> Result<Option<Epic>>;
     fn list_epics(&self, status: Option<EpicStatus>) -> Result<Vec<Epic>>;
     fn set_epic_status(&self, name: &str, status: EpicStatus, at: DateTime<Utc>) -> Result<()>;
+
+    /// Returns the unique active epic for `spec_path`, if any. The
+    /// invariant is that at most one active epic owns a given spec; if two
+    /// or more are observed, returns [`DomainError::Inconsistency`] so the
+    /// caller can surface it rather than silently picking one.
+    fn find_active_by_spec_path(&self, spec_path: &Path) -> Result<Option<Epic>>;
 }
 
 pub trait TaskRepo: Send + Sync {
@@ -111,6 +119,10 @@ pub trait TaskRepo: Send + Sync {
     fn list_tasks_by_epic(&self, epic: &str, status: Option<TaskStatus>) -> Result<Vec<Task>>;
 
     fn find_by_fingerprint(&self, epic: &str, fingerprint: &str) -> Result<Option<Task>>;
+
+    /// Looks up the task that owns a merged PR. Used by `MergeLoop` after a
+    /// PR merges to drive the corresponding task to `Done`.
+    fn find_task_by_pr(&self, pr_number: u64) -> Result<Option<Task>>;
 
     fn upsert_watch_task(&self, task: NewWatchTask, now: DateTime<Utc>) -> Result<UpsertOutcome>;
 
@@ -132,9 +144,24 @@ pub trait TaskRepo: Send + Sync {
 
     fn escalate_task(&self, id: &TaskId, issue_number: u64, now: DateTime<Utc>) -> Result<()>;
 
-    fn revert_to_ready(&self, id: &TaskId, now: DateTime<Utc>) -> Result<()>;
+    /// Releases an unused claim (UC-11 push-reject / claim_lost). Decrements
+    /// `attempts` so the cancelled try does not count toward `max_attempts`.
+    /// Use [`TaskRepo::mark_task_failed`] instead when an attempt was made
+    /// and failed (CI failure, implementer error, ...): that path preserves
+    /// `attempts` and feeds escalation.
+    fn release_claim(&self, id: &TaskId, now: DateTime<Utc>) -> Result<()>;
 
-    fn force_status(&self, id: &TaskId, new_status: TaskStatus, now: DateTime<Utc>) -> Result<()>;
+    /// Operator override (CLI `task force-status`). Bypasses the normal
+    /// transition graph but records `reason` in the emitted event for audit.
+    /// Does NOT cascade dependents (no auto-unblock / auto-block); the
+    /// caller must drive any further reconciliation explicitly.
+    fn force_status(
+        &self,
+        id: &TaskId,
+        target: TaskStatus,
+        reason: &str,
+        now: DateTime<Utc>,
+    ) -> Result<()>;
 
     fn apply_reconciliation(&self, plan: ReconciliationPlan, now: DateTime<Utc>) -> Result<()>;
 
@@ -146,5 +173,21 @@ pub trait EventLog: Send + Sync {
     fn list_events(&self, filter: EventFilter) -> Result<Vec<Event>>;
 }
 
-pub trait TaskStore: EpicRepo + TaskRepo + EventLog + Send + Sync {}
-impl<T: EpicRepo + TaskRepo + EventLog + Send + Sync + ?Sized> TaskStore for T {}
+/// Fingerprint-scoped suppression for HITL escalation (UC-7 unmatched
+/// watch, UC-9c rejected close). Prevents repeat-issue spam for the same
+/// finding within a configurable window.
+pub trait SuppressionRepo: Send + Sync {
+    fn suppress(
+        &self,
+        fingerprint: &str,
+        reason: &str,
+        suppress_until: DateTime<Utc>,
+    ) -> Result<()>;
+
+    fn is_suppressed(&self, fingerprint: &str, reason: &str, now: DateTime<Utc>) -> Result<bool>;
+
+    fn clear(&self, fingerprint: &str, reason: &str) -> Result<()>;
+}
+
+pub trait TaskStore: EpicRepo + TaskRepo + EventLog + SuppressionRepo + Send + Sync {}
+impl<T: EpicRepo + TaskRepo + EventLog + SuppressionRepo + Send + Sync + ?Sized> TaskStore for T {}

--- a/plugins/github-autopilot/cli/src/store/memory.rs
+++ b/plugins/github-autopilot/cli/src/store/memory.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::path::Path;
 use std::sync::Mutex;
 
 use chrono::{DateTime, Utc};
@@ -9,7 +10,7 @@ use crate::domain::{
 };
 use crate::ports::task_store::{
     EpicPlan, EpicRepo, EventFilter, EventLog, NewWatchTask, ReconciliationPlan, RemotePrState,
-    Result, TaskRepo, TaskStoreError, UnblockReport, UpsertOutcome,
+    Result, SuppressionRepo, TaskRepo, TaskStoreError, UnblockReport, UpsertOutcome,
 };
 
 #[derive(Default)]
@@ -18,6 +19,7 @@ struct State {
     tasks: BTreeMap<TaskId, Task>,
     deps: Vec<(TaskId, TaskId)>,
     events: Vec<Event>,
+    suppressions: BTreeMap<(String, String), DateTime<Utc>>,
 }
 
 #[derive(Default)]
@@ -128,6 +130,26 @@ impl EpicRepo for InMemoryTaskStore {
         );
         InMemoryTaskStore::push_event(&mut s, event);
         Ok(())
+    }
+
+    fn find_active_by_spec_path(&self, spec_path: &Path) -> Result<Option<Epic>> {
+        let s = self.state.lock().expect("poisoned");
+        let matches: Vec<&Epic> = s
+            .epics
+            .values()
+            .filter(|e| e.status == EpicStatus::Active && e.spec_path == spec_path)
+            .collect();
+        match matches.as_slice() {
+            [] => Ok(None),
+            [one] => Ok(Some((*one).clone())),
+            many => Err(DomainError::Inconsistency(format!(
+                "{} active epics share spec_path {:?}: {:?}",
+                many.len(),
+                spec_path,
+                many.iter().map(|e| &e.name).collect::<Vec<_>>()
+            ))
+            .into()),
+        }
     }
 }
 
@@ -537,30 +559,61 @@ impl TaskRepo for InMemoryTaskStore {
         Ok(())
     }
 
-    fn revert_to_ready(&self, id: &TaskId, now: DateTime<Utc>) -> Result<()> {
+    fn release_claim(&self, id: &TaskId, now: DateTime<Utc>) -> Result<()> {
         let mut s = self.state.lock().expect("poisoned");
         let task = s
             .tasks
             .get_mut(id)
             .ok_or_else(|| TaskStoreError::NotFound(format!("task '{id}'")))?;
         let cur = task.status;
-        if matches!(cur, TaskStatus::Done | TaskStatus::Escalated) {
+        if cur != TaskStatus::Wip {
             return Err(DomainError::IllegalTransition(id.clone(), cur, TaskStatus::Ready).into());
         }
         task.status = TaskStatus::Ready;
+        task.attempts = task.attempts.saturating_sub(1);
         task.updated_at = now;
         Ok(())
     }
 
-    fn force_status(&self, id: &TaskId, new_status: TaskStatus, now: DateTime<Utc>) -> Result<()> {
+    fn force_status(
+        &self,
+        id: &TaskId,
+        target: TaskStatus,
+        reason: &str,
+        now: DateTime<Utc>,
+    ) -> Result<()> {
         let mut s = self.state.lock().expect("poisoned");
-        let task = s
-            .tasks
-            .get_mut(id)
-            .ok_or_else(|| TaskStoreError::NotFound(format!("task '{id}'")))?;
-        task.status = new_status;
-        task.updated_at = now;
+        let (epic_name, prev) = {
+            let task = s
+                .tasks
+                .get_mut(id)
+                .ok_or_else(|| TaskStoreError::NotFound(format!("task '{id}'")))?;
+            let prev = task.status;
+            task.status = target;
+            task.updated_at = now;
+            (task.epic_name.clone(), prev)
+        };
+        let event = InMemoryTaskStore::make_event(
+            EventKind::TaskForceStatus,
+            Some(epic_name),
+            Some(id.clone()),
+            serde_json::json!({
+                "from": prev.as_str(),
+                "to": target.as_str(),
+                "reason": reason,
+            }),
+            now,
+        );
+        InMemoryTaskStore::push_event(&mut s, event);
         Ok(())
+    }
+
+    fn find_task_by_pr(&self, pr_number: u64) -> Result<Option<Task>> {
+        let s = self.state.lock().expect("poisoned");
+        Ok(s.tasks
+            .values()
+            .find(|t| t.pr_number == Some(pr_number))
+            .cloned())
     }
 
     fn apply_reconciliation(&self, plan: ReconciliationPlan, now: DateTime<Utc>) -> Result<()> {
@@ -714,6 +767,36 @@ fn remote_to_status(r: &crate::ports::task_store::RemoteTaskState, s: &State) ->
             }
         }
         (Some(_), false) => TaskStatus::Wip, // PR open without branch is unusual; treat as wip
+    }
+}
+
+impl SuppressionRepo for InMemoryTaskStore {
+    fn suppress(
+        &self,
+        fingerprint: &str,
+        reason: &str,
+        suppress_until: DateTime<Utc>,
+    ) -> Result<()> {
+        let mut s = self.state.lock().expect("poisoned");
+        s.suppressions.insert(
+            (fingerprint.to_string(), reason.to_string()),
+            suppress_until,
+        );
+        Ok(())
+    }
+
+    fn is_suppressed(&self, fingerprint: &str, reason: &str, now: DateTime<Utc>) -> Result<bool> {
+        let s = self.state.lock().expect("poisoned");
+        Ok(s.suppressions
+            .get(&(fingerprint.to_string(), reason.to_string()))
+            .is_some_and(|until| now < *until))
+    }
+
+    fn clear(&self, fingerprint: &str, reason: &str) -> Result<()> {
+        let mut s = self.state.lock().expect("poisoned");
+        s.suppressions
+            .remove(&(fingerprint.to_string(), reason.to_string()));
+        Ok(())
     }
 }
 

--- a/plugins/github-autopilot/cli/src/store/migrations/V2__lookup_indexes.sql
+++ b/plugins/github-autopilot/cli/src/store/migrations/V2__lookup_indexes.sql
@@ -1,0 +1,15 @@
+-- Partial indexes:
+--   * idx_tasks_pr_number — most tasks have pr_number IS NULL, so a full
+--     index would mostly store NULL keys.
+--   * idx_epics_active_spec — abandoned/completed epics never participate
+--     in WatchDispatcher routing, so the index only needs active rows.
+
+CREATE INDEX IF NOT EXISTS idx_tasks_pr_number
+  ON tasks(pr_number)
+  WHERE pr_number IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_epics_active_spec
+  ON epics(spec_path)
+  WHERE status = 'active';
+
+UPDATE meta SET value = '2' WHERE key = 'schema_version';

--- a/plugins/github-autopilot/cli/src/store/sqlite.rs
+++ b/plugins/github-autopilot/cli/src/store/sqlite.rs
@@ -15,12 +15,13 @@ use crate::domain::{
     TaskSource, TaskStatus,
 };
 use crate::ports::task_store::{
-    EpicPlan, EpicRepo, EventFilter, EventLog, NewWatchTask, ReconciliationPlan, Result, TaskRepo,
-    TaskStoreError, UnblockReport, UpsertOutcome,
+    EpicPlan, EpicRepo, EventFilter, EventLog, NewWatchTask, ReconciliationPlan, Result,
+    SuppressionRepo, TaskRepo, TaskStoreError, UnblockReport, UpsertOutcome,
 };
 
-const SCHEMA_VERSION: u32 = 1;
+const SCHEMA_VERSION: u32 = 2;
 const V1_SQL: &str = include_str!("migrations/V1__initial.sql");
+const V2_SQL: &str = include_str!("migrations/V2__lookup_indexes.sql");
 
 pub struct SqliteTaskStore {
     conn: Mutex<Connection>,
@@ -63,6 +64,7 @@ impl SqliteTaskStore {
 
         if !has_meta {
             conn.execute_batch(V1_SQL).map_err(backend)?;
+            conn.execute_batch(V2_SQL).map_err(backend)?;
             return Ok(());
         }
 
@@ -82,6 +84,10 @@ impl SqliteTaskStore {
                 found,
                 expected: SCHEMA_VERSION,
             });
+        }
+
+        if found < 2 {
+            conn.execute_batch(V2_SQL).map_err(backend)?;
         }
         Ok(())
     }
@@ -284,6 +290,32 @@ impl EpicRepo for SqliteTaskStore {
         )
         .map_err(backend)?;
         Ok(())
+    }
+
+    fn find_active_by_spec_path(&self, spec_path: &Path) -> Result<Option<Epic>> {
+        let conn = self.conn.lock().expect("poisoned");
+        let path_str = spec_path.to_string_lossy().to_string();
+        let mut stmt = conn
+            .prepare(
+                "SELECT * FROM epics WHERE status='active' AND spec_path=? ORDER BY name LIMIT 2",
+            )
+            .map_err(backend)?;
+        let mut rows = stmt
+            .query_map(params![path_str], epic_from_row)
+            .map_err(backend)?;
+        let first = match rows.next() {
+            None => return Ok(None),
+            Some(r) => r.map_err(backend)?,
+        };
+        if let Some(second) = rows.next() {
+            let second = second.map_err(backend)?;
+            return Err(DomainError::Inconsistency(format!(
+                "active epics share spec_path {path_str:?}: {} vs {}",
+                first.name, second.name
+            ))
+            .into());
+        }
+        Ok(Some(first))
     }
 }
 
@@ -819,7 +851,7 @@ impl TaskRepo for SqliteTaskStore {
         Ok(())
     }
 
-    fn revert_to_ready(&self, id: &TaskId, now: DateTime<Utc>) -> Result<()> {
+    fn release_claim(&self, id: &TaskId, now: DateTime<Utc>) -> Result<()> {
         let conn = self.conn.lock().expect("poisoned");
         let cur: Option<String> = conn
             .query_row(
@@ -832,31 +864,75 @@ impl TaskRepo for SqliteTaskStore {
         let cur = cur.ok_or_else(|| TaskStoreError::NotFound(format!("task '{id}'")))?;
         let cur_status = TaskStatus::parse(&cur)
             .ok_or_else(|| TaskStoreError::Backend(format!("invalid stored task status: {cur}")))?;
-        if matches!(cur_status, TaskStatus::Done | TaskStatus::Escalated) {
+        if cur_status != TaskStatus::Wip {
             return Err(
                 DomainError::IllegalTransition(id.clone(), cur_status, TaskStatus::Ready).into(),
             );
         }
         conn.execute(
-            "UPDATE tasks SET status='ready', updated_at=? WHERE id=?",
+            "UPDATE tasks
+                SET status='ready',
+                    attempts = MAX(attempts - 1, 0),
+                    updated_at=?
+              WHERE id=? AND status='wip'",
             params![now, id.as_str()],
         )
         .map_err(backend)?;
         Ok(())
     }
 
-    fn force_status(&self, id: &TaskId, new_status: TaskStatus, now: DateTime<Utc>) -> Result<()> {
+    fn force_status(
+        &self,
+        id: &TaskId,
+        target: TaskStatus,
+        reason: &str,
+        now: DateTime<Utc>,
+    ) -> Result<()> {
         let conn = self.conn.lock().expect("poisoned");
-        let updated = conn
-            .execute(
-                "UPDATE tasks SET status=?, updated_at=? WHERE id=?",
-                params![new_status.as_str(), now, id.as_str()],
+        let prev: Option<(String, String)> = conn
+            .query_row(
+                "SELECT epic_name, status FROM tasks WHERE id=?",
+                params![id.as_str()],
+                |row| Ok((row.get(0)?, row.get(1)?)),
             )
+            .optional()
             .map_err(backend)?;
-        if updated == 0 {
-            return Err(TaskStoreError::NotFound(format!("task '{id}'")));
-        }
+        let (epic_name, prev_status_str) =
+            prev.ok_or_else(|| TaskStoreError::NotFound(format!("task '{id}'")))?;
+        let prev = TaskStatus::parse(&prev_status_str).ok_or_else(|| {
+            TaskStoreError::Backend(format!("invalid stored task status: {prev_status_str}"))
+        })?;
+        conn.execute(
+            "UPDATE tasks SET status=?, updated_at=? WHERE id=?",
+            params![target.as_str(), now, id.as_str()],
+        )
+        .map_err(backend)?;
+        SqliteTaskStore::append_event_with(
+            &conn,
+            EventKind::TaskForceStatus,
+            Some(&epic_name),
+            Some(id),
+            &serde_json::json!({
+                "from": prev.as_str(),
+                "to": target.as_str(),
+                "reason": reason,
+            }),
+            now,
+        )
+        .map_err(backend)?;
         Ok(())
+    }
+
+    fn find_task_by_pr(&self, pr_number: u64) -> Result<Option<Task>> {
+        let conn = self.conn.lock().expect("poisoned");
+        let mut stmt = conn
+            .prepare("SELECT * FROM tasks WHERE pr_number=? LIMIT 1")
+            .map_err(backend)?;
+        let task = stmt
+            .query_row(params![pr_number as i64], task_from_row)
+            .optional()
+            .map_err(backend)?;
+        Ok(task)
     }
 
     fn apply_reconciliation(&self, plan: ReconciliationPlan, now: DateTime<Utc>) -> Result<()> {
@@ -1084,6 +1160,49 @@ impl TaskRepo for SqliteTaskStore {
     }
 }
 
+impl SuppressionRepo for SqliteTaskStore {
+    fn suppress(
+        &self,
+        fingerprint: &str,
+        reason: &str,
+        suppress_until: DateTime<Utc>,
+    ) -> Result<()> {
+        let conn = self.conn.lock().expect("poisoned");
+        conn.execute(
+            "INSERT INTO escalation_suppression(fingerprint, reason, suppress_until)
+             VALUES (?, ?, ?)
+             ON CONFLICT(fingerprint, reason) DO UPDATE SET suppress_until=excluded.suppress_until",
+            params![fingerprint, reason, suppress_until],
+        )
+        .map_err(backend)?;
+        Ok(())
+    }
+
+    fn is_suppressed(&self, fingerprint: &str, reason: &str, now: DateTime<Utc>) -> Result<bool> {
+        let conn = self.conn.lock().expect("poisoned");
+        let until: Option<DateTime<Utc>> = conn
+            .query_row(
+                "SELECT suppress_until FROM escalation_suppression
+                 WHERE fingerprint=? AND reason=?",
+                params![fingerprint, reason],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(backend)?;
+        Ok(until.is_some_and(|u| now < u))
+    }
+
+    fn clear(&self, fingerprint: &str, reason: &str) -> Result<()> {
+        let conn = self.conn.lock().expect("poisoned");
+        conn.execute(
+            "DELETE FROM escalation_suppression WHERE fingerprint=? AND reason=?",
+            params![fingerprint, reason],
+        )
+        .map_err(backend)?;
+        Ok(())
+    }
+}
+
 impl EventLog for SqliteTaskStore {
     fn append_event(&self, event: &Event) -> Result<()> {
         let conn = self.conn.lock().expect("poisoned");
@@ -1148,7 +1267,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn open_in_memory_initializes_schema_v1() {
+    fn open_in_memory_initializes_to_current_schema() {
         let store = SqliteTaskStore::open_in_memory().expect("open");
         let conn = store.conn.lock().unwrap();
         let v: String = conn
@@ -1158,7 +1277,43 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(v, "1");
+        assert_eq!(v, SCHEMA_VERSION.to_string());
+    }
+
+    #[test]
+    fn v2_lookup_indexes_are_present() {
+        let store = SqliteTaskStore::open_in_memory().expect("open");
+        let conn = store.conn.lock().unwrap();
+        let mut stmt = conn
+            .prepare(
+                "SELECT name FROM sqlite_master
+                  WHERE type='index' AND name IN ('idx_tasks_pr_number','idx_epics_active_spec')",
+            )
+            .unwrap();
+        let names: std::collections::HashSet<String> = stmt
+            .query_map([], |row| row.get::<_, String>(0))
+            .unwrap()
+            .collect::<rusqlite::Result<_>>()
+            .unwrap();
+        assert!(names.contains("idx_tasks_pr_number"));
+        assert!(names.contains("idx_epics_active_spec"));
+    }
+
+    #[test]
+    fn migrates_v1_db_to_current() {
+        // Simulate an older DB at V1: only V1 SQL applied. open() should
+        // upgrade by running V2 forward migrations.
+        let mut conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(V1_SQL).unwrap();
+        SqliteTaskStore::migrate(&mut conn).unwrap();
+        let v: String = conn
+            .query_row(
+                "SELECT value FROM meta WHERE key='schema_version'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(v, SCHEMA_VERSION.to_string());
     }
 
     #[test]
@@ -1174,7 +1329,7 @@ mod tests {
         match err {
             TaskStoreError::SchemaMismatch { found, expected } => {
                 assert_eq!(found, 999);
-                assert_eq!(expected, 1);
+                assert_eq!(expected, SCHEMA_VERSION);
             }
             other => panic!("expected SchemaMismatch, got {other:?}"),
         }

--- a/plugins/github-autopilot/cli/tests/config_tests.rs
+++ b/plugins/github-autopilot/cli/tests/config_tests.rs
@@ -1,0 +1,65 @@
+use std::path::PathBuf;
+
+use autopilot::config::Config;
+use tempfile::NamedTempFile;
+
+// ---------- helpers ----------
+
+fn write_toml(content: &str) -> NamedTempFile {
+    let f = NamedTempFile::new().unwrap();
+    std::fs::write(f.path(), content).unwrap();
+    f
+}
+
+// ---------- defaults ----------
+
+#[test]
+fn config_loads_defaults_when_file_missing() {
+    // Pick a path that does not exist; load() must not error and must return defaults.
+    let tmp = NamedTempFile::new().unwrap();
+    let path = tmp.path().to_path_buf();
+    drop(tmp); // closes and removes the file
+    assert!(!path.exists(), "precondition: path must be missing");
+
+    let cfg = Config::load(&path).expect("load() with missing file should be Ok");
+    assert_eq!(cfg, Config::default());
+    assert_eq!(
+        cfg.storage.db_path,
+        PathBuf::from(".autopilot/state.db"),
+        "default db_path"
+    );
+    assert_eq!(
+        cfg.epic.default_max_attempts, 3,
+        "default max_attempts matches PR-B's previous constant"
+    );
+}
+
+// ---------- field overrides ----------
+
+#[test]
+fn config_loads_storage_db_path_from_toml() {
+    let f = write_toml("[storage]\ndb_path = \"/tmp/custom.db\"\n");
+    let cfg = Config::load(f.path()).expect("load()");
+    assert_eq!(cfg.storage.db_path, PathBuf::from("/tmp/custom.db"));
+    // Other sections still get defaults.
+    assert_eq!(cfg.epic.default_max_attempts, 3);
+}
+
+#[test]
+fn config_loads_epic_max_attempts_from_toml() {
+    let f = write_toml("[epic]\ndefault_max_attempts = 7\n");
+    let cfg = Config::load(f.path()).expect("load()");
+    assert_eq!(cfg.epic.default_max_attempts, 7);
+    // Storage default still applies.
+    assert_eq!(cfg.storage.db_path, PathBuf::from(".autopilot/state.db"));
+}
+
+// ---------- failure modes ----------
+
+#[test]
+fn config_load_returns_error_on_invalid_toml() {
+    let f = write_toml("this is = not = valid toml [[\n");
+    let err = Config::load(f.path()).unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(msg.contains("parsing config"), "error: {msg}");
+}

--- a/plugins/github-autopilot/cli/tests/epic_tests.rs
+++ b/plugins/github-autopilot/cli/tests/epic_tests.rs
@@ -1,0 +1,404 @@
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use autopilot::cmd::epic::{EpicService, EpicStatusFilter};
+use autopilot::domain::{Epic, EpicStatus, EventKind, TaskId, TaskStatus};
+use autopilot::ports::clock::{Clock, FixedClock};
+use autopilot::ports::task_store::{EpicPlan, EventFilter, NewTask, TaskStore};
+use autopilot::store::InMemoryTaskStore;
+use chrono::{TimeZone, Utc};
+use tempfile::NamedTempFile;
+
+fn fixture() -> (Arc<dyn TaskStore>, FixedClock) {
+    let store: Arc<dyn TaskStore> = Arc::new(InMemoryTaskStore::new());
+    let clock = FixedClock::new(Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap());
+    (store, clock)
+}
+
+fn capture<F>(f: F) -> (i32, String)
+where
+    F: FnOnce(&mut Vec<u8>) -> anyhow::Result<i32>,
+{
+    let mut buf: Vec<u8> = Vec::new();
+    let code = f(&mut buf).expect("service call");
+    (code, String::from_utf8(buf).expect("utf-8"))
+}
+
+fn expect_err<F>(f: F) -> String
+where
+    F: FnOnce(&mut Vec<u8>) -> anyhow::Result<i32>,
+{
+    let mut buf: Vec<u8> = Vec::new();
+    format!("{:#}", f(&mut buf).unwrap_err())
+}
+
+fn seed_epic(svc: &EpicService, name: &str) {
+    let path = format!("spec/{name}.md");
+    let _ = capture(|w| svc.create(name, Path::new(&path), None, w));
+}
+
+fn write_plan_jsonl(lines: &[&str]) -> NamedTempFile {
+    let f = NamedTempFile::new().unwrap();
+    let mut h = std::fs::File::create(f.path()).unwrap();
+    for l in lines {
+        writeln!(h, "{l}").unwrap();
+    }
+    f
+}
+
+#[test]
+fn create_persists_epic_and_emits_started_event() {
+    let (store, clock) = fixture();
+    let svc = EpicService::new(store.as_ref(), &clock);
+
+    let (code, out) = capture(|w| svc.create("e", Path::new("spec/e.md"), None, w));
+    assert_eq!(code, 0, "stdout: {out}");
+
+    let epics = store.list_epics(None).unwrap();
+    assert_eq!(epics.len(), 1);
+    assert_eq!(epics[0].name, "e");
+    assert_eq!(epics[0].status, EpicStatus::Active);
+    assert_eq!(epics[0].branch, "epic/e");
+    assert_eq!(epics[0].spec_path, PathBuf::from("spec/e.md"));
+
+    let events = store
+        .list_events(EventFilter {
+            kinds: vec![EventKind::EpicStarted],
+            ..Default::default()
+        })
+        .unwrap();
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].epic_name.as_deref(), Some("e"));
+}
+
+#[test]
+fn create_uses_explicit_branch_override() {
+    let (store, clock) = fixture();
+    let svc = EpicService::new(store.as_ref(), &clock);
+    let (_code, _) = capture(|w| svc.create("e", Path::new("spec/e.md"), Some("custom/x"), w));
+    let e = store.get_epic("e").unwrap().unwrap();
+    assert_eq!(e.branch, "custom/x");
+}
+
+#[test]
+fn create_returns_exit_1_when_epic_already_exists() {
+    let (store, clock) = fixture();
+    let svc = EpicService::new(store.as_ref(), &clock);
+    let _ = capture(|w| svc.create("e", Path::new("spec/e.md"), None, w));
+    let (code, out) = capture(|w| svc.create("e", Path::new("spec/e.md"), None, w));
+    assert_eq!(code, 1);
+    assert!(out.contains("already exists"), "stdout: {out}");
+}
+
+#[test]
+fn list_filters_by_status_and_renders_json() {
+    let (store, clock) = fixture();
+    let svc = EpicService::new(store.as_ref(), &clock);
+    let _ = capture(|w| svc.create("a", Path::new("spec/a.md"), None, w));
+    let _ = capture(|w| svc.create("b", Path::new("spec/b.md"), None, w));
+    store
+        .set_epic_status("b", EpicStatus::Completed, clock.now())
+        .unwrap();
+
+    let (code, out) = capture(|w| svc.list(Some(EpicStatusFilter::Active), true, w));
+    assert_eq!(code, 0);
+    let v: serde_json::Value = serde_json::from_str(out.trim()).unwrap();
+    let arr = v.as_array().unwrap();
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["name"], "a");
+
+    let (_, out_all) = capture(|w| svc.list(Some(EpicStatusFilter::All), true, w));
+    let v: serde_json::Value = serde_json::from_str(out_all.trim()).unwrap();
+    assert_eq!(v.as_array().unwrap().len(), 2);
+}
+
+#[test]
+fn get_returns_exit_1_when_missing() {
+    let (store, clock) = fixture();
+    let svc = EpicService::new(store.as_ref(), &clock);
+    let (code, _) = capture(|w| svc.get("ghost", false, w));
+    assert_eq!(code, 1);
+}
+
+#[test]
+fn status_groups_tasks_by_state() {
+    let (store, clock) = fixture();
+    let svc = EpicService::new(store.as_ref(), &clock);
+
+    let now = clock.now();
+    store
+        .insert_epic_with_tasks(
+            EpicPlan {
+                epic: Epic {
+                    name: "e".into(),
+                    spec_path: PathBuf::from("spec/e.md"),
+                    branch: "epic/e".into(),
+                    status: EpicStatus::Active,
+                    created_at: now,
+                    completed_at: None,
+                },
+                tasks: vec![
+                    NewTask {
+                        id: TaskId::from_raw("aaaaaaaaaaaa"),
+                        source: autopilot::domain::TaskSource::Decompose,
+                        fingerprint: None,
+                        title: "first".into(),
+                        body: None,
+                    },
+                    NewTask {
+                        id: TaskId::from_raw("bbbbbbbbbbbb"),
+                        source: autopilot::domain::TaskSource::Decompose,
+                        fingerprint: None,
+                        title: "second".into(),
+                        body: None,
+                    },
+                ],
+                deps: vec![(
+                    TaskId::from_raw("bbbbbbbbbbbb"),
+                    TaskId::from_raw("aaaaaaaaaaaa"),
+                )],
+            },
+            now,
+        )
+        .unwrap();
+
+    let (code, out) = capture(|w| svc.status(Some("e"), true, w));
+    assert_eq!(code, 0, "stdout: {out}");
+    let v: serde_json::Value = serde_json::from_str(out.trim()).unwrap();
+    let r = &v.as_array().unwrap()[0];
+    assert_eq!(r["epic"], "e");
+    assert_eq!(r["counts"]["ready"], 1);
+    assert_eq!(r["counts"]["pending"], 1);
+    assert_eq!(r["total"], 2);
+}
+
+#[test]
+fn complete_marks_epic_completed_and_records_event() {
+    let (store, clock) = fixture();
+    let svc = EpicService::new(store.as_ref(), &clock);
+    let _ = capture(|w| svc.create("e", Path::new("spec/e.md"), None, w));
+
+    let (code, _) = capture(|w| svc.complete("e", w));
+    assert_eq!(code, 0);
+    let e = store.get_epic("e").unwrap().unwrap();
+    assert_eq!(e.status, EpicStatus::Completed);
+    let events = store
+        .list_events(EventFilter {
+            kinds: vec![EventKind::EpicCompleted],
+            ..Default::default()
+        })
+        .unwrap();
+    assert_eq!(events.len(), 1);
+}
+
+#[test]
+fn complete_returns_exit_1_when_epic_missing() {
+    let (store, clock) = fixture();
+    let svc = EpicService::new(store.as_ref(), &clock);
+    let (code, out) = capture(|w| svc.complete("ghost", w));
+    assert_eq!(code, 1);
+    assert!(out.contains("not found"));
+}
+
+#[test]
+fn abandon_marks_epic_abandoned() {
+    let (store, clock) = fixture();
+    let svc = EpicService::new(store.as_ref(), &clock);
+    let _ = capture(|w| svc.create("e", Path::new("spec/e.md"), None, w));
+    let (code, _) = capture(|w| svc.abandon("e", w));
+    assert_eq!(code, 0);
+    assert_eq!(
+        store.get_epic("e").unwrap().unwrap().status,
+        EpicStatus::Abandoned
+    );
+}
+
+#[test]
+fn find_by_spec_path_matches_active_epic() {
+    let (store, clock) = fixture();
+    let svc = EpicService::new(store.as_ref(), &clock);
+    let _ = capture(|w| svc.create("e", Path::new("spec/e.md"), None, w));
+    let (code, out) = capture(|w| svc.find_by_spec_path(Path::new("spec/e.md"), true, w));
+    assert_eq!(code, 0);
+    let v: serde_json::Value = serde_json::from_str(out.trim()).unwrap();
+    assert_eq!(v["name"], "e");
+}
+
+#[test]
+fn find_by_spec_path_returns_exit_1_when_no_match() {
+    let (store, clock) = fixture();
+    let svc = EpicService::new(store.as_ref(), &clock);
+    let (code, _) = capture(|w| svc.find_by_spec_path(Path::new("spec/none.md"), false, w));
+    assert_eq!(code, 1);
+}
+
+#[test]
+fn find_by_spec_path_returns_exit_3_on_inconsistency() {
+    let store: Arc<dyn TaskStore> = Arc::new(InMemoryTaskStore::new());
+    let clock = FixedClock::new(Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap());
+    let now = clock.now();
+    for name in ["a", "b"] {
+        store
+            .insert_epic_with_tasks(
+                EpicPlan {
+                    epic: Epic {
+                        name: name.into(),
+                        spec_path: PathBuf::from("spec/shared.md"),
+                        branch: format!("epic/{name}"),
+                        status: EpicStatus::Active,
+                        created_at: now,
+                        completed_at: None,
+                    },
+                    tasks: vec![],
+                    deps: vec![],
+                },
+                now,
+            )
+            .unwrap();
+    }
+    let svc = EpicService::new(store.as_ref(), &clock);
+    let (code, out) = capture(|w| svc.find_by_spec_path(Path::new("spec/shared.md"), false, w));
+    assert_eq!(code, 3);
+    assert!(out.contains("inconsistency"), "stdout: {out}");
+}
+
+#[test]
+fn reconcile_applies_jsonl_plan_and_is_idempotent() {
+    let (store, clock) = fixture();
+    let svc = EpicService::new(store.as_ref(), &clock);
+    let _ = capture(|w| svc.create("e", Path::new("spec/e.md"), None, w));
+
+    let plan = NamedTempFile::new().unwrap();
+    let lines = [
+        r#"{"kind":"task","id":"aaaaaaaaaaaa","title":"first","fingerprint":null,"source":"decompose"}"#,
+        r#"{"kind":"task","id":"bbbbbbbbbbbb","title":"second"}"#,
+        r#"{"kind":"dep","task":"bbbbbbbbbbbb","depends_on":"aaaaaaaaaaaa"}"#,
+    ];
+    {
+        let mut f = std::fs::File::create(plan.path()).unwrap();
+        for l in &lines {
+            writeln!(f, "{l}").unwrap();
+        }
+    }
+
+    let (code1, _) = capture(|w| svc.reconcile("e", plan.path(), w));
+    assert_eq!(code1, 0);
+    let tasks = store.list_tasks_by_epic("e", None).unwrap();
+    assert_eq!(tasks.len(), 2);
+    let by_id = |id: &str| tasks.iter().find(|t| t.id.as_str() == id).cloned().unwrap();
+    assert_eq!(by_id("aaaaaaaaaaaa").status, TaskStatus::Ready);
+    assert_eq!(by_id("bbbbbbbbbbbb").status, TaskStatus::Pending);
+
+    let snapshot1 = store.list_tasks_by_epic("e", None).unwrap();
+
+    let (code2, _) = capture(|w| svc.reconcile("e", plan.path(), w));
+    assert_eq!(code2, 0);
+    let snapshot2 = store.list_tasks_by_epic("e", None).unwrap();
+    assert_eq!(
+        snapshot1
+            .iter()
+            .map(|t| (&t.id, t.status))
+            .collect::<Vec<_>>(),
+        snapshot2
+            .iter()
+            .map(|t| (&t.id, t.status))
+            .collect::<Vec<_>>()
+    );
+
+    let reconciled_events = store
+        .list_events(EventFilter {
+            kinds: vec![EventKind::Reconciled],
+            ..Default::default()
+        })
+        .unwrap();
+    assert_eq!(reconciled_events.len(), 2);
+}
+
+#[test]
+fn reconcile_returns_exit_1_when_epic_missing() {
+    let (store, clock) = fixture();
+    let svc = EpicService::new(store.as_ref(), &clock);
+    let plan = NamedTempFile::new().unwrap();
+    let (code, out) = capture(|w| svc.reconcile("ghost", plan.path(), w));
+    assert_eq!(code, 1);
+    assert!(out.contains("not found"));
+}
+
+#[test]
+fn reconcile_rejects_duplicate_task_id_in_plan() {
+    let (store, clock) = fixture();
+    let svc = EpicService::new(store.as_ref(), &clock);
+    seed_epic(&svc, "e");
+
+    let plan = write_plan_jsonl(&[
+        r#"{"kind":"task","id":"aaaaaaaaaaaa","title":"first"}"#,
+        r#"{"kind":"task","id":"aaaaaaaaaaaa","title":"duplicate"}"#,
+    ]);
+
+    let msg = expect_err(|w| svc.reconcile("e", plan.path(), w));
+    assert!(
+        msg.contains("duplicate task id 'aaaaaaaaaaaa'"),
+        "error: {msg}"
+    );
+    assert!(store.list_tasks_by_epic("e", None).unwrap().is_empty());
+}
+
+#[test]
+fn reconcile_rejects_unknown_task_source() {
+    let (store, clock) = fixture();
+    let svc = EpicService::new(store.as_ref(), &clock);
+    seed_epic(&svc, "e");
+
+    let plan = write_plan_jsonl(&[
+        r#"{"kind":"task","id":"aaaaaaaaaaaa","title":"x","source":"telepathy"}"#,
+    ]);
+    let msg = expect_err(|w| svc.reconcile("e", plan.path(), w));
+    assert!(msg.contains("unknown source 'telepathy'"), "error: {msg}");
+    // No partial write on parse error.
+    assert!(store.list_tasks_by_epic("e", None).unwrap().is_empty());
+}
+
+#[test]
+fn reconcile_skips_blank_and_comment_lines() {
+    let (store, clock) = fixture();
+    let svc = EpicService::new(store.as_ref(), &clock);
+    seed_epic(&svc, "e");
+
+    // The `#`-prefixed line is itself valid JSON; if the parser stripped `#`
+    // *after* trying to deserialize it would either error or insert task
+    // `cccccccccccc`. Asserting only `aaaa...` is created proves `#` is
+    // recognized as a comment marker before parse.
+    let plan = write_plan_jsonl(&[
+        r#"# {"kind":"task","id":"cccccccccccc","title":"comment"}"#,
+        "",
+        r#"{"kind":"task","id":"aaaaaaaaaaaa","title":"first"}"#,
+        "   ",
+    ]);
+    let (code, _) = capture(|w| svc.reconcile("e", plan.path(), w));
+    assert_eq!(code, 0);
+    let tasks = store.list_tasks_by_epic("e", None).unwrap();
+    assert_eq!(tasks.len(), 1);
+    assert_eq!(tasks[0].id.as_str(), "aaaaaaaaaaaa");
+}
+
+#[test]
+fn list_renders_human_table_when_not_json() {
+    let (store, clock) = fixture();
+    let svc = EpicService::new(store.as_ref(), &clock);
+    seed_epic(&svc, "alpha");
+    let (code, out) = capture(|w| svc.list(None, false, w));
+    assert_eq!(code, 0);
+    assert!(out.contains("alpha"));
+    assert!(out.contains("epic/alpha"));
+    assert!(out.contains("active"));
+}
+
+#[test]
+fn list_emits_placeholder_when_empty() {
+    let (store, clock) = fixture();
+    let svc = EpicService::new(store.as_ref(), &clock);
+    let (code, out) = capture(|w| svc.list(None, false, w));
+    assert_eq!(code, 0);
+    assert!(out.contains("(no epics)"));
+}

--- a/plugins/github-autopilot/cli/tests/events_tests.rs
+++ b/plugins/github-autopilot/cli/tests/events_tests.rs
@@ -1,0 +1,196 @@
+use std::sync::Arc;
+
+use autopilot::cmd::events::{EventsService, ListArgs};
+use autopilot::domain::{Event, EventKind, TaskId};
+use autopilot::ports::task_store::TaskStore;
+use autopilot::store::InMemoryTaskStore;
+use chrono::{DateTime, TimeZone, Utc};
+
+// ---------- helpers ----------
+
+fn base_time() -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap()
+}
+
+fn fixture_with_events() -> Arc<dyn TaskStore> {
+    let store: Arc<dyn TaskStore> = Arc::new(InMemoryTaskStore::new());
+    let t0 = base_time();
+    // (epic, task, kind, +seconds)
+    let seeds: &[(Option<&str>, Option<&str>, EventKind, i64)] = &[
+        (Some("e1"), None, EventKind::EpicStarted, 0),
+        (
+            Some("e1"),
+            Some("aaaaaaaaaaaa"),
+            EventKind::TaskInserted,
+            10,
+        ),
+        (Some("e1"), Some("aaaaaaaaaaaa"), EventKind::TaskClaimed, 20),
+        (
+            Some("e1"),
+            Some("bbbbbbbbbbbb"),
+            EventKind::TaskInserted,
+            30,
+        ),
+        (Some("e2"), None, EventKind::EpicStarted, 40),
+        (
+            Some("e2"),
+            Some("cccccccccccc"),
+            EventKind::TaskInserted,
+            50,
+        ),
+    ];
+    for (epic, task, kind, sec) in seeds {
+        let event = Event {
+            task_id: task.map(TaskId::from_raw),
+            epic_name: epic.map(|s| s.to_string()),
+            kind: *kind,
+            payload: serde_json::Value::Null,
+            at: t0 + chrono::Duration::seconds(*sec),
+        };
+        store.append_event(&event).unwrap();
+    }
+    store
+}
+
+fn capture<F>(f: F) -> (i32, String)
+where
+    F: FnOnce(&mut Vec<u8>) -> anyhow::Result<i32>,
+{
+    let mut buf: Vec<u8> = Vec::new();
+    let code = f(&mut buf).expect("service call");
+    (code, String::from_utf8(buf).expect("utf-8"))
+}
+
+fn list_args() -> ListArgs {
+    ListArgs {
+        epic: None,
+        task: None,
+        kinds: vec![],
+        since: None,
+        limit: None,
+        json: false,
+    }
+}
+
+// ---------- list filters ----------
+
+#[test]
+fn events_list_filters_by_epic() {
+    let store = fixture_with_events();
+    let svc = EventsService::new(store.as_ref());
+    let args = ListArgs {
+        epic: Some("e1".to_string()),
+        json: true,
+        ..list_args()
+    };
+    let (code, out) = capture(|w| svc.list(&args, w));
+    assert_eq!(code, 0);
+    let arr: Vec<serde_json::Value> = serde_json::from_str(out.trim()).unwrap();
+    assert_eq!(arr.len(), 4);
+    for e in &arr {
+        assert_eq!(e["epic"], "e1");
+    }
+}
+
+#[test]
+fn events_list_filters_by_task() {
+    let store = fixture_with_events();
+    let svc = EventsService::new(store.as_ref());
+    let args = ListArgs {
+        task: Some("aaaaaaaaaaaa".to_string()),
+        json: true,
+        ..list_args()
+    };
+    let (code, out) = capture(|w| svc.list(&args, w));
+    assert_eq!(code, 0);
+    let arr: Vec<serde_json::Value> = serde_json::from_str(out.trim()).unwrap();
+    assert_eq!(arr.len(), 2);
+    for e in &arr {
+        assert_eq!(e["task"], "aaaaaaaaaaaa");
+    }
+}
+
+#[test]
+fn events_list_filters_by_kind() {
+    let store = fixture_with_events();
+    let svc = EventsService::new(store.as_ref());
+    let args = ListArgs {
+        kinds: vec!["task_inserted".to_string()],
+        json: true,
+        ..list_args()
+    };
+    let (code, out) = capture(|w| svc.list(&args, w));
+    assert_eq!(code, 0);
+    let arr: Vec<serde_json::Value> = serde_json::from_str(out.trim()).unwrap();
+    assert_eq!(arr.len(), 3);
+    for e in &arr {
+        assert_eq!(e["kind"], "task_inserted");
+    }
+}
+
+#[test]
+fn events_list_filters_by_since() {
+    let store = fixture_with_events();
+    let svc = EventsService::new(store.as_ref());
+    // Drop the first 3 events (at t+0, t+10s, t+20s) by passing t+25s.
+    let args = ListArgs {
+        since: Some("2026-01-01T00:00:25Z".to_string()),
+        json: true,
+        ..list_args()
+    };
+    let (code, out) = capture(|w| svc.list(&args, w));
+    assert_eq!(code, 0);
+    let arr: Vec<serde_json::Value> = serde_json::from_str(out.trim()).unwrap();
+    assert_eq!(arr.len(), 3);
+}
+
+#[test]
+fn events_list_respects_limit() {
+    let store = fixture_with_events();
+    let svc = EventsService::new(store.as_ref());
+    let args = ListArgs {
+        limit: Some(2),
+        json: true,
+        ..list_args()
+    };
+    let (code, out) = capture(|w| svc.list(&args, w));
+    assert_eq!(code, 0);
+    let arr: Vec<serde_json::Value> = serde_json::from_str(out.trim()).unwrap();
+    assert_eq!(arr.len(), 2);
+}
+
+#[test]
+fn events_list_json_output_is_array_of_event_records() {
+    let store = fixture_with_events();
+    let svc = EventsService::new(store.as_ref());
+    let args = ListArgs {
+        json: true,
+        ..list_args()
+    };
+    let (code, out) = capture(|w| svc.list(&args, w));
+    assert_eq!(code, 0);
+    let arr: Vec<serde_json::Value> = serde_json::from_str(out.trim()).unwrap();
+    assert!(!arr.is_empty());
+    // Each record must expose at, kind, epic, task, payload.
+    for e in &arr {
+        assert!(e["at"].is_string(), "missing `at`: {e}");
+        assert!(e["kind"].is_string(), "missing `kind`: {e}");
+        assert!(e.get("epic").is_some(), "missing `epic` (may be null): {e}");
+        assert!(e.get("task").is_some(), "missing `task` (may be null): {e}");
+        assert!(e.get("payload").is_some(), "missing `payload`: {e}");
+    }
+}
+
+#[test]
+fn events_list_rejects_unknown_kind() {
+    let store = fixture_with_events();
+    let svc = EventsService::new(store.as_ref());
+    let args = ListArgs {
+        kinds: vec!["definitely_not_a_kind".to_string()],
+        ..list_args()
+    };
+    let (code, out) = capture(|w| svc.list(&args, w));
+    assert_eq!(code, 1, "stdout: {out}");
+    assert!(out.contains("unknown event kind"), "stdout: {out}");
+    assert!(out.contains("definitely_not_a_kind"), "stdout: {out}");
+}

--- a/plugins/github-autopilot/cli/tests/store_conformance.rs
+++ b/plugins/github-autopilot/cli/tests/store_conformance.rs
@@ -152,12 +152,37 @@ fn body_claim_skips_tasks_with_unsatisfied_deps(store: Arc<dyn TaskStore>) {
     assert!(claimed_again.is_none());
 }
 
-fn body_claim_increments_attempts_on_each_call_after_revert(store: Arc<dyn TaskStore>) {
+fn body_release_claim_decrements_attempts(store: Arc<dyn TaskStore>) {
     store
         .insert_epic_with_tasks(plan("e", vec![nt("A", "a")], vec![]), t0())
         .unwrap();
     let _ = store.claim_next_task("e", t0()).unwrap().unwrap();
-    store.revert_to_ready(&TaskId::from_raw("A"), t0()).unwrap();
+    store.release_claim(&TaskId::from_raw("A"), t0()).unwrap();
+    let claimed = store.claim_next_task("e", t0()).unwrap().unwrap();
+    assert_eq!(claimed.attempts, 1);
+}
+
+fn body_release_claim_rejects_non_wip(store: Arc<dyn TaskStore>) {
+    store
+        .insert_epic_with_tasks(plan("e", vec![nt("A", "a")], vec![]), t0())
+        .unwrap();
+    let err = store
+        .release_claim(&TaskId::from_raw("A"), t0())
+        .unwrap_err();
+    assert!(
+        format!("{err}").contains("illegal status transition"),
+        "expected illegal-transition, got: {err}"
+    );
+}
+
+fn body_mark_failed_preserves_attempts_for_retry(store: Arc<dyn TaskStore>) {
+    store
+        .insert_epic_with_tasks(plan("e", vec![nt("A", "a")], vec![]), t0())
+        .unwrap();
+    let _ = store.claim_next_task("e", t0()).unwrap().unwrap();
+    let _ = store
+        .mark_task_failed(&TaskId::from_raw("A"), 3, t0())
+        .unwrap();
     let claimed = store.claim_next_task("e", t0()).unwrap().unwrap();
     assert_eq!(claimed.attempts, 2);
 }
@@ -403,6 +428,163 @@ fn body_upsert_watch_task_returns_duplicate_on_existing_fingerprint(store: Arc<d
     assert_eq!(tasks.len(), 1);
 }
 
+fn body_find_task_by_pr_returns_owning_task(store: Arc<dyn TaskStore>) {
+    store
+        .insert_epic_with_tasks(plan("e", vec![nt("A", "a"), nt("B", "b")], vec![]), t0())
+        .unwrap();
+    let _ = store.claim_next_task("e", t0()).unwrap().unwrap();
+    store
+        .complete_task_and_unblock(&TaskId::from_raw("A"), 42, t0())
+        .unwrap();
+    let found = store.find_task_by_pr(42).unwrap().unwrap();
+    assert_eq!(found.id.as_str(), "A");
+}
+
+fn body_find_task_by_pr_returns_none_when_unknown(store: Arc<dyn TaskStore>) {
+    assert!(store.find_task_by_pr(9999).unwrap().is_none());
+}
+
+fn body_find_active_by_spec_path_matches_active_only(store: Arc<dyn TaskStore>) {
+    store
+        .insert_epic_with_tasks(plan("e1", vec![], vec![]), t0())
+        .unwrap();
+    store
+        .insert_epic_with_tasks(plan("e2", vec![], vec![]), t0())
+        .unwrap();
+    store
+        .set_epic_status("e2", EpicStatus::Abandoned, t0() + Duration::seconds(1))
+        .unwrap();
+    let path = std::path::PathBuf::from("spec/e1.md");
+    let found = store.find_active_by_spec_path(&path).unwrap().unwrap();
+    assert_eq!(found.name, "e1");
+}
+
+fn body_find_active_by_spec_path_returns_none_when_no_match(store: Arc<dyn TaskStore>) {
+    store
+        .insert_epic_with_tasks(plan("e1", vec![], vec![]), t0())
+        .unwrap();
+    let path = std::path::PathBuf::from("spec/elsewhere.md");
+    assert!(store.find_active_by_spec_path(&path).unwrap().is_none());
+}
+
+fn body_find_active_by_spec_path_rejects_invariant_violation(store: Arc<dyn TaskStore>) {
+    let shared = std::path::PathBuf::from("spec/shared.md");
+    let mk = |name: &str| Epic {
+        name: name.to_string(),
+        spec_path: shared.clone(),
+        branch: format!("epic/{name}"),
+        status: EpicStatus::Active,
+        created_at: t0(),
+        completed_at: None,
+    };
+    store.upsert_epic(&mk("e1")).unwrap();
+    store.upsert_epic(&mk("e2")).unwrap();
+    let err = store.find_active_by_spec_path(&shared).unwrap_err();
+    assert!(
+        format!("{err}").contains("inconsistency"),
+        "expected Inconsistency error, got: {err}"
+    );
+}
+
+fn body_force_status_bypasses_normal_transition(store: Arc<dyn TaskStore>) {
+    store
+        .insert_epic_with_tasks(plan("e", vec![nt("A", "a")], vec![]), t0())
+        .unwrap();
+    for _ in 0..3 {
+        let _ = store.claim_next_task("e", t0()).unwrap().unwrap();
+        let _ = store
+            .mark_task_failed(&TaskId::from_raw("A"), 3, t0())
+            .unwrap();
+    }
+    store
+        .force_status(
+            &TaskId::from_raw("A"),
+            TaskStatus::Pending,
+            "manual reset",
+            t0(),
+        )
+        .unwrap();
+    let a = store.get_task(&TaskId::from_raw("A")).unwrap().unwrap();
+    assert_eq!(a.status, TaskStatus::Pending);
+}
+
+fn body_force_status_does_not_unblock_dependents(store: Arc<dyn TaskStore>) {
+    store
+        .insert_epic_with_tasks(
+            plan("e", vec![nt("A", "a"), nt("B", "b")], vec![("B", "A")]),
+            t0(),
+        )
+        .unwrap();
+    for _ in 0..3 {
+        let _ = store.claim_next_task("e", t0()).unwrap().unwrap();
+        let _ = store
+            .mark_task_failed(&TaskId::from_raw("A"), 3, t0())
+            .unwrap();
+    }
+    let b_before = store.get_task(&TaskId::from_raw("B")).unwrap().unwrap();
+    assert_eq!(b_before.status, TaskStatus::Blocked);
+    store
+        .force_status(
+            &TaskId::from_raw("A"),
+            TaskStatus::Done,
+            "human fixed",
+            t0(),
+        )
+        .unwrap();
+    let b_after = store.get_task(&TaskId::from_raw("B")).unwrap().unwrap();
+    assert_eq!(b_after.status, TaskStatus::Blocked);
+}
+
+fn body_force_status_records_event_with_reason(store: Arc<dyn TaskStore>) {
+    store
+        .insert_epic_with_tasks(plan("e", vec![nt("A", "a")], vec![]), t0())
+        .unwrap();
+    store
+        .force_status(
+            &TaskId::from_raw("A"),
+            TaskStatus::Pending,
+            "rollback for repro",
+            t0(),
+        )
+        .unwrap();
+    let evs = store
+        .list_events(EventFilter {
+            kinds: vec![EventKind::TaskForceStatus],
+            ..Default::default()
+        })
+        .unwrap();
+    assert_eq!(evs.len(), 1);
+    assert_eq!(evs[0].payload["reason"], "rollback for repro");
+    assert_eq!(evs[0].payload["to"], "pending");
+}
+
+fn body_suppression_blocks_until_window_expires(store: Arc<dyn TaskStore>) {
+    let until = t0() + Duration::hours(1);
+    store.suppress("fp-1", "unmatched_watch", until).unwrap();
+    assert!(store
+        .is_suppressed("fp-1", "unmatched_watch", t0() + Duration::minutes(30))
+        .unwrap());
+    assert!(!store
+        .is_suppressed("fp-1", "unmatched_watch", t0() + Duration::hours(2))
+        .unwrap());
+}
+
+fn body_suppression_is_scoped_by_reason(store: Arc<dyn TaskStore>) {
+    store
+        .suppress("fp-1", "unmatched_watch", t0() + Duration::hours(1))
+        .unwrap();
+    assert!(!store
+        .is_suppressed("fp-1", "rejected_by_human", t0())
+        .unwrap());
+}
+
+fn body_suppression_clear_unblocks_immediately(store: Arc<dyn TaskStore>) {
+    let until = t0() + Duration::days(30);
+    store.suppress("fp-1", "r", until).unwrap();
+    store.clear("fp-1", "r").unwrap();
+    assert!(!store.is_suppressed("fp-1", "r", t0()).unwrap());
+}
+
 macro_rules! conformance_suite {
     ($($name:ident),* $(,)?) => {
         mod in_memory {
@@ -440,7 +622,9 @@ conformance_suite!(
     body_claim_returns_none_when_no_ready_task,
     body_claim_returns_oldest_ready_task,
     body_claim_skips_tasks_with_unsatisfied_deps,
-    body_claim_increments_attempts_on_each_call_after_revert,
+    body_release_claim_decrements_attempts,
+    body_release_claim_rejects_non_wip,
+    body_mark_failed_preserves_attempts_for_retry,
     body_claim_is_atomic_under_concurrent_callers,
     body_completing_a_task_unblocks_dependents_with_satisfied_deps,
     body_complete_rejects_when_status_not_wip,
@@ -451,6 +635,17 @@ conformance_suite!(
     body_reconcile_preserves_attempts_counter,
     body_upsert_watch_task_inserts_new_when_no_fingerprint_match,
     body_upsert_watch_task_returns_duplicate_on_existing_fingerprint,
+    body_find_task_by_pr_returns_owning_task,
+    body_find_task_by_pr_returns_none_when_unknown,
+    body_find_active_by_spec_path_matches_active_only,
+    body_find_active_by_spec_path_returns_none_when_no_match,
+    body_find_active_by_spec_path_rejects_invariant_violation,
+    body_force_status_bypasses_normal_transition,
+    body_force_status_does_not_unblock_dependents,
+    body_force_status_records_event_with_reason,
+    body_suppression_blocks_until_window_expires,
+    body_suppression_is_scoped_by_reason,
+    body_suppression_clear_unblocks_immediately,
 );
 
 #[test]

--- a/plugins/github-autopilot/cli/tests/suppress_tests.rs
+++ b/plugins/github-autopilot/cli/tests/suppress_tests.rs
@@ -1,0 +1,103 @@
+use std::sync::Arc;
+
+use autopilot::cmd::suppress::SuppressService;
+use autopilot::ports::clock::FixedClock;
+use autopilot::ports::task_store::TaskStore;
+use autopilot::store::InMemoryTaskStore;
+use chrono::{TimeZone, Utc};
+
+// ---------- helpers ----------
+
+fn fixture() -> (Arc<dyn TaskStore>, FixedClock) {
+    let store: Arc<dyn TaskStore> = Arc::new(InMemoryTaskStore::new());
+    let clock = FixedClock::new(Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap());
+    (store, clock)
+}
+
+fn capture<F>(f: F) -> (i32, String)
+where
+    F: FnOnce(&mut Vec<u8>) -> anyhow::Result<i32>,
+{
+    let mut buf: Vec<u8> = Vec::new();
+    let code = f(&mut buf).expect("service call");
+    (code, String::from_utf8(buf).expect("utf-8"))
+}
+
+fn expect_err<F>(f: F) -> String
+where
+    F: FnOnce(&mut Vec<u8>) -> anyhow::Result<i32>,
+{
+    let mut buf: Vec<u8> = Vec::new();
+    format!("{:#}", f(&mut buf).unwrap_err())
+}
+
+// ---------- add ----------
+
+#[test]
+fn suppress_add_persists_until_window() {
+    let (store, clock) = fixture();
+    let svc = SuppressService::new(store.as_ref(), &clock);
+    let (code, out) = capture(|w| svc.add("fp1", "unmatched_watch", "2026-01-02T00:00:00Z", w));
+    assert_eq!(code, 0, "stdout: {out}");
+    assert!(out.contains("fp1"), "stdout: {out}");
+    assert!(out.contains("unmatched_watch"), "stdout: {out}");
+    // still inside the window at fixture's clock (2026-01-01)
+    let (check_code, _) = capture(|w| svc.check("fp1", "unmatched_watch", w));
+    assert_eq!(check_code, 0);
+}
+
+#[test]
+fn suppress_add_rejects_invalid_until_timestamp() {
+    let (store, clock) = fixture();
+    let svc = SuppressService::new(store.as_ref(), &clock);
+    let err = expect_err(|w| svc.add("fp1", "unmatched_watch", "not-a-date", w));
+    assert!(err.contains("--until"), "error: {err}");
+}
+
+// ---------- check ----------
+
+#[test]
+fn suppress_check_returns_exit_0_when_active() {
+    let (store, clock) = fixture();
+    let svc = SuppressService::new(store.as_ref(), &clock);
+    let _ = capture(|w| svc.add("fp1", "unmatched_watch", "2026-01-02T00:00:00Z", w));
+    let (code, out) = capture(|w| svc.check("fp1", "unmatched_watch", w));
+    assert_eq!(code, 0, "stdout: {out}");
+    assert!(out.contains("suppressed"), "stdout: {out}");
+}
+
+#[test]
+fn suppress_check_returns_exit_1_after_window_expires() {
+    let (store, clock) = fixture();
+    let svc = SuppressService::new(store.as_ref(), &clock);
+    let _ = capture(|w| svc.add("fp1", "unmatched_watch", "2026-01-02T00:00:00Z", w));
+    // Advance well past --until.
+    clock.advance(chrono::Duration::days(2));
+    let (code, out) = capture(|w| svc.check("fp1", "unmatched_watch", w));
+    assert_eq!(code, 1, "stdout: {out}");
+    assert!(out.contains("not suppressed"), "stdout: {out}");
+}
+
+#[test]
+fn suppress_check_returns_exit_1_when_never_suppressed() {
+    let (store, clock) = fixture();
+    let svc = SuppressService::new(store.as_ref(), &clock);
+    let (code, out) = capture(|w| svc.check("never-set", "rejected_by_human", w));
+    assert_eq!(code, 1, "stdout: {out}");
+    assert!(out.contains("not suppressed"), "stdout: {out}");
+}
+
+// ---------- clear ----------
+
+#[test]
+fn suppress_clear_removes_entry() {
+    let (store, clock) = fixture();
+    let svc = SuppressService::new(store.as_ref(), &clock);
+    let _ = capture(|w| svc.add("fp1", "unmatched_watch", "2026-01-02T00:00:00Z", w));
+    let (code, out) = capture(|w| svc.clear("fp1", "unmatched_watch", w));
+    assert_eq!(code, 0, "stdout: {out}");
+    assert!(out.contains("cleared"), "stdout: {out}");
+    // After clear, check should report not-suppressed (exit 1).
+    let (check_code, _) = capture(|w| svc.check("fp1", "unmatched_watch", w));
+    assert_eq!(check_code, 1);
+}

--- a/plugins/github-autopilot/cli/tests/task_tests.rs
+++ b/plugins/github-autopilot/cli/tests/task_tests.rs
@@ -1,0 +1,497 @@
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use autopilot::cmd::task::{TaskService, TaskSourceArg, TaskStatusArg};
+use autopilot::domain::{Epic, EpicStatus, EventKind, TaskId, TaskSource, TaskStatus};
+use autopilot::ports::clock::{Clock, FixedClock};
+use autopilot::ports::task_store::{EpicPlan, EventFilter, NewTask, TaskStore};
+use autopilot::store::InMemoryTaskStore;
+use chrono::{TimeZone, Utc};
+use tempfile::NamedTempFile;
+
+// ---------- helpers ----------
+
+fn fixture() -> (Arc<dyn TaskStore>, FixedClock) {
+    let store: Arc<dyn TaskStore> = Arc::new(InMemoryTaskStore::new());
+    let clock = FixedClock::new(Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap());
+    seed_epic(store.as_ref(), &clock, "e");
+    (store, clock)
+}
+
+fn seed_epic(store: &dyn TaskStore, clock: &dyn Clock, name: &str) {
+    let now = clock.now();
+    store
+        .insert_epic_with_tasks(
+            EpicPlan {
+                epic: Epic {
+                    name: name.to_string(),
+                    spec_path: PathBuf::from(format!("spec/{name}.md")),
+                    branch: format!("epic/{name}"),
+                    status: EpicStatus::Active,
+                    created_at: now,
+                    completed_at: None,
+                },
+                tasks: vec![],
+                deps: vec![],
+            },
+            now,
+        )
+        .unwrap();
+}
+
+fn capture<F>(f: F) -> (i32, String)
+where
+    F: FnOnce(&mut Vec<u8>) -> anyhow::Result<i32>,
+{
+    let mut buf: Vec<u8> = Vec::new();
+    let code = f(&mut buf).expect("service call");
+    (code, String::from_utf8(buf).expect("utf-8"))
+}
+
+fn write_jsonl(lines: &[&str]) -> NamedTempFile {
+    let f = NamedTempFile::new().unwrap();
+    let mut h = std::fs::File::create(f.path()).unwrap();
+    for l in lines {
+        writeln!(h, "{l}").unwrap();
+    }
+    f
+}
+
+/// Insert a watch-style task into epic 'e' through the public `add` path with
+/// a sane default title/source. Cuts the 7-arg ceremony at call sites that
+/// only care that the task exists with a known fingerprint.
+fn seed_via_add(svc: &TaskService<'_>, id: &str, fingerprint: &str) {
+    let mut buf: Vec<u8> = Vec::new();
+    svc.add(
+        "e",
+        id,
+        "x",
+        None,
+        Some(fingerprint),
+        TaskSourceArg::Human,
+        &mut buf,
+    )
+    .expect("seed_via_add");
+}
+
+/// Insert a task into epic `e` directly via the store, in a given starting status.
+/// Used to bypass the `add` lifecycle for tests that focus on later transitions.
+fn seed_task(
+    store: &dyn TaskStore,
+    clock: &dyn Clock,
+    id: &str,
+    status: TaskStatus,
+    deps_on: &[&str],
+) {
+    let now = clock.now();
+    let new_task = NewTask {
+        id: TaskId::from_raw(id),
+        source: TaskSource::Decompose,
+        fingerprint: None,
+        title: format!("task-{id}"),
+        body: None,
+    };
+    let mut tasks = vec![new_task];
+    let mut deps: Vec<(TaskId, TaskId)> = Vec::new();
+    for d in deps_on {
+        // also seed the dependency target as a Decompose task if we haven't already
+        tasks.push(NewTask {
+            id: TaskId::from_raw(*d),
+            source: TaskSource::Decompose,
+            fingerprint: None,
+            title: format!("dep-{d}"),
+            body: None,
+        });
+        deps.push((TaskId::from_raw(id), TaskId::from_raw(*d)));
+    }
+    // Upsert the new tasks/deps into existing epic 'e' via a minimal
+    // reconciliation plan, then nudge to a non-default status if requested.
+    use autopilot::ports::task_store::ReconciliationPlan;
+    let existing = store
+        .get_epic("e")
+        .unwrap()
+        .expect("seed_task assumes epic 'e' exists");
+    store
+        .apply_reconciliation(
+            ReconciliationPlan {
+                epic: existing,
+                tasks,
+                deps,
+                remote_state: vec![],
+                orphan_branches: vec![],
+            },
+            now,
+        )
+        .unwrap();
+    if status != TaskStatus::Ready && status != TaskStatus::Pending {
+        store
+            .force_status(&TaskId::from_raw(id), status, "test seed", now)
+            .unwrap();
+    }
+}
+
+// ---------- add ----------
+
+#[test]
+fn add_with_explicit_fingerprint_persists_task_and_emits_event() {
+    let (store, clock) = fixture();
+    let svc = TaskService::new(store.as_ref(), &clock);
+    let (code, out) = capture(|w| {
+        svc.add(
+            "e",
+            "aaaaaaaaaaaa",
+            "title",
+            Some("body"),
+            Some("0xDEADBEEF"),
+            TaskSourceArg::Human,
+            w,
+        )
+    });
+    assert_eq!(code, 0, "stdout: {out}");
+    assert!(out.contains("inserted task aaaaaaaaaaaa"), "stdout: {out}");
+
+    let task = store
+        .get_task(&TaskId::from_raw("aaaaaaaaaaaa"))
+        .unwrap()
+        .unwrap();
+    assert_eq!(task.fingerprint.as_deref(), Some("0xDEADBEEF"));
+    assert_eq!(task.title, "title");
+    assert_eq!(task.source, TaskSource::Human);
+    assert_eq!(task.status, TaskStatus::Ready);
+
+    let events = store
+        .list_events(EventFilter {
+            kinds: vec![EventKind::TaskInserted],
+            ..Default::default()
+        })
+        .unwrap();
+    assert_eq!(events.len(), 1);
+    assert_eq!(
+        events[0].task_id.as_ref().map(|t| t.as_str()),
+        Some("aaaaaaaaaaaa")
+    );
+}
+
+#[test]
+fn add_auto_derives_fingerprint_from_title_and_body() {
+    let (store, clock) = fixture();
+    let svc = TaskService::new(store.as_ref(), &clock);
+    let (code, _) = capture(|w| {
+        svc.add(
+            "e",
+            "aaaaaaaaaaaa",
+            "rate limiter middleware",
+            Some("add interceptor for throttling"),
+            None,
+            TaskSourceArg::Human,
+            w,
+        )
+    });
+    assert_eq!(code, 0);
+    let task = store
+        .get_task(&TaskId::from_raw("aaaaaaaaaaaa"))
+        .unwrap()
+        .unwrap();
+    let fp = task
+        .fingerprint
+        .expect("fingerprint should be auto-derived");
+    assert!(fp.starts_with("0x"), "expected hex fingerprint, got: {fp}");
+    assert_eq!(fp.len(), 18, "expected 0x + 16 hex chars, got: {fp}");
+}
+
+#[test]
+fn add_detects_duplicate_fingerprint_and_returns_same_id() {
+    let (store, clock) = fixture();
+    let svc = TaskService::new(store.as_ref(), &clock);
+
+    let (_, _out1) = capture(|w| {
+        svc.add(
+            "e",
+            "aaaaaaaaaaaa",
+            "first",
+            None,
+            Some("0xDEADBEEF"),
+            TaskSourceArg::Human,
+            w,
+        )
+    });
+    let (code2, out2) = capture(|w| {
+        svc.add(
+            "e",
+            "bbbbbbbbbbbb",
+            "second",
+            None,
+            Some("0xDEADBEEF"),
+            TaskSourceArg::Human,
+            w,
+        )
+    });
+    assert_eq!(code2, 0);
+    assert!(
+        out2.contains("duplicate of task aaaaaaaaaaaa"),
+        "stdout: {out2}"
+    );
+    // The second task was NOT inserted under bbbb...
+    assert!(store
+        .get_task(&TaskId::from_raw("bbbbbbbbbbbb"))
+        .unwrap()
+        .is_none());
+
+    let dup_events = store
+        .list_events(EventFilter {
+            kinds: vec![EventKind::WatchDuplicate],
+            ..Default::default()
+        })
+        .unwrap();
+    assert_eq!(dup_events.len(), 1);
+}
+
+// ---------- add-batch ----------
+
+#[test]
+fn add_batch_inserts_multiple_tasks_skipping_duplicates() {
+    let (store, clock) = fixture();
+    let svc = TaskService::new(store.as_ref(), &clock);
+
+    let f = write_jsonl(&[
+        r#"{"id":"aaaaaaaaaaaa","title":"first","fingerprint":"0x1"}"#,
+        r#"{"id":"bbbbbbbbbbbb","title":"second","fingerprint":"0x2"}"#,
+        // duplicate of "0x1" — should be detected
+        r#"{"id":"cccccccccccc","title":"third","fingerprint":"0x1"}"#,
+    ]);
+    let (code, out) = capture(|w| svc.add_batch("e", f.path(), w));
+    assert_eq!(code, 0);
+    assert!(out.contains("inserted: 2"), "stdout: {out}");
+    assert!(out.contains("duplicates: 1"), "stdout: {out}");
+
+    let tasks = store.list_tasks_by_epic("e", None).unwrap();
+    let ids: Vec<_> = tasks.iter().map(|t| t.id.as_str().to_string()).collect();
+    assert!(ids.contains(&"aaaaaaaaaaaa".to_string()));
+    assert!(ids.contains(&"bbbbbbbbbbbb".to_string()));
+    assert!(!ids.contains(&"cccccccccccc".to_string()));
+}
+
+#[test]
+fn add_batch_rejects_malformed_line() {
+    let (store, clock) = fixture();
+    let svc = TaskService::new(store.as_ref(), &clock);
+
+    // Missing required `title` field.
+    let f = write_jsonl(&[r#"{"id":"aaaaaaaaaaaa"}"#]);
+    let mut buf: Vec<u8> = Vec::new();
+    let err = svc.add_batch("e", f.path(), &mut buf).unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(msg.contains("parsing line 1"), "error: {msg}");
+    // No partial commits up to the failing line: the first (and only) line failed.
+    assert!(store.list_tasks_by_epic("e", None).unwrap().is_empty());
+}
+
+// ---------- get ----------
+
+#[test]
+fn get_renders_same_as_show() {
+    let (store, clock) = fixture();
+    let svc = TaskService::new(store.as_ref(), &clock);
+    seed_via_add(&svc, "aaaaaaaaaaaa", "0x1");
+    // `get` is wired in main.rs to call `show`. Verify they produce identical output.
+    let (c1, out_show) = capture(|w| svc.show("aaaaaaaaaaaa", true, w));
+    let (c2, out_get) = capture(|w| svc.show("aaaaaaaaaaaa", true, w));
+    assert_eq!(c1, 0);
+    assert_eq!(c2, 0);
+    assert_eq!(out_show, out_get);
+    let v: serde_json::Value = serde_json::from_str(out_show.trim()).unwrap();
+    assert_eq!(v["id"], "aaaaaaaaaaaa");
+}
+
+// ---------- claim ----------
+
+#[test]
+fn claim_outputs_next_ready_task_as_json() {
+    let (store, clock) = fixture();
+    let svc = TaskService::new(store.as_ref(), &clock);
+    seed_via_add(&svc, "aaaaaaaaaaaa", "0x1");
+
+    let (code, out) = capture(|w| svc.claim("e", true, w));
+    assert_eq!(code, 0);
+    let v: serde_json::Value = serde_json::from_str(out.trim()).unwrap();
+    assert_eq!(v["id"], "aaaaaaaaaaaa");
+    assert_eq!(v["status"], "wip");
+    assert_eq!(v["attempts"], 1);
+}
+
+#[test]
+fn claim_signals_no_ready_via_exit_1() {
+    let (store, clock) = fixture();
+    let svc = TaskService::new(store.as_ref(), &clock);
+    let (code, _out) = capture(|w| svc.claim("e", false, w));
+    assert_eq!(code, 1);
+}
+
+// ---------- complete ----------
+
+#[test]
+fn complete_updates_pr_and_unblocks_dependents() {
+    let (store, clock) = fixture();
+    // Seed two tasks with bbbb depending on aaaa (so bbbb starts pending).
+    seed_task(
+        store.as_ref(),
+        &clock,
+        "aaaaaaaaaaaa",
+        TaskStatus::Ready,
+        &[],
+    );
+    seed_task(
+        store.as_ref(),
+        &clock,
+        "bbbbbbbbbbbb",
+        TaskStatus::Pending,
+        &["aaaaaaaaaaaa"],
+    );
+
+    let svc = TaskService::new(store.as_ref(), &clock);
+    // Claim & complete aaaa.
+    let _ = capture(|w| svc.claim("e", false, w));
+    let (code, out) = capture(|w| svc.complete("aaaaaaaaaaaa", 42, w));
+    assert_eq!(code, 0);
+    assert!(out.contains("completed task aaaaaaaaaaaa"), "stdout: {out}");
+    assert!(out.contains("bbbbbbbbbbbb"), "stdout: {out}");
+
+    let a = store
+        .get_task(&TaskId::from_raw("aaaaaaaaaaaa"))
+        .unwrap()
+        .unwrap();
+    assert_eq!(a.status, TaskStatus::Done);
+    assert_eq!(a.pr_number, Some(42));
+
+    let b = store
+        .get_task(&TaskId::from_raw("bbbbbbbbbbbb"))
+        .unwrap()
+        .unwrap();
+    assert_eq!(b.status, TaskStatus::Ready);
+}
+
+// ---------- fail ----------
+
+#[test]
+fn fail_with_attempts_below_max_outputs_retried_outcome() {
+    let (store, clock) = fixture();
+    let svc = TaskService::new(store.as_ref(), &clock);
+    seed_via_add(&svc, "aaaaaaaaaaaa", "0x1");
+    // First claim => attempts=1
+    let _ = capture(|w| svc.claim("e", false, w));
+    let (code, out) = capture(|w| svc.fail("aaaaaaaaaaaa", w));
+    assert_eq!(code, 0);
+    let v: serde_json::Value = serde_json::from_str(out.trim()).unwrap();
+    assert_eq!(v["outcome"], "retried");
+    assert_eq!(v["attempts"], 1);
+
+    let t = store
+        .get_task(&TaskId::from_raw("aaaaaaaaaaaa"))
+        .unwrap()
+        .unwrap();
+    assert_eq!(t.status, TaskStatus::Ready);
+}
+
+#[test]
+fn fail_with_attempts_at_max_outputs_escalated_outcome() {
+    let (store, clock) = fixture();
+    let svc = TaskService::new(store.as_ref(), &clock);
+    seed_via_add(&svc, "aaaaaaaaaaaa", "0x1");
+    // claim+fail 3 times; the 3rd fail crosses max_attempts and emits the
+    // escalated JSON outcome (and persists status=Escalated, attempts=3).
+    let mut last: Option<(i32, String)> = None;
+    for _ in 0..3 {
+        let _ = capture(|w| svc.claim("e", false, w));
+        last = Some(capture(|w| svc.fail("aaaaaaaaaaaa", w)));
+    }
+    let (code, out) = last.expect("loop ran 3 times");
+    assert_eq!(code, 0);
+    let v: serde_json::Value = serde_json::from_str(out.trim()).unwrap();
+    assert_eq!(v["outcome"], "escalated");
+    assert_eq!(v["attempts"], 3);
+
+    let t = store
+        .get_task(&TaskId::from_raw("aaaaaaaaaaaa"))
+        .unwrap()
+        .unwrap();
+    assert_eq!(t.status, TaskStatus::Escalated);
+    assert_eq!(t.attempts, 3);
+}
+
+// ---------- escalate ----------
+
+#[test]
+fn escalate_sets_escalated_issue_field() {
+    let (store, clock) = fixture();
+    let svc = TaskService::new(store.as_ref(), &clock);
+    seed_via_add(&svc, "aaaaaaaaaaaa", "0x1");
+    let (code, _) = capture(|w| svc.escalate("aaaaaaaaaaaa", 99, w));
+    assert_eq!(code, 0);
+    let t = store
+        .get_task(&TaskId::from_raw("aaaaaaaaaaaa"))
+        .unwrap()
+        .unwrap();
+    assert_eq!(t.escalated_issue, Some(99));
+}
+
+// ---------- release ----------
+
+#[test]
+fn release_decrements_attempts_and_reverts_to_ready() {
+    let (store, clock) = fixture();
+    let svc = TaskService::new(store.as_ref(), &clock);
+    seed_via_add(&svc, "aaaaaaaaaaaa", "0x1");
+    let _ = capture(|w| svc.claim("e", false, w)); // attempts=1, status=wip
+    let (code, _) = capture(|w| svc.release("aaaaaaaaaaaa", w));
+    assert_eq!(code, 0);
+    let t = store
+        .get_task(&TaskId::from_raw("aaaaaaaaaaaa"))
+        .unwrap()
+        .unwrap();
+    assert_eq!(t.status, TaskStatus::Ready);
+    assert_eq!(t.attempts, 0);
+}
+
+// ---------- find-by-pr ----------
+
+#[test]
+fn find_by_pr_returns_task_when_present() {
+    let (store, clock) = fixture();
+    let svc = TaskService::new(store.as_ref(), &clock);
+    seed_via_add(&svc, "aaaaaaaaaaaa", "0x1");
+    let _ = capture(|w| svc.claim("e", false, w));
+    let _ = capture(|w| svc.complete("aaaaaaaaaaaa", 77, w));
+    let (code, out) = capture(|w| svc.find_by_pr(77, true, w));
+    assert_eq!(code, 0);
+    let v: serde_json::Value = serde_json::from_str(out.trim()).unwrap();
+    assert_eq!(v["id"], "aaaaaaaaaaaa");
+    assert_eq!(v["pr_number"], 77);
+}
+
+#[test]
+fn find_by_pr_returns_exit_1_when_no_match() {
+    let (store, clock) = fixture();
+    let svc = TaskService::new(store.as_ref(), &clock);
+    let (code, out) = capture(|w| svc.find_by_pr(404, false, w));
+    assert_eq!(code, 1);
+    assert!(out.contains("no task owns PR #404"), "stdout: {out}");
+}
+
+// Force-status arg type still routes through TaskService::force_status; smoke
+// test that the lifecycle commands cooperate (kept minimal — main coverage
+// lives in store_conformance and the `force_status_overrides_lifecycle`
+// inline test inside cmd/task.rs).
+#[test]
+fn force_status_still_routes_through_service() {
+    let (store, clock) = fixture();
+    let svc = TaskService::new(store.as_ref(), &clock);
+    seed_via_add(&svc, "aaaaaaaaaaaa", "0x1");
+    let (code, _) = capture(|w| svc.force_status("aaaaaaaaaaaa", TaskStatusArg::Done, None, w));
+    assert_eq!(code, 0);
+    let t = store
+        .get_task(&TaskId::from_raw("aaaaaaaaaaaa"))
+        .unwrap()
+        .unwrap();
+    assert_eq!(t.status, TaskStatus::Done);
+}


### PR DESCRIPTION
## Summary

Epic-branch rollup for the autopilot task store. Replaces the legacy orchestration model with a pure ledger architecture: autopilot becomes a state manager + CLI; agents (Claude Code sessions, autodev, etc.) own detection, decision, and orchestration. Net effect: ~3–5K LOC of orchestration code removed; trait surface reduced to `TaskStore + Clock`; CLI surface gains ~25 deterministic ledger subcommands.

### Domain
- New types: `Epic`, `EpicStatus`, `Task`, `TaskStatus`, `TaskSource`, `TaskId` (deterministic SHA256[:12]), `Event` + `EventKind`, `TaskFailureOutcome`, `DomainError` (incl. `Inconsistency` invariant variant).
- Dependency graph (`TaskGraph`) with cycle detection.

### Ports
- `TaskStore` is a supertype of `EpicRepo + TaskRepo + EventLog + SuppressionRepo` (ISP-split).
- Methods include atomic `insert_epic_with_tasks`, `claim_next_task`, `complete_task_and_unblock`, `mark_task_failed`, `release_claim`, `escalate_task`, `force_status`, `apply_reconciliation`, `find_active_by_spec_path`, `find_task_by_pr`.
- `SuppressionRepo` for fingerprint-scoped HITL suppression.

### Adapters
- `InMemoryTaskStore` — thread-safe in-memory implementation.
- `SqliteTaskStore` — WAL + Mutex<Connection> for single-machine multi-process safety. V1 → V2 migration adds `idx_tasks_pr_number` and `idx_epics_active_spec` partial indexes.
- LSP-enforcing conformance test suite runs every behavior body against both adapters.

### CLI surface
- `autopilot epic` — create / list / get / status / complete / abandon / reconcile / find-by-spec-path
- `autopilot task` — add / add-batch / list / show / get / find-by-pr / claim / release / complete / fail / escalate / force-status
- `autopilot suppress` — add / check / clear
- `autopilot events list` — filter by epic / task / kind / since / limit
- `autopilot.toml` — `[storage]`, `[epic]`, `[suppression]` sections; defaults applied when file missing.

### Spec docs
- `plans/github-autopilot/{00-concept,01-use-cases,02-architecture,03-detailed-spec,04-test-scenarios}.md` reworked to the ledger model.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --lib --bins -- -D warnings`
- [x] `cargo check`
- [x] `cargo test` — 280+ tests passing across lib + integration suites (epic_tests, task_tests, suppress_tests, events_tests, config_tests, store_conformance, etc.)

## Migration

`SqliteTaskStore` auto-migrates v1 → v2 on open; no operator action needed. The `autopilot.toml` config is optional — built-in defaults apply when absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)