### PR TITLE
feat(github-autopilot): tighten domain validation and error recovery hints

### DIFF
--- a/plugins/github-autopilot/cli/src/domain/error.rs
+++ b/plugins/github-autopilot/cli/src/domain/error.rs
@@ -4,12 +4,36 @@ use super::epic::EpicStatus;
 use super::task::TaskStatus;
 use super::task_id::TaskId;
 
+/// Marker error for CLI user-input validation failures. Surfaced through
+/// `anyhow::Error` and downcasted by `main::exit_code_for` to map onto
+/// exit code 1 (user error, distinct from clap's exit 2 for argparse and
+/// codes greater than 2 for system / unexpected failures). Use this
+/// whenever a CLI handler rejects an argument before any store mutation —
+/// the error string itself is the user-facing message, so write it
+/// actionably.
+#[derive(Debug, Error)]
+#[error("{0}")]
+pub struct UserInputError(pub String);
+
+impl UserInputError {
+    pub fn new(msg: impl Into<String>) -> Self {
+        Self(msg.into())
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum DomainError {
     #[error("dependency cycle detected: {0:?}")]
     DepCycle(Vec<TaskId>),
 
-    #[error("illegal status transition for task {0}: {1:?} -> {2:?}")]
+    /// A status change was attempted that is not allowed by the lifecycle
+    /// state machine (e.g. `pending -> done` skipping `ready`/`wip`). The
+    /// message names the offending transition so an operator can pick a
+    /// valid intermediate hop.
+    #[error(
+        "illegal status transition for task {0}: {1} -> {2} is not allowed; \
+         use `task set-status {0} --to <status> --reason ...` to override"
+    )]
     IllegalTransition(TaskId, TaskStatus, TaskStatus),
 
     /// Precondition failure: the operation needs the task to currently be in a
@@ -18,7 +42,11 @@ pub enum DomainError {
     /// status is the bug, not the target.
     ///
     /// Args: `(task_id, required_current_status, actual_current_status)`.
-    #[error("task {0} requires status {1:?}, was {2:?}")]
+    #[error(
+        "task {0} requires status '{1}' but was '{2}'; \
+         advance it first (e.g. `task claim --epic <name>` for ready->wip) \
+         or use `task set-status {0} --to {1} --reason ...` to override"
+    )]
     RequiresStatus(TaskId, TaskStatus, TaskStatus),
 
     #[error("epic '{0}' already exists with status {1:?}")]
@@ -27,7 +55,10 @@ pub enum DomainError {
     #[error("dep references unknown task: {0}")]
     UnknownDepTarget(TaskId),
 
-    #[error("duplicate task id in plan: {0}")]
+    #[error(
+        "task id '{0}' already exists in store; \
+         use `task show {0}` to inspect or `task set-status {0} --to <status>` to override"
+    )]
     DuplicateTaskId(TaskId),
 
     #[error("inconsistency: {0}")]

--- a/plugins/github-autopilot/cli/src/domain/mod.rs
+++ b/plugins/github-autopilot/cli/src/domain/mod.rs
@@ -7,7 +7,7 @@ pub mod task_id;
 
 pub use deps::{CycleError, TaskGraph};
 pub use epic::{Epic, EpicStatus};
-pub use error::DomainError;
+pub use error::{DomainError, UserInputError};
 pub use event::{Event, EventKind};
 pub use task::{Task, TaskFailureOutcome, TaskSource, TaskStatus};
-pub use task_id::TaskId;
+pub use task_id::{TaskId, TaskIdParseError};

--- a/plugins/github-autopilot/cli/src/domain/task.rs
+++ b/plugins/github-autopilot/cli/src/domain/task.rs
@@ -60,6 +60,12 @@ impl TaskStatus {
     }
 }
 
