### PR TITLE
feat(github-autopilot): wire gap-watch to ledger as integration pilot

### DIFF
--- a/plugins/github-autopilot/agents/gap-issue-creator.md
+++ b/plugins/github-autopilot/agents/gap-issue-creator.md
@@ -14,6 +14,7 @@ skills: ["issue-label", "resilience"]
 프롬프트로 전달받는 정보:
 - 갭 분석 리포트 (마크다운)
 - label_prefix (기본값: "autopilot:")
+- **(선택) ledger_epic**: autopilot ledger의 epic 이름 (예: `"gap-backlog"`). 비어있거나 미전달 시 ledger 쓰기를 skip한다 (GitHub issue 흐름은 그대로 진행).
 - **(선택) stagnation 컨텍스트**: 유사 이슈 목록 + persona 가이드
 
 ## 프로세스
@@ -119,6 +120,31 @@ EOF
 
 > **참고**: fingerprint HTML 주석과 simhash는 CLI가 body 하단에 자동 삽입합니다. exit 1이면 중복(skip).
 
+### 2. Ledger 동기 기록 (observer)
+
+`ledger_epic`이 전달되었고, GitHub issue 생성이 성공한 경우(중복 skip 제외)에만 동일 fingerprint로 ledger task를 기록합니다. 실패해도 GitHub issue 흐름은 절대 막지 않습니다.
+
+```bash
+if [ -n "${LEDGER_EPIC:-}" ]; then
+  # task id는 fingerprint의 sha256 앞 12자리(hex). 동일 fingerprint → 동일 id (idempotent).
+  TASK_ID=$(printf '%s' "gap:${SPEC_PATH}:${REQUIREMENT_KEYWORD}" | shasum -a 256 | cut -c1-12)
+  autopilot task add \
+    --epic "$LEDGER_EPIC" \
+    --id "$TASK_ID" \
+    --title "$ISSUE_TITLE" \
+    --fingerprint "gap:${SPEC_PATH}:${REQUIREMENT_KEYWORD}" \
+    --source gap-watch \
+    || echo "WARN: ledger task add 실패 (issue #${ISSUE_NUMBER}는 정상 생성됨) — 계속 진행"
+fi
+```
+
+> CLI 동작:
+> - 신규 fingerprint: `inserted task <id>` (exit 0)
+> - 이미 등록된 fingerprint: `duplicate of task <id>` (exit 0, no-op)
+> - epic 미존재 / 환경 오류: exit 2 → WARN 로그 후 무시 (GitHub issue는 이미 생성됨)
+>
+> 결과 보고의 `created`/`created_with_persona` 항목에 `ledger_task_id` 필드를 추가합니다 (ledger 쓰기 skip 시 `null`).
+
 ### 3. 결과 보고
 
 생성된 이슈 목록을 JSON 형태로 출력합니다:
@@ -126,10 +152,10 @@ EOF
 ```json
 {
   "created": [
-    {"number": 42, "title": "feat(auth): implement token refresh", "fingerprint": "gap:spec/auth.md:token-refresh", "persona": null}
+    {"number": 42, "title": "feat(auth): implement token refresh", "fingerprint": "gap:spec/auth.md:token-refresh", "persona": null, "ledger_task_id": "a1b2c3d4e5f6"}
   ],
   "created_with_persona": [
-    {"number": 73, "title": "feat(auth): implement token refresh — hacker approach", "fingerprint": "gap:spec/auth.md:token-refresh", "persona": "hacker", "related_issues": [42, 58]}
+    {"number": 73, "title": "feat(auth): implement token refresh — hacker approach", "fingerprint": "gap:spec/auth.md:token-refresh", "persona": "hacker", "related_issues": [42, 58], "ledger_task_id": "a1b2c3d4e5f6"}
   ],
   "skipped_duplicates": [
     {"fingerprint": "gap:spec/api.md:rate-limiting", "existing_issue": 38}
@@ -143,6 +169,8 @@ EOF
 }
 ```
 
