### PR TITLE
feat(github-autopilot): wire pr-merger to close ledger loop on merge

### DIFF
--- a/plugins/github-autopilot/agents/pr-merger.md
+++ b/plugins/github-autopilot/agents/pr-merger.md
@@ -72,7 +72,46 @@ gh api repos/{owner}/{repo}/pulls/${PR_NUMBER}/comments --jq '.[] | {path, body,
 gh pr merge ${PR_NUMBER} --squash --delete-branch
 ```
 
-### 4. 결과 보고
+### 4. Ledger Close-the-Loop (best-effort)
+
+머지 성공 시, 해당 PR을 소유한 task가 있으면 `Wip → Done` 으로 전환합니다.
+**Ledger 호출은 best-effort 입니다 — 실패해도 머지 결과 자체에는 영향을 주지 않습니다.**
+
+```bash
+# set -e 가 켜져 있어도 모든 ledger 실패를 흡수하기 위해 호출 전체를 if/then 으로 감쌉니다.
+# - `if cmd; then` 컨텍스트에서는 cmd 실패가 set -e 를 트리거하지 않습니다.
+# - jq 가 부재하거나 JSON 이 깨져도 `|| true` 로 빈 문자열로 흘려보냅니다.
+if FIND_OUT=$(autopilot task find-by-pr "${PR_NUMBER}" --json 2>/dev/null); then
+  TASK_ID=$(printf '%s' "${FIND_OUT}" | jq -r '.id // empty' 2>/dev/null || true)
+  if [ -n "${TASK_ID}" ]; then
+    if autopilot task complete "${TASK_ID}" --pr "${PR_NUMBER}"; then
+      echo "[INFO] ledger: completed task ${TASK_ID} for PR #${PR_NUMBER}"
+    else
+      echo "[WARN] ledger: task complete failed for ${TASK_ID} (PR #${PR_NUMBER}) — continuing" >&2
+    fi
+  else
+    echo "[WARN] ledger: could not parse task id from find-by-pr output for PR #${PR_NUMBER} — skipping" >&2
+  fi
+else
+  # find-by-pr exit 1 = pre-ledger PR (소유한 task 없음). 정상 케이스이므로 INFO.
+  # 그 외 exit 코드(DB 오류, 바이너리 부재 등)도 동일하게 흡수합니다 — best-effort.
+  echo "[INFO] ledger: no task owns PR #${PR_NUMBER} (or ledger unavailable) — skipping complete" >&2
+fi
+```
+
+**Failure isolation 원칙:**
+
+| 케이스 | 동작 |
+|--------|------|
+| `find-by-pr` exit 1 (no task owns PR) | INFO 로그 후 skip — 머지는 성공 보고 |
+| `find-by-pr` exit ≠ 0/1 (DB 오류 등) | INFO 로그 후 skip — 머지는 성공 보고 |
+| `autopilot` 바이너리 부재 | `if` 가 비-zero 로 평가되어 자동 skip |
+| `jq` 부재 또는 JSON 파싱 실패 | `\|\| true` 로 빈 id 처리 → WARN 로그 후 skip |
+| `task complete` 실패 (이미 done, not found 등) | WARN 로그 후 skip |
+
+> 이 단계의 어떤 실패도 PR 머지 상태(`"status": "merged"`)를 변경하지 않습니다.
+
+### 5. 결과 보고
 
 ```json
 {
@@ -80,17 +119,24 @@ gh pr merge ${PR_NUMBER} --squash --delete-branch
   "status": "merged",
   "resolved_problems": ["conflict"],
   "unresolved_problems": [],
-  "commits_added": 2
+  "commits_added": 2,
+  "ledger_closed": true
 }
 ```
+
+`ledger_closed`:
+- `true`: `task complete` 가 성공 (Wip → Done 전환됨)
+- `false`: PR 을 소유한 task 가 없거나 ledger 호출 실패 (머지 성공과 무관)
 
 ## 에러 처리
 
 - 확신 없는 충돌: 해결하지 않고 보고 (`"status": "needs_human_review"`)
 - 권한 문제: skip + 보고
+- Ledger 호출 (Step 4) 실패: WARN/INFO 로그만 남기고 계속 진행 — 머지 결과를 절대 실패로 바꾸지 않음
 
 ## 주의사항
 
 - `--force-with-lease` 사용 (force push 안전장치)
 - 머지 전 반드시 CI 재확인
 - 사람의 명시적 `changes_requested` 리뷰가 있으면 자동 머지하지 않고 보고
+- Ledger 쓰기는 best-effort: pre-ledger 시대의 PR 또는 ledger 가 모르는 PR 도 정상 머지되어야 함


### PR DESCRIPTION
## Why

The autopilot ledger now tracks task lifecycle (Wip → Done), but the merge path never tells it when a PR actually lands. This leaves tasks stuck in Wip indefinitely after their PR is merged. `pr-merger` is the natural close-the-loop point: it's the agent that performs the final `gh pr merge`.

## Change Summary

`plugins/github-autopilot/agents/pr-merger.md` only — added a new **Step 4: Ledger Close-the-Loop** between merge and result reporting.

After `gh pr merge` succeeds:
1. Call `autopilot task find-by-pr ${PR_NUMBER} --json`.
2. If exit 0 → parse `id` via `jq` → call `autopilot task complete <id> --pr <N>` (Wip → Done).
3. If exit 1 (no task owns this PR — pre-ledger world) → INFO log and skip.
4. Any other failure (binary missing, jq missing, malformed JSON, complete fails) → WARN/INFO log and skip.

The merge flow's `"status": "merged"` is **never** changed by ledger-call outcomes. Reflected by adding `ledger_closed: bool` to the result-report contract.

## Failure Isolation Pattern

```bash
if FIND_OUT=$(autopilot task find-by-pr "${PR_NUMBER}" --json 2>/dev/null); then
  TASK_ID=$(printf '%s' "${FIND_OUT}" | jq -r '.id // empty' 2>/dev/null || true)
  if [ -n "${TASK_ID}" ]; then
    autopilot task complete "${TASK_ID}" --pr "${PR_NUMBER}" || echo "[WARN] ..."
  ...