+impl std::fmt::Display for TaskStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum TaskSource {

--- a/plugins/github-autopilot/cli/src/domain/task_id.rs
+++ b/plugins/github-autopilot/cli/src/domain/task_id.rs
@@ -21,9 +21,51 @@ impl TaskId {
         Self(raw.into())
     }
 
+    /// Validates that `raw` is shaped like a deterministic task id —
+    /// 12 lowercase hex characters — and returns a `TaskId`. Returns
+    /// `Err(TaskIdParseError)` with an actionable message otherwise.
+    ///
+    /// Use this on every CLI input boundary that mutates state (e.g.,
+    /// `task add <task_id>`, `task add-batch`) so a typo can't silently
+    /// insert a row whose id will never match the deterministic form.
+    /// Read-only paths (`task show`, `task release`, ...) may keep
+    /// using [`Self::from_raw`] — a missing-id lookup already surfaces
+    /// the typo without corrupting state.
+    pub fn parse(raw: &str) -> Result<Self, TaskIdParseError> {
+        if raw.len() != TASK_ID_HEX_LEN {
+            return Err(TaskIdParseError::InvalidLength {
+                got: raw.to_string(),
+                len: raw.len(),
+            });
+        }
+        if !raw
+            .chars()
+            .all(|c| c.is_ascii_digit() || matches!(c, 'a'..='f'))
+        {
+            return Err(TaskIdParseError::InvalidChars {
+                got: raw.to_string(),
+            });
+        }
+        Ok(Self(raw.to_string()))
+    }
+
     pub fn as_str(&self) -> &str {
         &self.0
     }
+}
+
+/// Length of a deterministic task id (lowercase hex prefix of SHA-256).
+pub const TASK_ID_HEX_LEN: usize = 12;
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum TaskIdParseError {
+    #[error(
+        "invalid task id '{got}': expected 12 lowercase hex characters (e.g. 'a1b2c3d4e5f6'), got {len} characters"
+    )]
+    InvalidLength { got: String, len: usize },
+
+    #[error("invalid task id '{got}': must contain only lowercase hex characters [0-9a-f]")]
+    InvalidChars { got: String },
 }
 
 impl std::fmt::Display for TaskId {
@@ -117,5 +159,48 @@ mod tests {
         assert_eq!(slug("hello   world!!!"), "hello-world");
         assert_eq!(slug("---abc---"), "abc");
         assert_eq!(slug("foo/bar.baz"), "foo-bar-baz");
+    }
+
+    #[test]
+    fn parse_accepts_canonical_form() {
+        let id = TaskId::parse("a1b2c3d4e5f6").unwrap();
+        assert_eq!(id.as_str(), "a1b2c3d4e5f6");
+    }
+
+    #[test]
+    fn parse_rejects_wrong_length() {
+        let err = TaskId::parse("abc").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("12 lowercase hex"), "msg: {msg}");
+        assert!(msg.contains("got 3 characters"), "msg: {msg}");
+    }
+
+    #[test]
+    fn parse_rejects_uppercase() {
+        let err = TaskId::parse("A1B2C3D4E5F6").unwrap_err();
+        assert!(err.to_string().contains("lowercase hex"));
+    }
+
+    #[test]
+    fn parse_rejects_non_hex_chars() {
+        let err = TaskId::parse("g1b2c3d4e5f6").unwrap_err();
+        assert!(err.to_string().contains("lowercase hex"));
+    }
+
+    #[test]
+    fn parse_rejects_typo() {
+        // The kind of input the task description warned about: an 11-char
+        // id (typo from copy/paste) should be rejected with an actionable
+        // length message rather than silently accepted by the store.
+        let err = TaskId::parse("a1b2c3d4e5f").unwrap_err();
+        assert!(err.to_string().contains("got 11 characters"));
+    }
+
+    #[test]
+    fn parse_accepts_deterministic_output() {
+        // The deterministic generator's output must round-trip through parse —
+        // that's the contract that makes parse() a safe gate on user input.
+        let id = TaskId::new_deterministic("e", "## section", "requirement");
+        TaskId::parse(id.as_str()).expect("deterministic id must parse");
     }
 }