+> `ledger_task_id`는 ledger task가 성공적으로 기록되었거나 동일 fingerprint의 기존 task가 있을 때 12-hex-char id를 담습니다. `ledger_epic`이 전달되지 않았거나 ledger 쓰기가 실패하면 `null`입니다.
+
 ## 주의사항
 
 - issue-label 스킬의 라벨 필수 규칙과 fingerprint 규칙을 반드시 따른다
@@ -151,3 +179,4 @@ EOF
 - stagnation 이슈의 제목에 persona 접근법을 포함한다 (예: `— hacker approach`)
 - 모든 persona가 소진된 경우 이슈 본문에 "모든 자동 접근이 소진됨 — 사람의 검토 필요"를 명시하고 `{label_prefix}ready` 라벨을 부여하지 않는다
 - `--simhash` 옵션은 항상 포함하여 이후 stagnation 추적에 활용한다
+- ledger 쓰기는 GitHub issue 흐름의 보조 observer다. ledger 실패가 issue 생성 결과를 무효화하지 않도록 `|| echo WARN ...` 패턴으로 격리한다

--- a/plugins/github-autopilot/commands/gap-watch.md
+++ b/plugins/github-autopilot/commands/gap-watch.md
@@ -140,16 +140,42 @@ autopilot issue search-similar \
 
 ### Step 5: Issue 생성 (Agent)
 
+#### Step 5a: Ledger Epic 부트스트랩
+
+gap-issue-creator 호출 직전에, 결정적 ledger의 `gap-backlog` epic이 존재하도록 한 번만 보장합니다 (idempotent).
+
+```bash
+EPIC_NAME="gap-backlog"
+EPIC_SPEC="spec/gap-backlog.md"
+out=$(autopilot epic create --name "$EPIC_NAME" --spec "$EPIC_SPEC" 2>&1) || true
+case "$out" in
+  *"created"*|*"already exists"*)
+    # 정상: 새로 생성 또는 이미 존재 (epic create는 이미 존재 시 exit 1)
+    ;;
+  *)
+    # 실패해도 GitHub issue 흐름은 그대로 진행 (ledger는 observer)
+    echo "WARN: gap-backlog epic 부트스트랩 실패 — ledger 쓰기는 skip됩니다: $out"
+    EPIC_NAME=""
+    ;;
+esac
+```
+
+> ledger는 GitHub issue 생성과 독립적인 부가 기록입니다. epic 부트스트랩이 실패하면 `EPIC_NAME=""`로 설정하여 gap-issue-creator가 ledger 쓰기를 skip하도록 합니다.
+
+#### Step 5b: Agent 호출
+
 gap-issue-creator 에이전트를 호출합니다 (background=false):
 
 전달 정보:
 - 갭 분석 리포트 (Step 4 결과)
 - label_prefix
+- **ledger_epic**: `$EPIC_NAME` (비어있으면 ledger 쓰기 skip)
 - **(stagnation 시 추가)** 유사 이슈 목록 (번호, distance, 상태) + resilience persona 가이드
 
 에이전트가 ❌ Missing, ⚠️ Partial 항목을 GitHub issue로 변환합니다.
 중복 이슈는 자동 필터링됩니다.
 stagnation이 감지된 gap은 과거 이슈를 참조하고 새 persona 관점으로 이슈를 생성합니다.
+GitHub issue가 성공적으로 생성되면 동일 fingerprint로 ledger task도 함께 기록합니다 (observer).
 
 생성된 이슈가 0건이면 `autopilot check mark gap-watch --status idle` 후 Step 6으로 진행합니다.
 생성된 이슈가 1건 이상이면 `autopilot check mark gap-watch --status active` 후 Step 5.5로 진행합니다.


### PR DESCRIPTION
## Why this pilot

**Option A (gap-watch dual-write).** The `gap-issue-creator` agent already had the "agent-calls-CLI" pattern (it uses `autopilot issue create`), so adding a sibling `autopilot task add` is a low-risk, additive integration. Every gap-watch run now produces ledger entries, exercising both `epic create` (idempotent bootstrap) and `task add` (with auto-derived id from existing fingerprint). Existing GitHub-issue behavior is untouched — the ledger is a pure observer.

## What changed

