### PR TITLE
feat(github-autopilot): wire qa-boost to ledger as integration writer

### DIFF
--- a/plugins/github-autopilot/commands/qa-boost.md
+++ b/plugins/github-autopilot/commands/qa-boost.md
@@ -109,17 +109,44 @@ autopilot issue check-dup --fingerprint "$FINGERPRINT"
 
 중복인 갭은 skip합니다.
 
+### Step 5.5: Ledger Epic 부트스트랩
+
+이슈 발행 직전에, 결정적 ledger의 `qa-backlog` epic이 존재하도록 한 번만 보장합니다 (idempotent). gap-watch Step 5a와 동일한 패턴입니다.
+
+```bash
+EPIC_NAME="qa-backlog"
+EPIC_SPEC="spec/qa-backlog.md"
+out=$(autopilot epic create --name "$EPIC_NAME" --spec "$EPIC_SPEC" 2>&1) || true
+case "$out" in
+  *"created"*|*"already exists"*)
+    # 정상: 새로 생성 또는 이미 존재 (epic create는 이미 존재 시 exit 1)
+    ;;
+  *)
+    # 실패해도 GitHub issue 흐름은 그대로 진행 (ledger는 observer)
+    echo "WARN: qa-backlog epic 부트스트랩 실패 — ledger 쓰기는 skip됩니다: $out"
+    EPIC_NAME=""
+    ;;
+esac
+```
+
+> ledger는 GitHub issue 생성과 독립적인 부가 기록입니다. epic 부트스트랩이 실패하면 `EPIC_NAME=""`로 설정하여 Step 6의 ledger 쓰기를 skip합니다.
+>
+> **idempotent 처리 결정**: PR #661/662와 동일한 case-match fallback을 사용합니다 (`epic create --idempotent` 플래그는 별도 worktree의 T1에서 추가 중). T1 머지 이후 T6 follow-up에서 gap-watch와 함께 `--idempotent`로 정리할 예정입니다.
+
 ### Step 6: 이슈 발행
 
 이슈 발행을 시작하기 전에 idle count를 리셋합니다: `autopilot check mark qa-boost --status active`
 
-테스트 보강이 필요한 각 항목에 대해 autopilot CLI로 이슈를 생성합니다:
+테스트 보강이 필요한 각 항목에 대해 autopilot CLI로 이슈를 생성합니다. GitHub issue 생성이 성공하면 동일 fingerprint로 ledger task도 함께 기록합니다 (observer):
 
 ```bash
+FINGERPRINT="qa:${SOURCE_FILE}:${TEST_TYPE}"
+ISSUE_TITLE="test(scope): add missing tests for ${SOURCE_FILE}"
+
 autopilot issue create \
-  --title "test(scope): add missing tests for [source file/module]" \
+  --title "$ISSUE_TITLE" \
   --label "{label_prefix}qa-suggestion" \
-  --fingerprint "qa:${SOURCE_FILE}:${TEST_TYPE}" \
+  --fingerprint "$FINGERPRINT" \
   --body "$(cat <<'EOF'
 ## 테스트 보강 대상
 
@@ -144,9 +171,29 @@ autopilot issue create \
 - 기존 테스트 수정 금지 (추가만)
 EOF
 )"
+ISSUE_RC=$?
+
+# Ledger observer: 동일 fingerprint → 동일 12-hex id (sha256). issue 생성 성공 시에만 기록.
+if [ "$ISSUE_RC" = "0" ] && [ -n "${EPIC_NAME:-}" ]; then
+  TASK_ID=$(printf '%s' "$FINGERPRINT" | shasum -a 256 | cut -c1-12)
+  autopilot task add "$TASK_ID" \
+    --epic "$EPIC_NAME" \
+    --title "$ISSUE_TITLE" \
+    --fingerprint "$FINGERPRINT" \
+    --source qa-boost \
+    || echo "WARN: ledger task add 실패 (issue는 정상 생성됨) — 계속 진행"
+fi
 ```
 
 > **참고**: fingerprint HTML 주석은 CLI가 body 하단에 자동 삽입합니다.
+>
+> CLI 동작:
+> - 신규 task id + 신규 fingerprint: `inserted task <id>` (exit 0)
+> - 신규 task id + 기존 fingerprint: `duplicate of task <existing-id>` (exit 0, no-op)
+> - 기존 task id (재실행): `task '<id>' already exists` (exit 1, no-op) — `|| echo WARN ...` 가 흡수합니다
+> - epic 미존재 / 환경 오류: 비-0 exit → WARN 로그 후 무시 (GitHub issue는 이미 생성됨)
+>
+> ledger 쓰기는 GitHub issue 흐름의 보조 observer입니다. ledger 실패가 issue 생성 결과를 무효화하지 않도록 `|| echo WARN ...` 패턴으로 격리합니다.
 
 ### Step 7: 결과 보고
 
@@ -159,14 +206,16 @@ EOF
 - 테스트 보강 필요: 5개
 
 ### 발행된 이슈
