### PR TITLE
fix(github-autopilot): correct task add/fail error semantics and CLI consistency

### DIFF
--- a/plugins/github-autopilot/cli/Cargo.lock
+++ b/plugins/github-autopilot/cli/Cargo.lock
@@ -87,7 +87,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autopilot"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/plugins/github-autopilot/cli/src/cmd/mod.rs
+++ b/plugins/github-autopilot/cli/src/cmd/mod.rs
@@ -127,12 +127,11 @@ pub enum TaskCommands {
     },
     /// Insert (or detect duplicate of) a watch-style task
     Add {
+        /// Task id (deterministic 12-hex-char id)
+        task_id: String,
         /// Epic name
         #[arg(long)]
         epic: String,
-        /// Task id (deterministic 12-hex-char id)
-        #[arg(long)]
-        id: String,
         /// Title
         #[arg(long)]
         title: String,

--- a/plugins/github-autopilot/cli/src/cmd/task.rs
+++ b/plugins/github-autopilot/cli/src/cmd/task.rs
@@ -188,19 +188,21 @@ impl<'a> TaskService<'a> {
             title: title.to_string(),
             body: body.map(str::to_string),
         };
-        match self
-            .store
-            .upsert_watch_task(nt, now)
-            .with_context(|| format!("adding task '{task_id}' to epic '{epic}'"))?
-        {
-            UpsertOutcome::Inserted(id) => {
+        match self.store.upsert_watch_task(nt, now) {
+            Ok(UpsertOutcome::Inserted(id)) => {
                 writeln!(out, "inserted task {}", id.as_str())?;
+                Ok(0)
             }
-            UpsertOutcome::DuplicateFingerprint(id) => {
+            Ok(UpsertOutcome::DuplicateFingerprint(id)) => {
                 writeln!(out, "duplicate of task {}", id.as_str())?;
+                Ok(0)
             }
+            Err(TaskStoreError::Domain(DomainError::DuplicateTaskId(_))) => {
+                writeln!(out, "task '{task_id}' already exists")?;
+                Ok(1)
+            }
+            Err(e) => Err(e).with_context(|| format!("adding task '{task_id}' to epic '{epic}'")),
         }
-        Ok(0)
     }
 
     /// Reads `path` as JSONL where each line describes a single watch task.
@@ -302,11 +304,11 @@ impl<'a> TaskService<'a> {
                 writeln!(out, "task '{task_id}' not found")?;
                 Ok(1)
             }
-            Err(TaskStoreError::Domain(DomainError::IllegalTransition(_, from, _))) => {
+            Err(TaskStoreError::Domain(DomainError::RequiresStatus(_, _, actual))) => {
                 writeln!(
                     out,
                     "task '{task_id}' cannot be released from {} (must be wip)",
-                    from.as_str()
+                    actual.as_str()
                 )?;
                 Ok(1)
             }

--- a/plugins/github-autopilot/cli/src/domain/error.rs
+++ b/plugins/github-autopilot/cli/src/domain/error.rs
@@ -12,6 +12,15 @@ pub enum DomainError {
     #[error("illegal status transition for task {0}: {1:?} -> {2:?}")]
     IllegalTransition(TaskId, TaskStatus, TaskStatus),
 
+    /// Precondition failure: the operation needs the task to currently be in a
+    /// specific status, but it isn't. Distinct from [`Self::IllegalTransition`]
+    /// (which describes an attempted-target failure): here, the *current*
+    /// status is the bug, not the target.
+    ///
+    /// Args: `(task_id, required_current_status, actual_current_status)`.
+    #[error("task {0} requires status {1:?}, was {2:?}")]
+    RequiresStatus(TaskId, TaskStatus, TaskStatus),
+
     #[error("epic '{0}' already exists with status {1:?}")]
     EpicAlreadyExists(String, EpicStatus),
 

--- a/plugins/github-autopilot/cli/src/main.rs
+++ b/plugins/github-autopilot/cli/src/main.rs
@@ -3,6 +3,8 @@ use autopilot::cmd::{
     StatsCommands, TaskCommands, WorktreeCommands,
 };
 use autopilot::config::Config;
+use autopilot::domain::DomainError;
+use autopilot::ports::task_store::TaskStoreError;
 use autopilot::store::SqliteTaskStore;
 use autopilot::{cmd, fs, gh, git, github};
 use clap::Parser;
@@ -178,15 +180,15 @@ fn main() {
                     reason,
                 } => svc.force_status(&task_id, to, reason.as_deref(), &mut out),
                 TaskCommands::Add {
+                    task_id,
                     epic,
-                    id,
                     title,
                     body,
                     fingerprint,
                     source,
                 } => svc.add(
                     &epic,
-                    &id,
+                    &task_id,
                     &title,
                     body.as_deref(),
                     fingerprint.as_deref(),
@@ -261,9 +263,27 @@ fn main() {
         Ok(code) => std::process::exit(code),
         Err(e) => {
             eprintln!("{e:#}");
-            std::process::exit(2);
+            std::process::exit(exit_code_for(&e));
         }
     }
+}
+
+/// Maps a propagated error to a process exit code: `1` for user errors,
+/// `2` (default) for transient / unexpected failures.
+fn exit_code_for(e: &anyhow::Error) -> i32 {
+    for cause in e.chain() {
+        if let Some(domain) = cause.downcast_ref::<DomainError>() {
+            if matches!(domain, DomainError::DuplicateTaskId(_)) {
+                return 1;
+            }
+        }
+        if let Some(TaskStoreError::Domain(DomainError::DuplicateTaskId(_))) =
+            cause.downcast_ref::<TaskStoreError>()
+        {
+            return 1;
+        }
+    }
+    2
 }
 
 fn task_store_db_path(config: &Config) -> PathBuf {

--- a/plugins/github-autopilot/cli/src/store/memory.rs
+++ b/plugins/github-autopilot/cli/src/store/memory.rs
@@ -285,7 +285,10 @@ impl TaskRepo for InMemoryTaskStore {
     fn upsert_watch_task(&self, task: NewWatchTask, now: DateTime<Utc>) -> Result<UpsertOutcome> {
         let mut s = self.state.lock().expect("poisoned");
 
-        // Duplicate fingerprint check
+        if s.tasks.contains_key(&task.id) {
+            return Err(DomainError::DuplicateTaskId(task.id).into());
+        }
+
         if let Some(existing) = s
             .tasks
             .values()
@@ -399,7 +402,7 @@ impl TaskRepo for InMemoryTaskStore {
             .ok_or_else(|| TaskStoreError::NotFound(format!("task '{id}'")))?;
         if task.status != TaskStatus::Wip {
             let cur = task.status;
-            return Err(DomainError::IllegalTransition(id.clone(), cur, TaskStatus::Done).into());
+            return Err(DomainError::RequiresStatus(id.clone(), TaskStatus::Wip, cur).into());
         }
         task.status = TaskStatus::Done;
         task.pr_number = Some(pr_number);
@@ -467,7 +470,7 @@ impl TaskRepo for InMemoryTaskStore {
             .ok_or_else(|| TaskStoreError::NotFound(format!("task '{id}'")))?;
         if task.status != TaskStatus::Wip {
             let cur = task.status;
-            return Err(DomainError::IllegalTransition(id.clone(), cur, TaskStatus::Ready).into());
+            return Err(DomainError::RequiresStatus(id.clone(), TaskStatus::Wip, cur).into());
         }
         let attempts = task.attempts;
         let epic_name = task.epic_name.clone();
@@ -567,7 +570,7 @@ impl TaskRepo for InMemoryTaskStore {
             .ok_or_else(|| TaskStoreError::NotFound(format!("task '{id}'")))?;
         let cur = task.status;
         if cur != TaskStatus::Wip {
-            return Err(DomainError::IllegalTransition(id.clone(), cur, TaskStatus::Ready).into());
+            return Err(DomainError::RequiresStatus(id.clone(), TaskStatus::Wip, cur).into());
         }
         task.status = TaskStatus::Ready;
         task.attempts = task.attempts.saturating_sub(1);

--- a/plugins/github-autopilot/cli/src/store/sqlite.rs
+++ b/plugins/github-autopilot/cli/src/store/sqlite.rs
@@ -487,6 +487,19 @@ impl TaskRepo for SqliteTaskStore {
         let mut conn = self.conn.lock().expect("poisoned");
         let tx = conn.transaction().map_err(backend)?;
 
+        let id_exists: bool = tx
+            .query_row(
+                "SELECT 1 FROM tasks WHERE id=?",
+                params![task.id.as_str()],
+                |_| Ok(true),
+            )
+            .optional()
+            .map_err(backend)?
+            .unwrap_or(false);
+        if id_exists {
+            return Err(DomainError::DuplicateTaskId(task.id).into());
+        }
+
         let existing: Option<String> = tx
             .query_row(
                 "SELECT id FROM tasks WHERE epic_name=? AND fingerprint=? LIMIT 1",
@@ -626,7 +639,7 @@ impl TaskRepo for SqliteTaskStore {
         if cur != "wip" {
             let cur_status = TaskStatus::parse(&cur).unwrap_or(TaskStatus::Pending);
             return Err(
-                DomainError::IllegalTransition(id.clone(), cur_status, TaskStatus::Done).into(),
+                DomainError::RequiresStatus(id.clone(), TaskStatus::Wip, cur_status).into(),
             );
         }
 
@@ -638,12 +651,15 @@ impl TaskRepo for SqliteTaskStore {
             )
             .map_err(backend)?;
         if updated != 1 {
-            return Err(DomainError::IllegalTransition(
-                id.clone(),
-                TaskStatus::Wip,
-                TaskStatus::Done,
-            )
-            .into());
+            let actual: String = tx
+                .query_row(
+                    "SELECT status FROM tasks WHERE id=?",
+                    params![id.as_str()],
+                    |row| row.get(0),
+                )
+                .map_err(backend)?;
+            let actual = TaskStatus::parse(&actual).unwrap_or(TaskStatus::Pending);
+            return Err(DomainError::RequiresStatus(id.clone(), TaskStatus::Wip, actual).into());
         }
 
         let epic_name: String = tx
@@ -735,7 +751,7 @@ impl TaskRepo for SqliteTaskStore {
         if cur != "wip" {
             let cur_status = TaskStatus::parse(&cur).unwrap_or(TaskStatus::Pending);
             return Err(
-                DomainError::IllegalTransition(id.clone(), cur_status, TaskStatus::Ready).into(),
+                DomainError::RequiresStatus(id.clone(), TaskStatus::Wip, cur_status).into(),
             );
         }
         let attempts = attempts as u32;
@@ -866,7 +882,7 @@ impl TaskRepo for SqliteTaskStore {
             .ok_or_else(|| TaskStoreError::Backend(format!("invalid stored task status: {cur}")))?;
         if cur_status != TaskStatus::Wip {
             return Err(
-                DomainError::IllegalTransition(id.clone(), cur_status, TaskStatus::Ready).into(),
+                DomainError::RequiresStatus(id.clone(), TaskStatus::Wip, cur_status).into(),
             );
         }
         conn.execute(

--- a/plugins/github-autopilot/cli/tests/store_conformance.rs
+++ b/plugins/github-autopilot/cli/tests/store_conformance.rs
@@ -10,11 +10,12 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use autopilot::domain::{
-    Epic, EpicStatus, EventKind, TaskFailureOutcome, TaskGraph, TaskId, TaskSource, TaskStatus,
+    DomainError, Epic, EpicStatus, EventKind, TaskFailureOutcome, TaskGraph, TaskId, TaskSource,
+    TaskStatus,
 };
 use autopilot::ports::task_store::{
     EpicPlan, EventFilter, NewTask, NewWatchTask, ReconciliationPlan, RemotePrState,
-    RemoteTaskState, TaskStore, UpsertOutcome,
+    RemoteTaskState, TaskStore, TaskStoreError, UpsertOutcome,
 };
 use chrono::{DateTime, Duration, TimeZone, Utc};
 
@@ -170,8 +171,8 @@ fn body_release_claim_rejects_non_wip(store: Arc<dyn TaskStore>) {
         .release_claim(&TaskId::from_raw("A"), t0())
         .unwrap_err();
     assert!(
-        format!("{err}").contains("illegal status transition"),
-        "expected illegal-transition, got: {err}"
+        format!("{err}").contains("requires status Wip"),
+        "expected RequiresStatus(_, Wip, _), got: {err}"
     );
 }
 
@@ -245,7 +246,7 @@ fn body_complete_rejects_when_status_not_wip(store: Arc<dyn TaskStore>) {
     let err = store
         .complete_task_and_unblock(&TaskId::from_raw("A"), 1, t0())
         .unwrap_err();
-    assert!(format!("{err}").contains("illegal status transition"));
+    assert!(format!("{err}").contains("requires status Wip"));
 }
 
 fn body_failure_below_max_returns_to_ready(store: Arc<dyn TaskStore>) {
@@ -426,6 +427,45 @@ fn body_upsert_watch_task_returns_duplicate_on_existing_fingerprint(store: Arc<d
     }
     let tasks = store.list_tasks_by_epic("e", None).unwrap();
     assert_eq!(tasks.len(), 1);
+}
+
+fn body_upsert_watch_task_rejects_same_id_with_different_fingerprint(store: Arc<dyn TaskStore>) {
+    store
+        .insert_epic_with_tasks(plan("e", vec![], vec![]), t0())
+        .unwrap();
+    store
+        .upsert_watch_task(
+            NewWatchTask {
+                id: TaskId::from_raw("watch1"),
+                epic_name: "e".to_string(),
+                source: TaskSource::Human,
+                fingerprint: "fp-1".to_string(),
+                title: "first".to_string(),
+                body: None,
+            },
+            t0(),
+        )
+        .unwrap();
+    let err = store
+        .upsert_watch_task(
+            NewWatchTask {
+                id: TaskId::from_raw("watch1"),
+                epic_name: "e".to_string(),
+                source: TaskSource::Human,
+                fingerprint: "fp-2".to_string(),
+                title: "second".to_string(),
+                body: Some("different body".to_string()),
+            },
+            t0(),
+        )
+        .unwrap_err();
+    assert!(
+        matches!(
+            &err,
+            TaskStoreError::Domain(DomainError::DuplicateTaskId(id)) if id.as_str() == "watch1"
+        ),
+        "expected DuplicateTaskId, got: {err:?}"
+    );
 }
 
 fn body_find_task_by_pr_returns_owning_task(store: Arc<dyn TaskStore>) {
@@ -635,6 +675,7 @@ conformance_suite!(
     body_reconcile_preserves_attempts_counter,
     body_upsert_watch_task_inserts_new_when_no_fingerprint_match,
     body_upsert_watch_task_returns_duplicate_on_existing_fingerprint,
+    body_upsert_watch_task_rejects_same_id_with_different_fingerprint,
     body_find_task_by_pr_returns_owning_task,
     body_find_task_by_pr_returns_none_when_unknown,
     body_find_active_by_spec_path_matches_active_only,

--- a/plugins/github-autopilot/cli/tests/task_tests.rs
+++ b/plugins/github-autopilot/cli/tests/task_tests.rs
@@ -3,9 +3,11 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use autopilot::cmd::task::{TaskService, TaskSourceArg, TaskStatusArg};
-use autopilot::domain::{Epic, EpicStatus, EventKind, TaskId, TaskSource, TaskStatus};
+use autopilot::domain::{DomainError, Epic, EpicStatus, EventKind, TaskId, TaskSource, TaskStatus};
 use autopilot::ports::clock::{Clock, FixedClock};
-use autopilot::ports::task_store::{EpicPlan, EventFilter, NewTask, TaskStore};
+use autopilot::ports::task_store::{
+    EpicPlan, EventFilter, NewTask, NewWatchTask, TaskStore, TaskStoreError,
+};
 use autopilot::store::InMemoryTaskStore;
 use chrono::{TimeZone, Utc};
 use tempfile::NamedTempFile;
@@ -476,6 +478,99 @@ fn find_by_pr_returns_exit_1_when_no_match() {
     let (code, out) = capture(|w| svc.find_by_pr(404, false, w));
     assert_eq!(code, 1);
     assert!(out.contains("no task owns PR #404"), "stdout: {out}");
+}
+
+// ---------- Bug 1: same task_id, different fingerprint ----------
+
+/// CLI-surface check: re-adding the same task id (different body so distinct
+/// fingerprint) must print a friendly message and exit 1, never propagate
+/// the raw SQLite UNIQUE error.
+#[test]
+fn add_with_existing_id_and_different_body_returns_friendly_error() {
+    let (store, clock) = fixture();
+    let svc = TaskService::new(store.as_ref(), &clock);
+    let (_, _) = capture(|w| {
+        svc.add(
+            "e",
+            "aaaaaaaaaaaa",
+            "first",
+            Some("body one"),
+            None,
+            TaskSourceArg::Human,
+            w,
+        )
+    });
+    let (code, out) = capture(|w| {
+        svc.add(
+            "e",
+            "aaaaaaaaaaaa",
+            "second",
+            Some("body two — different content => different fingerprint"),
+            None,
+            TaskSourceArg::Human,
+            w,
+        )
+    });
+    assert_eq!(code, 1, "stdout: {out}");
+    assert!(
+        out.contains("task 'aaaaaaaaaaaa' already exists"),
+        "stdout: {out}"
+    );
+}
+
+// ---------- Bug 2: RequiresStatus error semantics ----------
+
+#[test]
+fn fail_from_ready_returns_requires_status_error() {
+    let (store, clock) = fixture();
+    let svc = TaskService::new(store.as_ref(), &clock);
+    seed_via_add(&svc, "aaaaaaaaaaaa", "0x1");
+    // Task is Ready (never claimed). fail() should surface RequiresStatus(_, Wip, Ready).
+    let mut buf: Vec<u8> = Vec::new();
+    let err = svc.fail("aaaaaaaaaaaa", &mut buf).unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("requires status Wip") && msg.contains("was Ready"),
+        "expected RequiresStatus(_, Wip, Ready), got: {msg}"
+    );
+}
+
+#[test]
+fn complete_from_ready_returns_requires_status_error() {
+    let (store, clock) = fixture();
+    let svc = TaskService::new(store.as_ref(), &clock);
+    seed_via_add(&svc, "aaaaaaaaaaaa", "0x1");
+    let mut buf: Vec<u8> = Vec::new();
+    let err = svc.complete("aaaaaaaaaaaa", 99, &mut buf).unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("requires status Wip") && msg.contains("was Ready"),
+        "expected RequiresStatus(_, Wip, Ready), got: {msg}"
+    );
+}
+
+#[test]
+fn release_from_done_returns_requires_status_error_via_cli() {
+    let (store, clock) = fixture();
+    let svc = TaskService::new(store.as_ref(), &clock);
+    seed_via_add(&svc, "aaaaaaaaaaaa", "0x1");
+    // Drive the task to Done via force_status, then release should reject.
+    store
+        .force_status(
+            &TaskId::from_raw("aaaaaaaaaaaa"),
+            TaskStatus::Done,
+            "test",
+            clock.now(),
+        )
+        .unwrap();
+    // CLI's `release` catches the precondition failure and prints a friendly
+    // message with exit 1 — verify the surface matches the new variant.
+    let (code, out) = capture(|w| svc.release("aaaaaaaaaaaa", w));
+    assert_eq!(code, 1);
+    assert!(
+        out.contains("cannot be released from done"),
+        "stdout: {out}"
+    );
 }
 
 // Force-status arg type still routes through TaskService::force_status; smoke


### PR DESCRIPTION
## Summary

End-to-end smoke testing surfaced 3 CLI quality bugs in the just-merged autopilot ledger. Fixes:

- **\`task add\` raw SQLite error on duplicate id (different fingerprint)**: id collision check moved ahead of the \`(epic, fingerprint)\` dedup check in both stores. CLI prints \`task '<id>' already exists\` and exits 1.
- **\`task fail\` from non-Wip prints \"Ready -> Ready\"**: introduced \`DomainError::RequiresStatus(task, expected, actual)\`; migrated the 3 precondition sites in mark_task_failed / complete_task_and_unblock / release_claim across both stores. Race-loss fallback in complete_task_and_unblock re-reads actual status before constructing the error.
- **\`task add --id <ID>\` inconsistent with other task subcommands**: switched to positional \`<TASK_ID>\` to match show/get/complete/fail/escalate/release/force-status/find-by-pr.

## Test plan

- [x] \`cargo test\` (all suites green; +2 conformance tests for the id-collision case run against both InMemory and Sqlite adapters)
- [x] \`cargo fmt --check\`
- [x] \`cargo clippy --lib --bins -- -D warnings\`
- [x] Smoke test on release binary: bug 1 → \`task '<id>' already exists\` exit 1; bug 2 → \`task <id> requires status Wip, was Ready\`; bug 3 → \`task add <id> --epic <e> --title <t>\` (positional) works
- [x] /simplify (3-perspective: code reuse / quality / efficiency) — applied: comment trim, asymmetric IllegalTransition fix, conformance-suite coverage, dead binding cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)