### PR TITLE
feat(github-autopilot): wire issue-implementer to ledger as first reader

### DIFF
--- a/plugins/github-autopilot/commands/work-ledger.md
+++ b/plugins/github-autopilot/commands/work-ledger.md
@@ -1,0 +1,209 @@
+---
+description: "ledger의 Ready task를 claim하여 issue-implementer로 구현하고 PR을 생성합니다 (첫 reader)"
+argument-hint: ""
+allowed-tools: ["Bash", "Read", "Agent"]
+---
+
+# Work Ledger
+
+결정적 ledger(SQLite)에 누적된 Ready task를 epic별로 claim하여 `issue-implementer` 에이전트에 디스패치하는 첫 reader 파이프라인입니다. gap-watch / qa-boost / ci-watch가 쓴 task를 실제 코드로 옮기는 단일 경로입니다.
+
+## 사용법
+
+```bash
+/github-autopilot:work-ledger
+```
+
+> 반복 실행은 `/github-autopilot:autopilot`이 `CronCreate`로 관리합니다.
+
+## Context
+
+- 설정 파일: !`cat github-autopilot.local.md 2>/dev/null | head -20 || echo "설정 파일 없음 - 기본값 사용"`
+- 현재 브랜치: !`git branch --show-current`
+
+## 책임 경계
+
+이 커맨드는 **claim → dispatch → branch-promote → PR open** 까지만 담당합니다.
+
+| 단계 | 담당 |
+|------|------|
+| Ready task 발생 | gap-watch, qa-boost, ci-watch (writer) |
+| Ready → Wip (claim) | **work-ledger (이 커맨드)** |
+| 구현 / 커밋 | issue-implementer 에이전트 |
+| draft → feature 승격 + PR open | branch-promoter 에이전트 |
+| PR 머지 | merge-prs (pr-merger) |
+| Wip → Done | pr-merger의 ledger close-the-loop (`task complete --pr`) |
+| Wip → Ready 또는 Escalated (실패) | **work-ledger (이 커맨드)** — `task fail` |
+
+PR 머지 시 Wip→Done 전환은 **항상 pr-merger가** 수행합니다. 이 커맨드는 PR 생성에 성공하면 task를 Wip 상태로 두고, pr-merger가 close-the-loop을 닫을 때까지 기다립니다.
+
+## 작업 프로세스
+
+### Step 1: Base 브랜치 동기화
+
+**branch-sync** 스킬의 절차를 수행합니다.
+
+### Step 2: 설정 로딩
+
+설정 파일(`github-autopilot.local.md`) frontmatter에서 다음 값을 읽습니다:
+
+- `max_parallel_agents`: 동시 실행 에이전트 수 (기본값: 3)
+- `quality_gate_command`: (optional) 커스텀 quality gate
+- `work_branch` / `branch_strategy`: base 브랜치 결정 (draft-branch 스킬)
+- `label_prefix`: GitHub 라벨 접두사 (기본값: `autopilot:`)
+
+### Step 3: Ledger Epic 부트스트랩
+
+3개 writer epic이 모두 존재함을 보장합니다 (멱등):
+
+```bash
+EPICS=("gap-backlog:spec/gap-backlog.md" "qa-backlog:spec/qa-backlog.md" "ci-backlog:spec/ci-backlog.md")
+for entry in "${EPICS[@]}"; do
+  name="${entry%%:*}"
+  spec="${entry##*:}"
+  if ! autopilot epic create --name "$name" --spec "$spec" --idempotent 2>&1; then
+    echo "WARN: epic '$name' 부트스트랩 실패 — 이번 cycle에서 해당 epic은 skip됩니다"
+  fi
+done
+```
+
+> `epic create --idempotent`(PR #663)는 동일 spec_path로 이미 존재하면 exit 0입니다. 부트스트랩 실패 시 해당 epic 처리를 skip하고, cycle을 중단하지 않습니다.
+
+### Step 4: Task Claim (epic당 1개)
+
+각 epic에 대해 round-robin 순서로 `task claim`을 호출합니다. 순서는 `gap-backlog → qa-backlog → ci-backlog`로 고정합니다 (결정적).
+
+```bash
+CLAIMED_JSON="[]"
+for EPIC in gap-backlog qa-backlog ci-backlog; do
+  out=$(autopilot task claim --epic "$EPIC" --json 2>/dev/null)
+  rc=$?
+  if [ "$rc" = "0" ] && [ -n "$out" ]; then
+    # claim 성공 → CLAIMED_JSON에 누적 (epic 메타데이터 포함)
+    CLAIMED_JSON=$(printf '%s' "$CLAIMED_JSON" | jq --argjson t "$out" --arg e "$EPIC" '. + [$t + {epic: $e}]')
+  fi
+  # exit 1: empty queue (정상) → skip
+  # exit 2+: 환경 오류 → WARN 후 skip
+  if [ "$rc" -ge 2 ]; then
+    echo "WARN: task claim --epic $EPIC 실패 (exit $rc) — skip"
+  fi
+done
+```
+
+**Failure isolation**: `claim` exit 1 (empty queue)은 정상이고, exit ≥ 2는 WARN 후 해당 epic만 skip합니다. 상세 분기는 §"에러 처리" 표 참조.
+
+`CLAIMED_JSON`이 빈 배열이면 "Ready task 없음" 출력 후 Step 7 (결과 보고)로 이동합니다.
+
+### Step 5: 디스패치 (Agent Team)
+
+claimed task들을 `max_parallel_agents` 단위로 분할하여 issue-implementer에 위임합니다. 서브그룹 분할 / rate-limit 백오프 / 병렬 실행 규칙은 **build-issues Step 8과 동일**합니다 (단일 출처 유지 — 분할 로직을 두 곳에 복제하지 않습니다).
+
+**전달 정보 (task → issue-implementer 입력 매핑):**
+
+| issue-implementer 입력 | 매핑 값 |
+|------------------------|---------|
+| `issue_number` | (생략) — ledger task에는 GitHub issue가 없음 |
+| `issue_title` | task의 `title` |
+| `issue_body` | task의 `body` (없으면 `task의 title을 단일 요구사항으로 간주합니다 (source: <task.source>).`) |
+| `issue_comments` | `[]` |
+| `recommended_persona` | (생략) — ledger task에는 코멘트 기반 failure-analysis가 없음 |
+| `draft_branch` | `draft/task-{task_id}` (task_id는 claim JSON의 `id` 12-hex) |
+| `base_branch` | Step 1에서 결정한 base 브랜치 |
+| `quality_gate_command` | 설정값 (비어있으면 자동 감지) |
+
+> **branch naming**: GitHub issue가 없으므로 `draft/issue-{N}` 대신 `draft/task-{id}`를 사용합니다. issue-implementer는 `draft_branch` 값을 그대로 사용하므로 에이전트 변경은 불필요합니다.
+
+### Step 6: 결과 수집 및 PR 생성
+
+각 에이전트의 결과를 수집합니다.
+
+#### 성공 (issue-implementer status=success)
+
+해당 task에 대해 branch-promoter 에이전트를 호출하여 draft → feature 승격 + PR open:
+- `draft_branch`: `draft/task-{task_id}`
+- `issue_number`: (생략) — ledger task에는 GitHub issue가 없음
+- `issue_title`: task의 title
+- `base_branch`: 결정된 base
+- `pr_type`: `auto`
+
+> **알려진 follow-up**: 현재 branch-promoter는 입력에 `issue_number`가 있을 때 PR body에 `Closes #{issue_number}`를 자동 삽입합니다. 본 커맨드는 `issue_number`를 전달하지 않아 promoter의 missing-key 처리에 의존합니다. promoter가 누락된 경우에도 안전하게 PR을 생성하도록 명세에 추가하는 작업은 별도 이슈로 surface (PR 설명 참조).
+
+PR 생성 성공 시:
+- task는 **Wip 상태로 유지** — `task complete`는 호출하지 않습니다 (pr-merger의 책임)
+- PR 번호와 task id를 보고에 누적
+
+#### 실패 (issue-implementer status=failed 또는 PR 미생성)
+
+failure_category에 따라 분기합니다:
+
+| failure_category | 동작 | 이유 |
+|------------------|------|------|
+| `rate_limit` (429 등 transient) | `autopilot task release {id}` | task의 잘못이 아님. attempts 증가 없이 재시도 큐로 |
+| 그 외 (test_failure, lint_failure, complexity_exceeded, dependency_error 등) | `autopilot task fail {id}` | attempts 증가, max 도달 시 자동 escalate |
+
+```bash
+# 예: lint_failure
+autopilot task fail "$TASK_ID"
+# 출력 (JSON): {"outcome": "retried", "attempts": 1} 또는 {"outcome": "escalated", "attempts": 3}
+```
+
+> **결정**: `release`(무한 재시도)가 아닌 `fail`을 default로 선택했습니다. `fail`은 attempts를 증가시키고 outcome=`retried`이면 Wip → Ready, outcome=`escalated`(max_attempts 도달)이면 Wip → Escalated 로 자동 전환하므로 poison task 무한 루프를 방지합니다. transient 실패만 `release`로 격리합니다.
+
+draft 브랜치는 issue-implementer가 worktree에서 `wip: partial work` 커밋을 남겨두므로 다음 cycle에서 재시도 시 이어서 작업합니다.
+
+### Step 7: 결과 보고
+
+```
+## Work Ledger 결과
+
+### Claim
+- gap-backlog: a1b2c3d4e5f6 ("Add /healthz endpoint")
+- qa-backlog: (empty)
+- ci-backlog: 7e8f9a0b1c2d ("Fix flaky test in api_test.rs")
+
+### 구현
+- 성공: a1b2c3d4e5f6 → PR #142 (Wip 유지, pr-merger 대기)
+- 실패: 7e8f9a0b1c2d (test_failure) → fail → outcome=retried, attempts=1
+
+### 다음 cycle
+- 7e8f9a0b1c2d: ready (attempts=1) — 다음 cycle에서 재시도
+```
+
+## 에러 처리
+
+| 케이스 | 동작 |
+|--------|------|
+| `epic create --idempotent` 실패 | WARN 로그 후 해당 epic skip, 다른 epic 계속 처리 |
+| `task claim` exit 1 (empty queue) | 정상 — skip, 다음 epic 진행 |
+| `task claim` exit ≥ 2 (DB 오류) | WARN 로그 후 해당 epic skip |
+| `task fail` 호출 실패 | WARN 로그 후 cycle 계속 — task는 Wip로 남음 (다음 cycle에서 stale Wip 감지 follow-up 필요) |
+| issue-implementer 타임아웃 / 크래시 | task `fail` 호출 (실패 카테고리: `agent_crash`) |
+
+## Output Examples
+
+### 성공 케이스
+
+```
+[STEP 3] epic 부트스트랩 완료: gap-backlog, qa-backlog, ci-backlog
+[STEP 4] claimed: gap-backlog/a1b2c3d4e5f6
+[STEP 4] claimed: ci-backlog/7e8f9a0b1c2d
+[STEP 5] dispatching 2 tasks (max_parallel_agents=3, single subgroup)
+[STEP 6] a1b2c3d4e5f6 → success → PR #142 (Wip)
+[STEP 6] 7e8f9a0b1c2d → failed (test_failure) → task fail → retried (attempts=1)
+```
+
+### 빈 큐 케이스
+
+```
+[STEP 3] epic 부트스트랩 완료
+[STEP 4] claimed: (none — all 3 epics empty)
+[STEP 7] Ready task 없음 — cycle 종료
+```
+
+## 주의사항
+
+- 한 cycle에서 epic당 **최대 1개** task만 claim합니다 (round-robin fairness). max_parallel_agents가 3이어도 epic이 3개를 넘으면 일부는 다음 cycle에서 처리됩니다.
+- task complete은 **호출하지 않습니다** — pr-merger의 close-the-loop 단계가 PR 머지 시 호출합니다.
+- 실패 시 default는 `task fail` (attempts 증가) 입니다. transient 실패만 `task release`를 사용합니다.
+- draft 브랜치는 `draft/task-{12-hex-id}` 형식이며 로컬 only입니다 (remote push 금지).
+- ledger reader는 GitHub 라벨/이슈 상태와 독립적으로 동작합니다 — `:wip`, `:ready` 라벨을 사용하지 않습니다.


### PR DESCRIPTION
## Summary

Phase 2 of the orchestration: add the **first reader-side ledger integration**. Until now the ledger had 4 writers (gap-watch, ci-watch, qa-boost, pr-merger close-the-loop) but **nothing was reading from it**. This PR wires the implementer pipeline to the ledger as a standalone reader.

- Adds `/github-autopilot:work-ledger` (`plugins/github-autopilot/commands/work-ledger.md`, 209 lines)
- Per cycle: bootstrap 3 writer epics (idempotent) → claim one Ready task per epic round-robin → dispatch claimed tasks to `issue-implementer` (worktree, parallel) → on success call `branch-promoter` for PR open → leave task in Wip for pr-merger to close on merge → on failure call `task fail` (or `task release` for transient errors)
- No changes to existing flows (build-issues, gap-watch, ci-watch, qa-boost, pr-merger, issue-implementer all untouched)

## Design decisions

### Option A vs B → **Option A (new command)**

Picked the standalone command. build-issues already orchestrates 12 steps spanning GitHub-issue scan, dependency analysis, similarity check, escalation, and label management — folding ledger-only tasks in would tangle two state spaces (GitHub Issues + ledger) with different lifecycles, increasing regression risk on the production path. Option A exercises the full ledger contract in isolation as a clean pilot; if it stabilizes we can later DRY shared sub-steps without touching build-issues mid-cycle.

### Per-epic processing order → **fixed round-robin: gap → qa → ci**

One claim per epic per cycle. Deterministic, fair, bounded work per cycle. Per-epic fairness avoids one noisy epic (e.g. ci-backlog after a CI storm) starving gap/qa fixes. If a `claim` returns exit 1 (empty queue) we silently skip and move to the next epic — that's the documented empty-queue contract.

### Failure recovery → **`task fail` (default) + `task release` (transient only)**

`fail` was chosen as default over `release`:

| Choice | attempts behavior | Poison-task safety |
|--------|-------------------|---------------------|
| `release` (rejected default) | Not bumped — Wip → Ready, attempts unchanged | None — infinite retry loop |
| **`fail` (chosen)** | Bumped; outcome=`retried` → Wip → Ready; outcome=`escalated` (≥ max_attempts, default 3) → Wip → Escalated | Bounded retries, automatic escalation |

`release` is reserved for transient infra failures (`rate_limit` / 429 / network) where attempts shouldn't count against the task. Mirrors the existing build-issues consecutive-failure behavior (max_consecutive_failures=3 → escalation).

### Branch flow

GitHub-issue-keyed branches don't apply (no issue exists). We use `draft/task-{12-hex-id}` and pass it as `draft_branch` to issue-implementer. issue-implementer treats the value as opaque (`git branch --list draft/task-{id}`) so no agent change is needed.

## End-to-end smoke test

Ran the exact session from the task spec against the freshly-built release binary (`autopilot v0.21.0`). All 10 steps exit-0 except `claim` on empty queue (exit 1, expected and documented).

```
$ AUTOPILOT_DB_PATH=/tmp/at-reader.db rm -f $AUTOPILOT_DB_PATH
$ BIN=plugins/github-autopilot/cli/target/release/autopilot

=== STEP 1: epic create --idempotent ===
epic 'gap-backlog' created
exit: 0

=== STEP 2: task add ===
inserted task gap1
exit: 0

=== STEP 3: task claim --json (first) ===
{"id":"gap1","epic_name":"gap-backlog","source":"gap-watch","fingerprint":"0xE91B1F2968B58074","title":"Add /healthz endpoint","body":"Spec requires /healthz returning 200","status":"wip","attempts":1,"branch":null,"pr_number":null,"escalated_issue":null,"created_at":"2026-05-05T01:14:04.785259Z","updated_at":"2026-05-05T01:14:04.791095Z"}
exit: 0

=== STEP 4: task list (after claim) ===
ID            STATUS     ATTEMPTS  TITLE
gap1          wip               1  Add /healthz endpoint
exit: 0

=== STEP 5: task release ===
released task gap1
exit: 0

=== STEP 6: task list (after release) ===
ID            STATUS     ATTEMPTS  TITLE
gap1          ready             0  Add /healthz endpoint
exit: 0

=== STEP 7: task claim again ===
{"id":"gap1","epic_name":"gap-backlog","source":"gap-watch","fingerprint":"0xE91B1F2968B58074","title":"Add /healthz endpoint","body":"Spec requires /healthz returning 200","status":"wip","attempts":1,"branch":null,"pr_number":null,"escalated_issue":null,"created_at":"2026-05-05T01:14:04.785259Z","updated_at":"2026-05-05T01:14:04.810285Z"}
exit: 0

=== STEP 8: task complete --pr 999 ===
completed task gap1 (PR #999)
newly ready: (none)
exit: 0

=== STEP 9: task list (after complete) ===
ID            STATUS     ATTEMPTS  TITLE
gap1          done              1  Add /healthz endpoint
exit: 0

=== STEP 10: task find-by-pr 999 ===
id:              gap1
epic:            gap-backlog
status:          done
source:          gap-watch
attempts:        1
title:           Add /healthz endpoint
pr_number:       999
fingerprint:     0xE91B1F2968B58074
---
Spec requires /healthz returning 200
exit: 0
```

Confirmed `release` decrements attempts (1 → 0) and `claim` re-acquires. Confirmed `complete --pr 999` is what pr-merger calls and `find-by-pr 999` resolves back to the task.

Additionally verified the failure-recovery path:

```
=== task fail (1st) ===          {"outcome":"retried","attempts":1}     exit 0
=== task list ===                t1  ready  1  x
=== task fail (2nd) ===          {"outcome":"retried","attempts":2}     exit 0
=== task fail (3rd, escalates) === {"outcome":"escalated","attempts":3} exit 0
=== task list ===                t1  escalated  3  x
=== claim on empty queue ===     (no ready tasks on epic 'gap-backlog')  exit: 1
```

`task fail` cleanly transitions Wip→Ready until attempts reach max_attempts, then escalates. Empty-queue claim returns exit 1 as documented (treated as "no work" by the command, not an error).

Plugin validation: `make validate` → 594 passed / 9 pre-existing warnings / 0 failed.

## /simplify findings + applied changes

Three review passes (reuse / quality / efficiency) on the new file:

**Applied:**
1. **Reuse — sub-group dispatch**: removed the duplicated subgroup-split / rate-limit-backoff prose; replaced with a single-line reference to **build-issues Step 8** to keep one source of truth.
2. **Quality — dead step**: dropped a do-nothing "Pipeline Idle Check" Step that explicitly said it doesn't gate the cycle (information-only, no action).
3. **Quality — invented heuristic**: removed the "attempts ≥ 2 → simplifier persona" rule. `recommended_persona` is normally derived from `filter-comments` failure analysis — ledger tasks have no comments, so we pass nothing and let issue-implementer follow its default path.
4. **Quality — `Closes #0` risk**: instead of passing `issue_number: 0` as a sentinel and asking branch-promoter to special-case it, we **omit `issue_number` entirely** from the promoter call. Promoter spec hardening is now a documented follow-up rather than a bake-in mismatch.
5. **Quality — unverified Step**: removed the `autopilot stats update --command work-ledger` Step. `--command` validation behavior wasn't confirmed for the new value, so baking an uncertain command into a release was wrong; surfaced as follow-up.
6. **Quality — duplicate error notes**: collapsed inline failure-isolation paragraphs into a single reference to the §"에러 처리" table.
7. **Quality — fail outcome wording**: clarified that `fail` itself transitions Wip→Ready (retried) or Wip→Escalated (escalated) — earlier wording implied the transition was a separate step.

**Efficiency:** no changes. Three sequential `epic create --idempotent` and three sequential `task claim` calls per cycle are intentional (round-robin must be sequential; each call is a single SQLite transaction). Agent dispatch parallelism is preserved by reference to build-issues' `max_parallel_agents` machinery.

Final size: 209 lines (well under the 300-line responsibility warning).

## Out-of-scope follow-ups

| # | Item | Why deferred |
|---|------|---------------|
| 1 | `branch-promoter` should tolerate missing `issue_number` (skip the `Closes #N` body line) | Touches another agent's spec; orthogonal to the reader pilot |
| 2 | `autopilot stats` should accept `--command work-ledger` (or document the allowed set) | CLI change; not markdown-only — outside this PR's constraints |
| 3 | Stale-Wip detector for tasks where `task fail` itself failed (CLI/DB outage) | Requires new CLI command — out of scope per "if you find a missing CLI command, surface, don't add it" |
| 4 | Idempotent re-claim semantics: today claim assigns the next Ready task; if a previous worktree is still alive (rare crash), we have no way to resume same task. Need lease/heartbeat. | Design discussion needed |
| 5 | Per-epic `max_parallel_agents` budget (e.g. ci-backlog burst caps) | Premature until we observe real load |
| 6 | Wire `/github-autopilot:work-ledger` into `/github-autopilot:autopilot` cron registry alongside the existing watchers | Wiring change; should follow once this lands and a default interval is chosen |

## Test plan

- [ ] Smoke session above re-runs clean against the merged binary
- [ ] `make validate` passes (confirmed locally: 594 ✓ / 9 pre-existing ⚠ / 0 ✗)
- [ ] On a repo with a non-empty `gap-backlog` epic, `/github-autopilot:work-ledger` claims the head task, opens a PR, and leaves the task in `wip` until pr-merger merges
- [ ] On an empty ledger, the command exits cleanly with "Ready task 없음"
- [ ] Inducing 3 consecutive failures escalates the task (no infinite retry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)