### PR TITLE
refactor(github-autopilot): clarify task subcommand naming

### DIFF
--- a/plugins/github-autopilot/RUNBOOK.md
+++ b/plugins/github-autopilot/RUNBOOK.md
@@ -421,20 +421,37 @@ done
 # stale Wip 후보 관찰 (read-only)
 $BIN task list-stale --before 1h --json
 
-# 단건 release (에이전트 권장 경로)
-$BIN task release-stale --task-id <task_id>
-
-# 단건 release (alias — 동일 효과)
+# 단건 release (권장 경로 — 단건 회수의 canonical 이름)
 $BIN task release <task_id>
+
+# 단건 release (deprecated alias — 신규 호출자는 `release` 를 사용)
+$BIN task release-stale --task-id <task_id>
 
 # 비상시 bulk release (에이전트 우회 — 운영자 판단으로 일괄 회수)
 $BIN task release-stale --before 1h --json
 
-# Wip → 명시적 status 강제 변경 (operator override)
-$BIN task force-status <task_id> ready
+# Wip → 명시적 status 변경 (operator override; canonical 이름)
+$BIN task set-status <task_id> --to ready
+
+# (deprecated alias for one release; 동일 효과)
+$BIN task force-status <task_id> --to ready
 ```
 
 > `release-stale --task-id` 와 `release-stale --before` 는 mutually exclusive — clap 이 parser 단계에서 거부합니다.
+
+#### Naming audit 결과 (PR #696)
+
+| 명령 | 평가 | 권장 |
+|------|------|------|
+| `add` / `add-batch` / `list` / `claim` / `complete` / `fail` / `escalate` | 명확 | 유지 |
+| `show` / `get` | 동일 명령 (alias) | 유지, RUNBOOK 에 alias 명시 |
+| `find-by-pr` / `list-stale` | 명확 (다른 의도) | 유지 |
+| `release` | 단건 Wip→Ready (attempts 감소). canonical 단건 회수 이름 | 유지 |
+| `release-stale --before <D>` | bulk-only (운영자 우회) | 유지 |
+| `release-stale --task-id <ID>` | `release <ID>` 와 100% 동일 — `-stale` suffix 는 오해 유발 | **deprecated alias** (한 릴리스 유지). 신규 호출은 `release <ID>` |
+| `force-status` → `set-status` | "force" 는 일회성 override 뉘앙스, "set" 이 직관적 | **rename** + `force-status` deprecated alias |
+
+`show ↔ get` 은 모두 단일 task 조회로 동일하게 동작합니다. `get` 이 spec-canonical 이며 `show` 가 humans-facing helper alias 입니다 — 어느 쪽을 호출해도 결과가 동일합니다.
 
 > lease/heartbeat 기반 정교화 (worker liveness 직접 추적) 는 carry-forward follow-up 입니다 (Section F).
 

--- a/plugins/github-autopilot/agents/stale-task-reviewer.md
+++ b/plugins/github-autopilot/agents/stale-task-reviewer.md
@@ -56,7 +56,7 @@ CLAUDE.md "책임 경계 (CLI vs Skill/Agent)" 에 따라:
 - worker crash / ctrl-C / worktree 강제 삭제 등 일시적 사유
 - attempts 가 max_attempts 미만이고 다른 worker 가 다시 집어들 여지 있음
 
-> 명령: `autopilot task release-stale --task-id <ID>`. 이 CLI 는 attempts 를 1 감소시키고 Ready 로 되돌립니다 (`release_claim` 과 동일 효과).
+> 명령: `autopilot task release <ID>`. 이 CLI 는 attempts 를 1 감소시키고 Ready 로 되돌립니다 (`release_claim` 과 동일 효과). `release-stale --task-id <ID>` 는 동일 효과의 deprecated alias 이며 기존 호출자 호환을 위해 유지됩니다 — 신규 호출은 `release` 를 사용합니다 (PR #696 audit 참조).
 
 ### 4. leave alone
 
@@ -69,8 +69,8 @@ drop-through 케이스 (가능한 한 보수적으로 사용):
 각 task 결정 후 즉시 해당 CLI 를 실행합니다. 한 task 의 실행 실패가 다른 task 의 처리를 막지 않도록, 각 명령은 독립 호출하고 실패 시 stderr 만 기록한 뒤 다음으로 진행합니다.
 
 ```bash
