### PR TITLE
feat(github-autopilot): accept work-ledger in stats --command

### DIFF
--- a/plugins/github-autopilot/cli/Cargo.lock
+++ b/plugins/github-autopilot/cli/Cargo.lock
@@ -87,7 +87,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autopilot"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/plugins/github-autopilot/cli/src/cmd/mod.rs
+++ b/plugins/github-autopilot/cli/src/cmd/mod.rs
@@ -319,7 +319,9 @@ pub enum StatsCommands {
     Init,
     /// Update statistics for a command
     Update {
-        /// Command name (e.g. "build-issues")
+        /// Command name. Canonical: build-issues, gap-watch, qa-boost,
+        /// ci-watch, pr-merger, merge-prs, work-ledger. Unknown but
+        /// well-formed names are accepted with a stderr warning.
         #[arg(long)]
         command: String,
         /// Number of issues processed this cycle

--- a/plugins/github-autopilot/cli/src/cmd/stats.rs
+++ b/plugins/github-autopilot/cli/src/cmd/stats.rs
@@ -2,11 +2,28 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-use crate::cmd::check::state::{state_dir, utc_timestamp};
+use crate::cmd::check::state::{state_dir, utc_timestamp, validate_loop_name};
 use crate::fs::FsOps;
 use crate::git::GitOps;
 
 const STATS_FILE: &str = "session-stats.json";
+
+/// Canonical autopilot loop / cron command names that emit stats.
+///
+/// `--command` is intentionally a free string so new loops can land without a
+/// CLI release, but values *should* match this list. Unknown names are accepted
+/// (a warning is emitted on stderr) so we never block a new command from
+/// recording stats; rejecting only happens for structurally invalid values
+/// (empty, path-traversal characters — see `validate_loop_name`).
+pub const KNOWN_COMMANDS: &[&str] = &[
+    "build-issues",
+    "gap-watch",
+    "qa-boost",
+    "ci-watch",
+    "pr-merger",
+    "merge-prs",
+    "work-ledger",
+];
 
 #[derive(Serialize, Deserialize, Default)]
 pub struct SessionStats {
@@ -57,6 +74,13 @@ impl StatsService {
         failed: u32,
         false_positive: u32,
     ) -> Result<i32> {
+        validate_loop_name(command)?;
+        if !KNOWN_COMMANDS.contains(&command) {
+            eprintln!(
+                "warning: --command {command:?} is not in the canonical list ({}). Recording anyway.",
+                KNOWN_COMMANDS.join(", ")
+            );
+        }
         let path = state_dir(self.git.as_ref())?.join(STATS_FILE);
         let mut stats = self.read_or_init(&path)?;
 
@@ -85,6 +109,9 @@ impl StatsService {
 
     /// Show session statistics.
     pub fn show(&self, command: Option<&str>) -> Result<i32> {
+        if let Some(name) = command {
+            validate_loop_name(name)?;
+        }
         let path = state_dir(self.git.as_ref())?.join(STATS_FILE);
         let stats = match self.fs.read_file(&path) {
             Ok(content) => serde_json::from_str::<SessionStats>(&content)?,
@@ -111,6 +138,23 @@ impl StatsService {
                 started_at: utc_timestamp(),
                 commands: HashMap::new(),
             }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn known_commands_includes_work_ledger() {
+        assert!(KNOWN_COMMANDS.contains(&"work-ledger"));
+    }
+
+    #[test]
+    fn all_canonical_names_pass_validation() {
+        for name in KNOWN_COMMANDS {
+            assert!(validate_loop_name(name).is_ok(), "rejected: {name}");
         }
     }
 }

--- a/plugins/github-autopilot/cli/tests/stats_tests.rs
+++ b/plugins/github-autopilot/cli/tests/stats_tests.rs
@@ -154,6 +154,51 @@ fn show_returns_0_when_no_stats() {
 }
 
 #[test]
+fn update_accepts_work_ledger() {
+    let git = MockGit::new();
+    let fs = MockFs::new();
+    let svc = make_svc(git, fs.clone());
+
+    let code = svc.update("work-ledger", 5, 3, 1, 0).unwrap();
+    assert_eq!(code, 0);
+
+    let written = fs.written_files();
+    let stats: serde_json::Value = serde_json::from_str(&written[0].1).unwrap();
+    let cmd = &stats["commands"]["work-ledger"];
+    assert_eq!(cmd["processed"], 5);
+    assert_eq!(cmd["success"], 3);
+    assert_eq!(cmd["failed"], 1);
+}
+
+#[test]
+fn update_rejects_empty_command() {
+    let git = MockGit::new();
+    let fs = MockFs::new();
+    let svc = make_svc(git, fs);
+    assert!(svc.update("", 1, 1, 0, 0).is_err());
+}
+
+#[test]
+fn update_rejects_path_traversal_command() {
+    let git = MockGit::new();
+    let fs = MockFs::new();
+    let svc = make_svc(git, fs);
+    assert!(svc.update("../etc/passwd", 1, 1, 0, 0).is_err());
+}
+
+#[test]
+fn update_accepts_unknown_well_formed_command() {
+    let git = MockGit::new();
+    let fs = MockFs::new();
+    let svc = make_svc(git, fs.clone());
+    let code = svc.update("future-loop", 1, 1, 0, 0).unwrap();
+    assert_eq!(code, 0);
+    let written = fs.written_files();
+    let stats: serde_json::Value = serde_json::from_str(&written[0].1).unwrap();
+    assert_eq!(stats["commands"]["future-loop"]["processed"], 1);
+}
+
+#[test]
 fn show_with_command_filter() {
     let git = MockGit::new();
     let fs = MockFs::new().with_file(


### PR DESCRIPTION
## Why

PR #674 (`/github-autopilot:work-ledger`) introduced a new ledger-reader command, but the `autopilot stats` CLI had no record of which command names are canonical. RUNBOOK.md B.1 flagged this as PR #674 follow-up #2: _"`autopilot stats update --command work-ledger`의 허용 여부가 미확인"_. This PR codifies the canonical list and explicitly recognizes `work-ledger`.

## What changed

- `plugins/github-autopilot/cli/src/cmd/stats.rs` — added `KNOWN_COMMANDS: &[&str]` listing the seven canonical loop/cron command names (`build-issues`, `gap-watch`, `qa-boost`, `ci-watch`, `pr-merger`, `merge-prs`, `work-ledger`). `StatsService::update` now validates the command name (reusing the existing `validate_loop_name` helper from `cmd/check/state.rs`) and emits a `stderr` warning when the name is well-formed but not in the canonical list. `show` also rejects structurally invalid filters.
- `plugins/github-autopilot/cli/src/cmd/mod.rs` — `--command` help text now lists the canonical names so `--help` is the source of truth.
- `plugins/github-autopilot/cli/tests/stats_tests.rs` — 4 new black-box tests: accepts `work-ledger`, accepts unknown well-formed names, rejects empty / path-traversal.
- `plugins/github-autopilot/cli/src/cmd/stats.rs` (`mod tests`) — pins `KNOWN_COMMANDS` invariants (must contain `work-ledger`; every canonical name must pass validation).
- `plugins/github-autopilot/cli/Cargo.lock` — auto-regenerated to match Cargo.toml `0.22.0` (was stale at `0.21.0`). No version bump.

**Free string vs enum**: chose to keep `--command` as a free string and document the convention. New loops can land without a CLI release; unknown names emit a warning rather than a hard error so stats collection is never blocked.

## Tests

- Inline (lib) tests: 2 new (`known_commands_includes_work_ledger`, `all_canonical_names_pass_validation`) — pass.
- Integration tests: 4 new (`update_accepts_work_ledger`, `update_rejects_empty_command`, `update_rejects_path_traversal_command`, `update_accepts_unknown_well_formed_command`) — pass. Total stats integration tests: 12.
- `cargo fmt --check` clean.
- `cargo clippy --lib --bins -- -D warnings` clean.
- `cargo test` passes the full suite.

## Smoke test

```
$ autopilot stats init
session stats initialized at 2026-05-05T02:05:25Z

$ autopilot stats update --command work-ledger --processed 5 --success 3 --failed 1 --false-positive 0
{"total_cycles":1,"processed":5,"success":3,"failed":1,"false_positive":0,"idle_cycles":0,"consecutive_idle":0,"agent_calls":5}

$ autopilot stats show --command work-ledger
{
  "total_cycles": 1,
  "processed": 5,
  "success": 3,
  "failed": 1,
  "false_positive": 0,
  "idle_cycles": 0,
  "consecutive_idle": 0,
  "agent_calls": 5
}

$ autopilot stats update --command typo-loop --processed 1
warning: --command "typo-loop" is not in the canonical list (build-issues, gap-watch, qa-boost, ci-watch, pr-merger, merge-prs, work-ledger). Recording anyway.
{"total_cycles":1,"processed":1, ...}

$ autopilot stats update --command "../etc" --processed 1
invalid loop_name: ../etc
# exit 2
```

## /simplify findings (applied)

1. **Reuse**: dropped a hand-rolled `validate_command_name` and reused `validate_loop_name` from `cmd/check/state.rs` (identical anti-traversal logic). −10 LOC.
2. **Test redundancy**: removed inline duplicates of `validate_loop_name` rejection tests (already covered in `cmd/check/state.rs::tests`). Kept only the two invariants unique to stats. −20 LOC.
3. **Comment hygiene**: removed WHAT-style comments narrating test intent — test names are self-describing.

Final diff: 93 LOC (≤ 120 LOC budget).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --lib --bins -- -D warnings`
- [x] `cargo test` (full suite + new tests)
- [x] Smoke test against release binary (work-ledger / typo / traversal cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)