### PR TITLE
feat(github-autopilot): accept day/week units in duration parser

### DIFF
--- a/plugins/github-autopilot/cli/Cargo.lock
+++ b/plugins/github-autopilot/cli/Cargo.lock
@@ -87,7 +87,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autopilot"
-version = "0.22.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/plugins/github-autopilot/cli/src/cmd/task.rs
+++ b/plugins/github-autopilot/cli/src/cmd/task.rs
@@ -440,10 +440,22 @@ pub fn task_service<'a>(store: &'a dyn TaskStore, clock: &'a dyn Clock) -> TaskS
     TaskService::new(store, clock)
 }
 
-/// Parses a Go-style duration (`30s`, `5m`, `1h`, `2h30m`) to seconds.
-/// Intentionally minimal — supports `s`/`m`/`h` units, integer counts,
-/// and concatenation. Anything unrecognized is rejected so callers can
-/// fall back to `--before-seconds` rather than silently round-trip.
+/// Parses a Go-style duration (`30s`, `5m`, `1h`, `1d`, `1w`, `2h30m`,
+/// `2d12h`, `1w3d`, `2d12h30m`) to seconds.
+///
+/// Supported units (fixed length only — month/year are intentionally
+/// omitted because they're variable-length and ambiguous):
+/// - `s` = 1 second
+/// - `m` = 60 seconds
+/// - `h` = 3 600 seconds
+/// - `d` = 86 400 seconds
+/// - `w` = 604 800 seconds
+///
+/// Unit ordering is **not** enforced — the result is the sum of every
+/// `<count><unit>` part regardless of order. Empty input, missing units
+/// (`90`), unknown units (`1y`, `1mo`), zero/negative totals, and
+/// integer overflow all return `Err` with a message naming the offending
+/// fragment.
 pub fn parse_duration_seconds(s: &str) -> std::result::Result<i64, String> {
     if s.is_empty() {
         return Err("empty duration".to_string());
@@ -463,10 +475,12 @@ pub fn parse_duration_seconds(s: &str) -> std::result::Result<i64, String> {
         if !saw_digit {
             return Err(format!("invalid duration '{s}': unit '{c}' without count"));
         }
-        let mult = match c {
+        let mult: i64 = match c {
             's' => 1,
             'm' => 60,
             'h' => 3_600,
+            'd' => 86_400,
+            'w' => 604_800,
             _ => return Err(format!("invalid duration '{s}': unknown unit '{c}'")),
         };
         let part = acc

--- a/plugins/github-autopilot/cli/tests/task_tests.rs
+++ b/plugins/github-autopilot/cli/tests/task_tests.rs
@@ -520,14 +520,39 @@ fn release_stale_json_emits_array_of_recovered_ids() {
 #[test]
 fn parse_duration_seconds_supports_compound_units() {
     use autopilot::cmd::task::parse_duration_seconds;
+    // Single units
     assert_eq!(parse_duration_seconds("30s").unwrap(), 30);
     assert_eq!(parse_duration_seconds("5m").unwrap(), 300);
     assert_eq!(parse_duration_seconds("1h").unwrap(), 3_600);
+    assert_eq!(parse_duration_seconds("1d").unwrap(), 86_400);
+    assert_eq!(parse_duration_seconds("1w").unwrap(), 604_800);
+    // Compound units
     assert_eq!(parse_duration_seconds("2h30m").unwrap(), 9_000);
+    assert_eq!(
+        parse_duration_seconds("2d12h").unwrap(),
+        2 * 86_400 + 12 * 3_600
+    );
+    assert_eq!(
+        parse_duration_seconds("1w3d").unwrap(),
+        7 * 86_400 + 3 * 86_400
+    );
+    assert_eq!(parse_duration_seconds("1h30m").unwrap(), 5_400);
+    assert_eq!(
+        parse_duration_seconds("2d12h30m").unwrap(),
+        2 * 86_400 + 12 * 3_600 + 30 * 60
+    );
+    // Rejected inputs
     assert!(parse_duration_seconds("").is_err());
-    assert!(parse_duration_seconds("1d").is_err());
     assert!(parse_duration_seconds("0s").is_err());
     assert!(parse_duration_seconds("90").is_err()); // trailing digits, no unit
+    assert!(parse_duration_seconds("-1d").is_err()); // negative not supported
+    let err_y = parse_duration_seconds("1y").unwrap_err();
+    assert!(
+        err_y.contains("unknown unit") && err_y.contains('y'),
+        "unexpected message for `1y`: {err_y}"
+    );
+    // `1mo` is rejected because `o` is not a recognized unit (after `1m` parses)
+    assert!(parse_duration_seconds("1mo").is_err());
 }
 
 // ---------- find-by-pr ----------


### PR DESCRIPTION
## Summary

PR #688 added `task release-stale --before <duration>` but the parser only handled `s`/`m`/`h`. Callers wanting a day or week threshold had to fall back to `--before-seconds 86400`. This PR removes that workaround by extending the unit table.

## Accepted formats

- Singles: `30s`, `15m`, `2h`, `1d`, `1w`
- Compounds (any order, summed): `2d12h`, `1w3d`, `1h30m`, `2d12h30m`

## Rejected examples

| Input  | Error message                                  |
|--------|------------------------------------------------|
| `""`   | `empty duration`                               |
| `90`   | `invalid duration '90': trailing digits without unit` |
| `0s`   | `duration must be positive: 0s`                |
| `1y`   | `invalid duration '1y': unknown unit 'y'`      |
| `1mo`  | `invalid duration '1mo': unit 'o' without count` (parses `1m`, then `o` has no count) |
| `-1d`  | rejected at clap level (`unexpected argument '-1' found`) |

`mo` (month) and `y` (year) are intentionally not supported because they're variable-length and ambiguous (CLI must stay deterministic per `CLAUDE.md` 책임 경계).

## Tests added

In `parse_duration_seconds_supports_compound_units` (tests/task_tests.rs):
- New singles: `1d` → 86 400, `1w` → 604 800
- New compounds: `2d12h`, `1w3d`, `1h30m`, `2d12h30m`
- New rejections: `1y` (asserts message contains `unknown unit` and `y`), `1mo`, `-1d`
- Existing `2h30m` regression case retained
- Removed the now-obsolete `assert!(parse_duration_seconds("1d").is_err())`

## Smoke test

```bash
$BIN task release-stale --before 1d         # released 0 stale tasks
$BIN task release-stale --before 1w         # released 0 stale tasks
$BIN task release-stale --before 2d12h      # released 0 stale tasks
$BIN task release-stale --before 2d12h30m   # released 0 stale tasks
$BIN task release-stale --before 1y         # invalid duration '1y': unknown unit 'y'
$BIN task release-stale --before 1mo        # invalid duration '1mo': unit 'o' without count
$BIN task release-stale --before 30s        # released 0 stale tasks (regression)
```

## /simplify findings

Three-perspective review (reuse / quality / efficiency) found no issues:
- Parser is the only duration parser in the crate; no existing utility duplicates it.
- 5-entry `match` on unit char is clearer than a slice/HashMap lookup at this scale.
- Single-pass O(n) iteration, no allocations, no hot-path concerns.
- Comments retained explain non-obvious WHY (`1mo` semantics, variable-length unit omission).

## Test plan

- [x] `cargo test` (all 111+ existing tests + 1 expanded) green
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --lib --bins -- -D warnings` clean
- [x] Release-binary smoke for accepted/rejected inputs

## Constraints honored

- Base = `epic/ledger-polish`
- Diff: 46 insertions / 7 deletions across parser + tests (well under 120 LOC budget)
- No version bumps in Cargo.toml (Cargo.lock refresh only — package version was already 0.24.0 on base, lock was stale)
- Parser stays deterministic — no judgment, no auto-defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)