-# release
-autopilot task release-stale --task-id <ID> || echo "WARN: release failed for <ID>"
+# release (per-task — same primitive as manual `task release`)
+autopilot task release <ID> || echo "WARN: release failed for <ID>"
 
 # fail
 autopilot task fail <ID> || echo "WARN: fail failed for <ID>"
@@ -79,6 +79,8 @@ autopilot task fail <ID> || echo "WARN: fail failed for <ID>"
 ISSUE=$(gh issue create --title "stale task <ID>" --body "..." --json number -q '.number')
 autopilot task escalate <ID> --issue "$ISSUE" || echo "WARN: escalate failed for <ID>"
 ```
+
+> Legacy: `autopilot task release-stale --task-id <ID>` 는 `release <ID>` 와 100% 동일한 효과의 deprecated alias 입니다 (PR #696 audit). 기존 자동화 스크립트 호환을 위해 유지하지만, 신규 호출은 `release` 를 사용합니다 — `-stale` suffix 는 "stale 한 것을 release" 로 오해를 일으켜 단건 회수에 부적합한 이름입니다.
 
 ## 출력
 

--- a/plugins/github-autopilot/cli/src/cmd/mod.rs
+++ b/plugins/github-autopilot/cli/src/cmd/mod.rs
@@ -114,8 +114,13 @@ pub enum TaskCommands {
         #[arg(long)]
         json: bool,
     },
-    /// Force a task into a specific status (operator override)
-    ForceStatus {
+    /// Set a task to a specific status (operator override).
+    ///
+    /// Renamed from `force-status` for clarity — "set" describes the
+    /// effect more directly than "force". `force-status` remains as a
+    /// deprecated alias for one release.
+    #[command(alias = "force-status")]
+    SetStatus {
         /// Task id
         task_id: String,
         /// Target status
@@ -177,10 +182,10 @@ pub enum TaskCommands {
         task_id: String,
     },
     /// Read-only: list Wip tasks whose claim is older than `--before`.
-    /// Companion to `release-stale`: agents call `list-stale` first, review
-    /// each candidate, then dispatch per-task to `release-stale --task-id`,
-    /// `fail`, or `escalate` based on judgment (per CLAUDE.md "책임 경계").
-    /// Always exits 0 — empty list is normal.
+    /// Companion to `release` / `release-stale`: agents call `list-stale`
+    /// first, review each candidate, then dispatch per-task to `release`
+    /// (canonical), `fail`, or `escalate` based on judgment (per CLAUDE.md
+    /// "책임 경계"). Always exits 0 — empty list is normal.
     ListStale {
         /// Go-style duration: `30s`, `5m`, `1h`, `2h30m`. Mutually
         /// exclusive with `--before-seconds`.
@@ -194,12 +199,13 @@ pub enum TaskCommands {
         #[arg(long)]
         json: bool,
     },
-    /// Recover a stale Wip task back to Ready. Two mutually exclusive modes:
-    /// `--task-id <ID>` releases exactly one task (recommended path, used by
-    /// the agent reviewer after `list-stale`); `--before <duration>` bulk
-    /// releases every Wip task older than the cutoff (emergency operator use
-    /// only — the agent-reviewed per-task flow is preferred per CLAUDE.md
-    /// "책임 경계"). Idempotent: empty case exits 0.
+    /// Recover stale Wip tasks back to Ready. Two mutually exclusive modes:
+    /// `--before <duration>` (canonical) bulk releases every Wip task older
+    /// than the cutoff — emergency operator use, the agent-reviewed per-task
+    /// flow is preferred per CLAUDE.md "책임 경계". `--task-id <ID>` is a
+    /// deprecated alias for `task release <ID>` (functionally identical
+    /// post-P2; kept for one release for back-compat). Idempotent: empty
+    /// case exits 0.
     ReleaseStale {
         /// Single task id to release (per-task path). Mutually exclusive
         /// with `--before` and `--before-seconds`.

--- a/plugins/github-autopilot/cli/src/cmd/task.rs
+++ b/plugins/github-autopilot/cli/src/cmd/task.rs
@@ -328,15 +328,17 @@ impl<'a> TaskService<'a> {
         Ok(0)
     }
 
-    /// Reaps Wip tasks whose claim went stale (worker crashed / ctrl-C /
-    /// worktree destroyed) by reverting them to Ready. Same effect as
-    /// per-task `release` but driven by a `before` cutoff. Emits a
-    /// `TaskReleasedStale` event per recovered task. Always exits 0 on the
-    /// happy path — empty recovery is normal.
+    /// Bulk recovery: reaps every Wip task whose claim went stale (worker
+    /// crashed / ctrl-C / worktree destroyed) by reverting them to Ready.
+    /// Driven by a `before` cutoff — same effect as per-task `release` for
+    /// each candidate. Emits a `TaskReleasedStale` event per recovered task.
+    /// Always exits 0 on the happy path — empty recovery is normal.
     ///
     /// Per `CLAUDE.md` "책임 경계", this remains an emergency operator
     /// primitive — the recommended flow is agent-driven review via
-    /// `list_stale` + per-task `release` / `fail` / `escalate` calls.
+    /// `list_stale` + per-task `release` / `fail` / `escalate` calls. Per-task
+    /// recovery should call `release` directly; `release-stale --task-id`
+    /// remains a deprecated alias for back-compat (PR #696 audit).
     pub fn release_stale(
         &self,
         before_seconds: i64,

--- a/plugins/github-autopilot/cli/src/main.rs
+++ b/plugins/github-autopilot/cli/src/main.rs
@@ -174,7 +174,7 @@ fn main() {
                 }
                 TaskCommands::Show { task_id, json } => svc.show(&task_id, json, &mut out),
                 TaskCommands::Get { task_id, json } => svc.show(&task_id, json, &mut out),
-                TaskCommands::ForceStatus {
+                TaskCommands::SetStatus {
                     task_id,
                     to,
                     reason,
@@ -219,9 +219,10 @@ fn main() {
                     json,
                 } => {
                     if let Some(id) = task_id {
-                        // Per-task path reuses `release` so the transition is
-                        // identical to manual `task release` — see CLAUDE.md
-                        // "책임 경계" for why this branch exists.
+                        // Deprecated per-task alias: routes to `release` so the
+                        // transition is identical to manual `task release`.
+                        // Kept for back-compat (PR #696 audit) — new callers
+                        // should use `task release <ID>` directly.
                         svc.release(&id, &mut out)
                     } else {
                         match resolve_before_seconds(before.as_deref(), before_seconds) {

--- a/plugins/github-autopilot/cli/tests/task_tests.rs
+++ b/plugins/github-autopilot/cli/tests/task_tests.rs
@@ -838,3 +838,35 @@ fn force_status_still_routes_through_service() {
         .unwrap();
     assert_eq!(t.status, TaskStatus::Done);
 }
+
+// ---------- set-status (rename of force-status, with deprecated alias) ----------
+
+/// Both `set-status` (canonical post-rename) and `force-status` (deprecated
+/// alias kept for one release) must parse to the same `TaskCommands::SetStatus`
+/// variant with identical field values — this is what backwards-compat means
+/// at the CLI surface (PR #696 audit).
+fn assert_set_status_parses(subcmd: &str) {
+    use autopilot::cmd::{Cli, Commands, TaskCommands};
+    use clap::Parser;
+    let cli = Cli::try_parse_from(["autopilot", "task", subcmd, "aaaaaaaaaaaa", "--to", "done"])
+        .unwrap_or_else(|e| panic!("`task {subcmd}` should parse: {e}"));
+    match cli.command {
+        Commands::Task {
+            command: TaskCommands::SetStatus { task_id, to, .. },
+        } => {
+            assert_eq!(task_id, "aaaaaaaaaaaa");
+            assert_eq!(to, TaskStatusArg::Done);
+        }
+        _ => panic!("`task {subcmd}` did not resolve to SetStatus variant"),
+    }
+}
+
+#[test]
+fn set_status_parses_as_canonical_name() {
+    assert_set_status_parses("set-status");
+}
+
+#[test]
+fn force_status_alias_still_parses_to_set_status() {
+    assert_set_status_parses("force-status");
+}

--- a/plugins/github-autopilot/commands/stale-task-review.md
+++ b/plugins/github-autopilot/commands/stale-task-review.md
@@ -14,7 +14,7 @@ allowed-tools: ["Bash", "Agent"]
 |------|------|
 | stale 후보 관찰 (deterministic) | `autopilot task list-stale` (CLI) |
 | task 별 결정 (judgment) | `stale-task-reviewer` 에이전트 |
-| 결정 실행 (deterministic state transition) | `autopilot task release-stale --task-id` / `task fail` / `task escalate` (CLI) |
+| 결정 실행 (deterministic state transition) | `autopilot task release` / `task fail` / `task escalate` (CLI) |
 
 CLI는 절대 "release할지 fail할지" 를 추측하지 않습니다. 동일 입력 → 동일 출력 보장이 깨지기 때문입니다. 결정은 컨텍스트 (task의 attempts 횟수, 최근 이벤트, 관련 PR 상태) 를 보고 에이전트가 내립니다.
 
@@ -43,10 +43,12 @@ autopilot task list-stale --before $BEFORE --json
 
 | 결정 | 트리거 조건 (가이드) | 실행 명령 |
 |------|---------------------|----------|
-| release | 일시적 stall — worker crash 가능성, attempts 여유 있음 | `autopilot task release-stale --task-id <ID>` |
+| release | 일시적 stall — worker crash 가능성, attempts 여유 있음 | `autopilot task release <ID>` |
 | fail | 진행 불가 시도가 명백 — escalation policy 에 위임 | `autopilot task fail <ID>` |
 | escalate | HITL 필요 — 컨텍스트 상 자동 복구 부적절 | `autopilot task escalate <ID> --issue <N>` (이슈 선등록 후) |
 | leave alone | 아직 progress 가능 — 다음 cycle 에서 재평가 | (no-op, 다음 tick 에 재관찰) |
+
+> 단건 회수는 `release-stale --task-id` 가 아닌 `release` 를 사용합니다 — 두 명령은 100% 동일하지만 "release-stale" 이름은 단건 회수에 부적합 (PR #696 audit). `release-stale --task-id` 는 deprecated alias 로 유지되며 기존 호출자 호환만 보장합니다.
 
 상세 결정 기준은 `agents/stale-task-reviewer.md` 참조.
 


### PR DESCRIPTION
## Summary

User-facing audit of the post-P2 (PR #695) `autopilot task` subcommand surface, focused on naming clarity from a fresh user's perspective. Two confusing names are renamed to clearer canonicals; old names kept as deprecated aliases for one release.

## Audit table

| Command | Severity | Recommendation |
|---|---|---|
| `add` / `add-batch` / `list` / `claim` / `complete` / `fail` / `escalate` | low | keep |
| `show` / `get` | low | keep (already aliased; documented in RUNBOOK) |
| `find-by-pr` / `list-stale` | low | keep (different intents, names are clear) |
| `release` | low | keep — canonical single-task Wip→Ready primitive |
| `release-stale --before <D>` | low | keep — bulk-only emergency operator path |
| **`release-stale --task-id <ID>`** | **high** | **deprecate**: 100% identical to `release <ID>` post-P2; `-stale` suffix misleads. Agent + RUNBOOK now recommend `release` |
| **`force-status`** | **medium** | **rename → `set-status`**: "force" implies one-time override; "set" is more direct |

## Renames applied

| Old | New | Back-compat strategy |
|-----|-----|----------------------|
| `task force-status` | `task set-status` | clap `#[command(alias = "force-status")]` — old name still parses to same variant |
| `task release-stale --task-id <ID>` (recommended path) | `task release <ID>` (recommended path) | CLI shape unchanged — `release-stale --task-id` still works as a deprecated alias; only documentation/agent changes the recommended call |