fi
```

- `if cmd; then` neutralizes `set -e` for the condition's exit code.
- `2>/dev/null || true` on the `jq` pipeline absorbs jq-missing and parse-error failures into an empty `TASK_ID`.
- All branches log INFO/WARN to stderr — operators retain trace, callers don't fail.

## Smoke Output (matches task spec)

```
$ autopilot epic create --name test --spec specs/t.md
epic 'test' created
$ autopilot task add t1 --epic test --title "Test" --source human
inserted task t1
$ autopilot task claim --epic test  # claims t1 (Ready → Wip)
$ autopilot task complete t1 --pr 999  # simulates pr-merger flow
completed task t1 (PR #999)
newly ready: (none)
$ autopilot task find-by-pr 999  # task owns PR
id:              t1
status:          done
pr_number:       999
$ autopilot task find-by-pr 12345; echo "exit=$?"  # no owner
no task owns PR #12345
exit=1
```

End-to-end ledger-loop test (with `set -e`):
- **Scenario A** PR owned by t1 → `[INFO] ledger: completed task t1 for PR #999` ✓
- **Scenario B** PR not owned → `[INFO] ledger: no task owns PR #12345 ... — skipping complete` ✓
- **Scenario C** `jq` removed from PATH → `[WARN] ledger: could not parse task id ... — skipping`, `set -e` survives ✓
- **Scenario D** stub returns malformed JSON → same WARN, `set -e` survives ✓

## /simplify Findings

Three review passes (bash idiom / error tolerance / convention):

1. **Bash idiom (FIXED)**: original snippet had `TASK_ID=$(... | jq ...)` outside any `if` — under `set -e`, jq failure (missing binary OR parse error) would abort the whole script. Wrapped jq in `2>/dev/null || true` so failures collapse to empty `TASK_ID`, which the next `[ -n ... ]` guard already handles.
2. **Error tolerance (FIXED)**: failure-isolation table claimed "jq parse failure → WARN skip" before the actual code supported it; table now matches behavior, with binary-missing case promoted next to other ledger-side failures.
3. **Convention**: pre-existing `## 입력` section doesn't follow `## 입력 형식` / `## 출력 형식` split from `plugin-agent.md` rule — out of scope for this PR (pre-existing).

## Out-of-Scope (follow-up)

`commands/merge-prs.md` Step 4 also performs `gh pr merge` inline (the all-green fast path) without going through pr-merger. To fully close the loop for **every** merge, that step needs the same ledger close-the-loop. Suggest a follow-up issue.

## Test Plan

- [x] `cargo build --release` for autopilot CLI green
- [x] Smoke commands from task spec match expected output
- [x] Ledger close-the-loop bash snippet tested under `set -e` against 4 failure scenarios (owned, not owned, jq missing, malformed JSON)
- [ ] (manual, post-merge) observe a real autopilot PR and verify the relevant task transitions Wip → Done after `pr-merger` runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)