### PR TITLE
feat(github-autopilot): add CLI e2e test infrastructure

### DIFF
--- a/plugins/github-autopilot/cli/Cargo.lock
+++ b/plugins/github-autopilot/cli/Cargo.lock
@@ -15,6 +15,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -80,6 +89,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "assert_cmd"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,12 +111,14 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autopilot"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "chrono",
  "clap",
  "hex",
+ "predicates",
  "rusqlite",
  "serde",
  "serde_json",
@@ -116,6 +142,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -226,6 +263,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,6 +317,15 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "foldhash"
@@ -481,6 +533,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -512,6 +570,36 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "prettyplease"
@@ -546,6 +634,35 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rusqlite"
@@ -699,6 +816,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -818,6 +941,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "wasip2"

--- a/plugins/github-autopilot/cli/Cargo.toml
+++ b/plugins/github-autopilot/cli/Cargo.toml
@@ -25,6 +25,8 @@ toml = "0.8"
 unicode-normalization = "0.1"
 
 [dev-dependencies]
+assert_cmd = "2"
+predicates = "3"
 tempfile = "3"
 
 [profile.release]

--- a/plugins/github-autopilot/cli/tests/cli_e2e.rs
+++ b/plugins/github-autopilot/cli/tests/cli_e2e.rs
@@ -1,0 +1,114 @@
+//! End-to-end black-box tests for the `autopilot` binary.
+//!
+//! Unlike the in-process tests under `tests/*_tests.rs` (which construct
+//! `TaskService` directly and exercise pure Rust APIs), these tests **spawn
+//! the actual binary** via `assert_cmd`. They cover the `clap` argparse
+//! layer, the routing in `main.rs`, and the real `stdout` / `stderr` /
+//! exit-code surface that operators see — the gap C1 of `cli-ux-hardening`
+//! is filling.
+//!
+//! Each test owns a `TempDir` workspace and points the binary's SQLite
+//! store there via `AUTOPILOT_DB_PATH` (the env var honored by
+//! `task_store_db_path` in `main.rs`). The temp dir is also used as the
+//! process `current_dir` so that `Config::load` does not accidentally pick
+//! up an `autopilot.toml` from the developer's checkout.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+/// Isolated workspace for a single test invocation.
+///
+/// Holds a `TempDir` (kept alive for the duration of the test) and hands
+/// out fresh `Command` builders preconfigured with:
+/// - `AUTOPILOT_DB_PATH` -> `<tempdir>/state.db` so the SQLite store is
+///   private to this test.
+/// - `current_dir` set to the tempdir so the binary does not pick up the
+///   repository's `autopilot.toml` via the default lookup in
+///   `load_config`.
+///
+/// Designed so that follow-up tasks (C2/C3/C4) can write 1- to 2-line
+/// scenarios on top: `Workspace::new().cmd().args([...]).assert()...`.
+pub struct Workspace {
+    dir: TempDir,
+}
+
+impl Workspace {
+    /// Create a fresh isolated workspace.
+    pub fn new() -> Self {
+        let dir = TempDir::new().expect("create tempdir for autopilot e2e workspace");
+        Self { dir }
+    }
+
+    /// Path to the SQLite store this workspace will use. The binary
+    /// honors `AUTOPILOT_DB_PATH` (see `main.rs::task_store_db_path`) and
+    /// will create the file lazily on first command.
+    pub fn db_path(&self) -> std::path::PathBuf {
+        self.dir.path().join("state.db")
+    }
+
+    /// Build a fresh `Command` for the `autopilot` binary, scoped to this
+    /// workspace. Each call returns a new builder so callers may chain
+    /// `.args(...)` without leaking state between invocations.
+    pub fn cmd(&self) -> Command {
+        let mut cmd = Command::cargo_bin("autopilot").expect("locate `autopilot` cargo binary");
+        cmd.current_dir(self.dir.path())
+            .env("AUTOPILOT_DB_PATH", self.db_path());
+        cmd
+    }
+}
+
+impl Default for Workspace {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[test]
+fn e2e_help_subcommand_exits_zero() {
+    // Sanity: the binary boots, clap renders its help, exit code is 0,
+    // and stdout mentions the binary name. If this fails the harness
+    // itself is broken — every other e2e scenario depends on it.
+    let ws = Workspace::new();
+    ws.cmd()
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("autopilot"));
+}
+
+#[test]
+fn e2e_task_add_then_list_shows_task() {
+    // Happy-path round-trip across three commands sharing one SQLite
+    // store: `epic create` bootstraps the epic, `task add` inserts a
+    // watch-style task, `task list` renders it. Validates that argparse
+    // routing, the env-var-driven store path, and the task table format
+    // line up end-to-end. Subsequent C2/C3/C4 scenarios layer assertions
+    // about UX edges on top of this same shape.
+    let ws = Workspace::new();
+    let task_id = "abc123def456"; // 12 hex chars, matches deterministic id format
+    let title = "c1 demo task";
+
+    ws.cmd()
+        .args([
+            "epic",
+            "create",
+            "--name",
+            "demo",
+            "--spec",
+            "specs/demo.md",
+        ])
+        .assert()
+        .success();
+
+    ws.cmd()
+        .args(["task", "add", task_id, "--epic", "demo", "--title", title])
+        .assert()
+        .success();
+
+    ws.cmd()
+        .args(["task", "list", "--epic", "demo"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(task_id).and(predicate::str::contains(title)));
+}


### PR DESCRIPTION
## Summary

C1 of the `epic/cli-ux-hardening` epic — introduces the black-box test harness that subsequent UX-hardening tasks (C2/C3/C4) will build on. Today's `tests/*_tests.rs` are all in-process: they construct `TaskService` directly and never exercise the `clap` argparse layer, the routing in `main.rs`, or the real `stdout`/`stderr`/exit-code surface. This PR adds the missing layer.

- New `tests/cli_e2e.rs` with a `Workspace` helper that owns a `TempDir`, sets `AUTOPILOT_DB_PATH` to a tempdir-scoped SQLite file, and pins `current_dir` to the tempdir (so the binary doesn't pick up the repo's `autopilot.toml`). Each call to `Workspace::cmd()` returns a fresh `assert_cmd::Command` for the `autopilot` cargo binary — designed so C2/C3/C4 scenarios are 1-2 lines on top.
- Adds `assert_cmd = "2"` and `predicates = "3"` as dev-deps (matching the versions already used by `plugins/autodev/cli` and `plugins/suggest-workflow/cli`).
- Two happy-path scenarios validate the harness end-to-end:
  - `e2e_help_subcommand_exits_zero` — `autopilot --help` exits 0 and stdout contains `autopilot`. Sanity check the binary boots.
  - `e2e_task_add_then_list_shows_task` — `epic create --name demo --spec specs/demo.md` -> `task add abc123def456 --epic demo --title "c1 demo task"` -> `task list --epic demo`, asserts both the task id and title appear in stdout.

No production CLI code was changed; the binary already exposed `AUTOPILOT_DB_PATH` for store redirection so the harness needed no shims.

## How the helper is used

```rust
let ws = Workspace::new();
ws.cmd().args(["epic", "create", "--name", "demo", "--spec", "specs/demo.md"])
    .assert().success();
```

Each `Workspace` is fully isolated (own tempdir, own DB) so tests are safe to run in parallel.

## Sharp edges discovered (inputs for C2/C3, NOT fixed here)

These surfaced while wiring up the happy path and are worth surfacing as candidates for the UX-hardening follow-ups:

1. **`epic create --spec` accepts a non-existent path silently.** `specs/demo.md` does not need to exist on disk — the create call only stores the path. May be intentional (lazy materialization) but worth a UX call: should `create` warn / error when the spec file is missing? Not exercised today.
2. **`task add` requires a positional `task_id` that is documented as "deterministic 12-hex-char id" but is in fact accepted as any string** (`TaskId::from_raw` does no validation). A typo'd id silently inserts garbage. Candidate for C2 or C3 input validation.
3. **`Config::load` defaults to `./autopilot.toml`** with no warning if the file is missing — fine, but combined with the above the binary is happy to operate against a missing config and a missing spec, only failing later when something downstream actually needs the data. A `preflight`-style early check might fit the UX-hardening theme.
4. **`task list` table format** prints the literal header `ID            STATUS     ATTEMPTS  TITLE` even when piping to a non-tty — not a bug per se, but worth deciding if a `--no-header` or auto-detection belongs in C4's polish pass.

## Test plan

- [x] `cargo test -p autopilot --test cli_e2e` — both new scenarios pass
- [x] `cargo test -p autopilot` — full suite passes (no regressions)
- [x] `cargo clippy -p autopilot --tests -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] CI green on PR (will verify after push)

Targets `epic/cli-ux-hardening`, NOT `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)