## Why each rename improves user clarity

- **`force-status` → `set-status`**: The word "force" in CLI tradition (think `git push --force`) implies a one-time, dangerous override. Operators reading `force-status` may hesitate to use it for routine status corrections. `set-status` is direct: it describes the effect, not the emotional weight.
- **`release-stale --task-id` → `release`**: After P2 split observation/decision (#695), per-task recovery dispatches the same `release_claim` transition as manual `task release`. The `-stale` suffix tells a fresh user "this is for stale tasks only" — but the CLI doesn't actually check staleness for the per-task path, it just calls release. Confusing.

## Backwards-compat notes

- `task force-status <ID> --to <S>` still works (clap alias) — verified by `force_status_alias_still_parses_to_set_status` test.
- `task release-stale --task-id <ID>` still works (unchanged CLI shape, comment marks it deprecated).
- The bulk path `release-stale --before <D>` is unchanged — it is the canonical way to drive bulk recovery.
- No version bump required (renames are additive at the CLI surface).

## /simplify findings

- **Code reuse**: clap `#[command(alias = "...")]` is the canonical clap-native back-compat mechanism — no existing helper duplicated. ✓
- **Quality**: extracted shared helper `assert_set_status_parses(subcmd: &str)` to dedupe the two clap-parser tests; both now call the helper with `"set-status"` and `"force-status"` — the behavioral guarantee (both names → same `SetStatus` variant) is now expressed in one place.
- **Efficiency**: pure CLI parser + doc changes, zero runtime impact. Deprecated `release-stale --task-id` path routes to the same `svc.release()` call.

## Items deferred

- **`task stale {list, release-bulk}` subcommand group**: would group bulk-only stale operations under a logical namespace, but it's a breaking change for `release-stale --before` callers (cron registrations in `autopilot.md`, RUNBOOK examples). Trade-off doesn't justify the churn for a marginal organizational win — flat names are fine for this small surface. Documented current shape clearly in RUNBOOK audit table instead.
- **Removing `release-stale --task-id` outright**: kept as deprecated alias for one release per the task constraints (maintain back-compat). Removal can ship in a follow-up after one release cycle of deprecation visibility.
- **Audit-only renames**: did not touch `add` / `add-batch` / `list` / `claim` / `complete` / `fail` / `escalate` / `find-by-pr` / `list-stale` / `release` / `escalate` / `show` / `get` — all judged clear enough that renaming would cost more than it gains.

## Test plan

- [x] `cargo fmt --check` — passes
- [x] `cargo clippy --lib --bins -- -D warnings` — passes
- [x] `cargo test` — all 341+ tests pass, including 2 new clap-parser tests verifying `set-status` (canonical) and `force-status` (alias) both resolve to `TaskCommands::SetStatus`
- [x] `make validate` — 8984 passed, 11 pre-existing warnings, 0 failures
- [ ] Smoke: `autopilot task set-status <ID> --to ready` succeeds; `autopilot task force-status <ID> --to ready` succeeds with same effect
- [ ] Smoke: `autopilot task release <ID>` and `autopilot task release-stale --task-id <ID>` produce identical state transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)