- `plugins/github-autopilot/commands/gap-watch.md` — added Step 5a "Ledger Epic 부트스트랩" before the agent call: idempotent `epic create --name gap-backlog`, tolerates exit-1 "already exists", falls back to skip-mode (`EPIC_NAME=""`) on unexpected errors.
- `plugins/github-autopilot/agents/gap-issue-creator.md` — added `ledger_epic` input, new "Ledger 동기 기록 (observer)" step that runs `autopilot task add --source gap-watch` after each successful issue create, and surfaces `ledger_task_id` in the result JSON. Failures are logged as WARN and never block the GitHub issue flow.

Task id is derived deterministically as `sha256(fingerprint)[:12]` so re-running the same gap yields the same id (idempotent).

## End-to-end verification

```
$ export AUTOPILOT_DB_PATH=/tmp/at-pilot.db ; rm -f $AUTOPILOT_DB_PATH
$ BIN=plugins/github-autopilot/cli/target/release/autopilot

$ $BIN epic create --name gap-backlog --spec spec/gap-backlog.md
epic 'gap-backlog' created                                # exit 0

$ $BIN epic create --name gap-backlog --spec spec/gap-backlog.md
epic 'gap-backlog' already exists (active)                # exit 1 — tolerated by case "*already exists*"

$ FP="gap:spec/auth.md:token-refresh"
$ TID=$(printf '%s' "$FP" | shasum -a 256 | cut -c1-12)   # 905ad8424947 (deterministic)

$ $BIN task add --epic gap-backlog --id $TID \
    --title "feat(auth): implement token refresh" \
    --fingerprint "$FP" --source gap-watch
inserted task 905ad8424947                                # exit 0

$ $BIN task add --epic gap-backlog --id $TID \
    --title "feat(auth): implement token refresh" \
    --fingerprint "$FP" --source gap-watch
duplicate of task 905ad8424947                            # exit 0 — idempotent re-run

$ $BIN events list --limit 3
epic_started     gap-backlog -            {}
task_inserted    gap-backlog 905ad8424947 {"fingerprint":"gap:spec/auth.md:..."}
watch_duplicate  gap-backlog 905ad8424947 {"fingerprint":"gap:spec/auth.md:..."}
```

All assertions in the prompt's smoke-test recipe pass.

## /simplify findings (self-review)

- **Reuse**: ledger task uses the same `gap:{spec}:{keyword}` fingerprint the agent already builds for `issue create` — no string duplication. CLI lacks a string→12-hex helper, so a one-shot `shasum | cut` is the minimal addition (false-positive: nothing to reuse).
- **Quality**: `epic create` exit-1 is tolerated via `case` on the message, not a brittle exit-code check. Agent contract (input/output) updated explicitly with `ledger_epic` and `ledger_task_id` (with null semantics). `|| echo WARN` isolates ledger failures from issue creation.
- **Efficiency**: `epic create` runs once per cycle (Step 5a), not per gap. `task add` runs once per created issue. No hot-path bloat.

## Open questions / follow-ups

- **CLI gap surfaced (not fixed)**: `epic create` is not idempotent — exits 1 with "already exists" on every cycle after the first. An `epic create-or-skip` (or `--idempotent` flag) variant would let callers stop relying on string-pattern tolerance. Filed as a follow-up; out of scope for this pilot.
- **Other workflows still ledger-blind**: `pr-merger` (Option B) should call `task find-by-pr` + `task complete --pr` to close the loop. `qa-boost` and `ci-watch` should also dual-write tasks with their respective `--source` tags.
- **Downstream consumers**: no workflow reads from the ledger yet (e.g. an implementer-loop that picks `task claim` instead of GitHub-label-based dispatch). That's the next-stage integration once writes are stable across all watchers.
- **Spec path on epic**: synthetic `spec/gap-backlog.md` (file may not exist on disk). Acceptable since `epic create` doesn't validate spec existence, but a future `epic create --strict` would catch this.

## Smoke test pass/fail

PASS — all 8 assertions in the prompt's verification recipe (epic create x2, task add x3, list, events log, error-case tolerance). Diff is ~58 LOC across 2 markdown files, well under the 300 LOC ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)