--- a/plugins/github-autopilot/cli/tests/store_conformance.rs
+++ b/plugins/github-autopilot/cli/tests/store_conformance.rs
@@ -342,9 +342,16 @@ fn body_release_claim_rejects_non_wip(store: Arc<dyn TaskStore>) {
     let err = store
         .release_claim(&TaskId::from_raw("A"), t0())
         .unwrap_err();
+    // C3 reworded RequiresStatus to lowercase canonical statuses with
+    // an actionable suffix (`task claim ...` / `task set-status ...`).
+    let msg = format!("{err}");
     assert!(
-        format!("{err}").contains("requires status Wip"),
-        "expected RequiresStatus(_, Wip, _), got: {err}"
+        msg.contains("requires status 'wip'"),
+        "expected RequiresStatus(_, Wip, _), got: {msg}"
+    );
+    assert!(
+        msg.contains("task claim") || msg.contains("set-status"),
+        "expected actionable hint in: {msg}"
     );
 }
 
@@ -418,7 +425,8 @@ fn body_complete_rejects_when_status_not_wip(store: Arc<dyn TaskStore>) {
     let err = store
         .complete_task_and_unblock(&TaskId::from_raw("A"), 1, t0())
         .unwrap_err();
-    assert!(format!("{err}").contains("requires status Wip"));
+    // Match the C3 lowercase canonical-status message.
+    assert!(format!("{err}").contains("requires status 'wip'"));
 }
 
 fn body_failure_below_max_returns_to_ready(store: Arc<dyn TaskStore>) {

--- a/plugins/github-autopilot/cli/tests/task_tests.rs
+++ b/plugins/github-autopilot/cli/tests/task_tests.rs
@@ -775,9 +775,12 @@ fn fail_from_ready_returns_requires_status_error() {
     let mut buf: Vec<u8> = Vec::new();
     let err = svc.fail("aaaaaaaaaaaa", &mut buf).unwrap_err();
     let msg = format!("{err:#}");
+    // C3: RequiresStatus message uses lowercase canonical statuses and an
+    // actionable suffix. Pin both halves so a future copy edit doesn't
+    // silently re-introduce the cryptic `Wip`/`Ready` debug form.
     assert!(
-        msg.contains("requires status Wip") && msg.contains("was Ready"),
-        "expected RequiresStatus(_, Wip, Ready), got: {msg}"
+        msg.contains("requires status 'wip'") && msg.contains("was 'ready'"),
+        "expected RequiresStatus(_, wip, ready), got: {msg}"
     );
 }
 
@@ -790,8 +793,8 @@ fn complete_from_ready_returns_requires_status_error() {
     let err = svc.complete("aaaaaaaaaaaa", 99, &mut buf).unwrap_err();
     let msg = format!("{err:#}");
     assert!(
-        msg.contains("requires status Wip") && msg.contains("was Ready"),
-        "expected RequiresStatus(_, Wip, Ready), got: {msg}"
+        msg.contains("requires status 'wip'") && msg.contains("was 'ready'"),
+        "expected RequiresStatus(_, wip, ready), got: {msg}"
     );
 }
 


### PR DESCRIPTION
## Summary

Adds the foundation for CLI input-validation failures to surface as actionable errors instead of silent corruption.

### Domain
- `TaskId::parse(raw)` validates 12-char lowercase hex and returns `TaskIdParseError::{InvalidLength, InvalidChars}` with example-bearing messages.
- `UserInputError` marker type in `domain::error` for handlers to raise pre-store validation rejections (intended exit code 1, distinct from clap's exit 2 for argparse).
- `DomainError::IllegalTransition` / `RequiresStatus` messages now include recovery hints — the user sees what command to run next instead of just what blew up.

### Tests
- `task_id::tests::parse_*` cover canonical / wrong-length / uppercase / non-hex.
- `task_tests` and `store_conformance` updated for the new error formatting.

## Sharp edges (originally surfaced by C1) — wiring not yet done in this PR

This PR introduces the validation primitives but does **not** yet wire them through the CLI surface. Follow-up work to land before this epic rolls up to main:

1. **`task add <id>` should call `TaskId::parse`** — currently still accepts arbitrary strings via `TaskId::from_raw`. The parser exists; flip the call site.
2. **`epic create --spec <path>` should reject non-existent paths** — currently silently stores the path and lets the failure surface much later.
3. **e2e scenarios in `cli_e2e.rs`** locking stderr text + exit code for the two wired paths above.

## Test plan
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p autopilot --tests -- -D warnings` — clean
- [x] `cargo test -p autopilot` — full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)