-| # | 소스 파일 | 테스트 타입 |
-|---|----------|-----------|
-| #60 | src/auth/refresh.rs | unit |
-| #61 | src/api/handler.rs | unit, e2e |
+| # | 소스 파일 | 테스트 타입 | ledger task id |
+|---|----------|-----------|----------------|
+| #60 | src/auth/refresh.rs | unit | a1b2c3d4e5f6 |
+| #61 | src/api/handler.rs | unit, e2e | f7e8d9c0b1a2 |
 
 ### 건너뛴 항목
 - src/auth/mod.rs: 이미 이슈 존재 (#45)
 ```
+
+> ledger task id는 ledger 쓰기가 성공했거나 동일 fingerprint의 기존 task가 있을 때 12-hex-char id를 표시합니다. epic 부트스트랩이 실패했거나 ledger 쓰기 자체가 실패했으면 `null`(또는 공란)로 표시합니다.
 
 ## 주의사항
 
@@ -175,3 +224,4 @@ EOF
 - 사용자가 이슈를 검토 후 `{label_prefix}ready`로 라벨을 변경하면 build-issues가 처리
 - issue-label 스킬의 라벨 필수 규칙과 fingerprint 규칙을 반드시 따른다
 - 기존 이슈와 중복되지 않도록 fingerprint로 검사
+- ledger 쓰기는 GitHub issue 흐름의 보조 observer다. ledger 실패가 qa-boost cycle을 막지 않도록 `|| echo WARN ...` 패턴으로 격리한다 (gap-watch와 동일한 dual-write 패턴)


### PR DESCRIPTION
## Summary

- Wire `qa-boost` as the second integration writer to the deterministic ledger, mirroring the `gap-watch` pilot in PR #662. Every QA gap that produces a GitHub issue now also produces a ledger task in the `qa-backlog` epic with `--source qa-boost`.
- Markdown-only change to `commands/qa-boost.md` (no Rust diff): adds Step 5.5 "Ledger Epic 부트스트랩" before issue creation, and extends Step 6 to dual-write each successful issue as a ledger task with deterministic 12-hex id derived from `sha256(fingerprint)`.
- Failure isolation: ledger write failures log WARN and never block the qa-boost cycle. epic bootstrap failures set `EPIC_NAME=""` so per-finding ledger writes are skipped (issue creation flow is untouched).

## Idempotent fallback choice

Used the **case-match fallback** (`case "$out" in *"created"*|*"already exists"*) ;; ...`), mirroring `gap-watch.md` Step 5a exactly. Reasoning:

- Lands cleanly regardless of T1 (`epic create --idempotent`) merge order.
- Maximizes consistency between gap-watch and qa-boost — a single T6 follow-up can swap both to `--idempotent` once T1 is in.
- The prompt explicitly listed this as the simpler form and recommended it.

## Smoke test

```
$ AUTOPILOT_DB_PATH=/tmp/at-qa.db rm -f $AUTOPILOT_DB_PATH
$ BIN=plugins/github-autopilot/cli/target/release/autopilot

$ $BIN epic create --name qa-backlog --spec spec/qa-backlog.md
epic 'qa-backlog' created                              # exit 0

$ $BIN epic create --name qa-backlog --spec spec/qa-backlog.md
epic 'qa-backlog' already exists (active)              # exit 1 — tolerated by case "*already exists*"

$ $BIN task add qa001 --epic qa-backlog --title "Test coverage gap" --source qa-boost
inserted task qa001                                    # exit 0

$ $BIN task list --epic qa-backlog
ID            STATUS     ATTEMPTS  TITLE
qa001         ready             0  Test coverage gap

# Deterministic id from fingerprint
$ FP="qa:src/auth/refresh.rs:unit"
$ TID=$(printf '%s' "$FP" | shasum -a 256 | cut -c1-12)   # 45ca5bfe4667
$ $BIN task add "$TID" --epic qa-backlog \
    --title "test(auth): add missing tests for src/auth/refresh.rs" \
    --fingerprint "$FP" --source qa-boost
inserted task 45ca5bfe4667                             # exit 0

$ $BIN task add "$TID" --epic qa-backlog ... (re-run, same id+fp)
task '45ca5bfe4667' already exists                     # exit 1 — absorbed by `|| echo WARN ...`
```

All assertions pass. The case-match block tolerates the exit-1 path; the `|| echo WARN ...` on `task add` absorbs duplicate id re-runs.

## /simplify findings (self-review)

Three lenses on the markdown diff:

- **Reuse**: bootstrap block is structurally identical to `gap-watch.md` Step 5a (only `gap-backlog` → `qa-backlog`); fingerprint formula and 12-hex id derivation match `gap-issue-creator.md`. No duplication beyond what is intrinsic to two markdown specs sharing a contract.
- **Quality**: extracted `FINGERPRINT` and `ISSUE_TITLE` shell vars to eliminate string duplication between `issue create` and `task add`. Trimmed a verbose narrative comment to a one-liner that explains the WHY (deterministic id). The `EPIC_NAME=""` skip-signal is leaky but consistent with gap-watch — better symmetry than a clean local abstraction.
- **Efficiency**: epic bootstrap runs once per cycle (Step 5.5), not per finding. `task add` runs once per created issue (matching the per-issue cadence). No hot-path bloat. Cargo.lock drift from a local build was reverted to keep the diff markdown-only.

## Follow-ups

- **T6 cleanup**: when T1's `epic create --idempotent` lands on main, swap both `gap-watch.md` and `qa-boost.md` Step 5a/5.5 to use the flag and drop the case-match fallback.
- **CLI doc accuracy**: `gap-issue-creator.md` shows `task add --id $TASK_ID` but the CLI accepts only positional `task_id`. Out of scope here, but worth a follow-up edit.
- **Other watchers**: `ci-watch` is the next dual-write candidate after this PR (per PR #662's open questions).

## Test plan

- [x] `epic create` first-run produces ledger epic.
- [x] `epic create` second-run hits exit-1 "already exists" and is tolerated.
- [x] `task add` with positional id + `--source qa-boost` succeeds.
- [x] `task list --epic qa-backlog` shows the task in `ready`.
- [x] Re-run of `task add` with same id is absorbed (exit 1, message-only).
- [x] Diff is markdown-only (no Rust/Cargo changes).
- [ ] Live cron run on a real repo with QA gaps (out of CI; defer to operator smoke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)