### PR TITLE
feat(github-autopilot): CLI UX hardening — e2e infra + scenarios

### DIFF
--- a/plugins/github-autopilot/cli/Cargo.lock
+++ b/plugins/github-autopilot/cli/Cargo.lock
@@ -15,6 +15,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -80,6 +89,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "assert_cmd"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,12 +111,14 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autopilot"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "chrono",
  "clap",
  "hex",
+ "predicates",
  "rusqlite",
  "serde",
  "serde_json",
@@ -116,6 +142,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -226,6 +263,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,6 +317,15 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "foldhash"
@@ -481,6 +533,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -512,6 +570,36 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "prettyplease"
@@ -546,6 +634,35 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rusqlite"
@@ -699,6 +816,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -818,6 +941,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "wasip2"

--- a/plugins/github-autopilot/cli/Cargo.toml
+++ b/plugins/github-autopilot/cli/Cargo.toml
@@ -25,6 +25,8 @@ toml = "0.8"
 unicode-normalization = "0.1"
 
 [dev-dependencies]
+assert_cmd = "2"
+predicates = "3"
 tempfile = "3"
 
 [profile.release]

--- a/plugins/github-autopilot/cli/src/domain/error.rs
+++ b/plugins/github-autopilot/cli/src/domain/error.rs
@@ -4,12 +4,36 @@ use super::epic::EpicStatus;
 use super::task::TaskStatus;
 use super::task_id::TaskId;
 
+/// Marker error for CLI user-input validation failures. Surfaced through
+/// `anyhow::Error` and downcasted by `main::exit_code_for` to map onto
+/// exit code 1 (user error, distinct from clap's exit 2 for argparse and
+/// codes greater than 2 for system / unexpected failures). Use this
+/// whenever a CLI handler rejects an argument before any store mutation —
+/// the error string itself is the user-facing message, so write it
+/// actionably.
+#[derive(Debug, Error)]
+#[error("{0}")]
+pub struct UserInputError(pub String);
+
+impl UserInputError {
+    pub fn new(msg: impl Into<String>) -> Self {
+        Self(msg.into())
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum DomainError {
     #[error("dependency cycle detected: {0:?}")]
     DepCycle(Vec<TaskId>),
 
-    #[error("illegal status transition for task {0}: {1:?} -> {2:?}")]
+    /// A status change was attempted that is not allowed by the lifecycle
+    /// state machine (e.g. `pending -> done` skipping `ready`/`wip`). The
+    /// message names the offending transition so an operator can pick a
+    /// valid intermediate hop.
+    #[error(
+        "illegal status transition for task {0}: {1} -> {2} is not allowed; \
+         use `task set-status {0} --to <status> --reason ...` to override"
+    )]
     IllegalTransition(TaskId, TaskStatus, TaskStatus),
 
     /// Precondition failure: the operation needs the task to currently be in a
@@ -18,7 +42,11 @@ pub enum DomainError {
     /// status is the bug, not the target.
     ///
     /// Args: `(task_id, required_current_status, actual_current_status)`.
-    #[error("task {0} requires status {1:?}, was {2:?}")]
+    #[error(
+        "task {0} requires status '{1}' but was '{2}'; \
+         advance it first (e.g. `task claim --epic <name>` for ready->wip) \
+         or use `task set-status {0} --to {1} --reason ...` to override"
+    )]
     RequiresStatus(TaskId, TaskStatus, TaskStatus),
 
     #[error("epic '{0}' already exists with status {1:?}")]
@@ -27,7 +55,10 @@ pub enum DomainError {
     #[error("dep references unknown task: {0}")]
     UnknownDepTarget(TaskId),
 
-    #[error("duplicate task id in plan: {0}")]
+    #[error(
+        "task id '{0}' already exists in store; \
+         use `task show {0}` to inspect or `task set-status {0} --to <status>` to override"
+    )]
     DuplicateTaskId(TaskId),
 
     #[error("inconsistency: {0}")]

--- a/plugins/github-autopilot/cli/src/domain/mod.rs
+++ b/plugins/github-autopilot/cli/src/domain/mod.rs
@@ -7,7 +7,7 @@ pub mod task_id;
 
 pub use deps::{CycleError, TaskGraph};
 pub use epic::{Epic, EpicStatus};
-pub use error::DomainError;
+pub use error::{DomainError, UserInputError};
 pub use event::{Event, EventKind};
 pub use task::{Task, TaskFailureOutcome, TaskSource, TaskStatus};
-pub use task_id::TaskId;
+pub use task_id::{TaskId, TaskIdParseError};

--- a/plugins/github-autopilot/cli/src/domain/task.rs
+++ b/plugins/github-autopilot/cli/src/domain/task.rs
@@ -60,6 +60,12 @@ impl TaskStatus {
     }
 }
 
+impl std::fmt::Display for TaskStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum TaskSource {

--- a/plugins/github-autopilot/cli/src/domain/task_id.rs
+++ b/plugins/github-autopilot/cli/src/domain/task_id.rs
@@ -21,9 +21,51 @@ impl TaskId {
         Self(raw.into())
     }
 
+    /// Validates that `raw` is shaped like a deterministic task id —
+    /// 12 lowercase hex characters — and returns a `TaskId`. Returns
+    /// `Err(TaskIdParseError)` with an actionable message otherwise.
+    ///
+    /// Use this on every CLI input boundary that mutates state (e.g.,
+    /// `task add <task_id>`, `task add-batch`) so a typo can't silently
+    /// insert a row whose id will never match the deterministic form.
+    /// Read-only paths (`task show`, `task release`, ...) may keep
+    /// using [`Self::from_raw`] — a missing-id lookup already surfaces
+    /// the typo without corrupting state.
+    pub fn parse(raw: &str) -> Result<Self, TaskIdParseError> {
+        if raw.len() != TASK_ID_HEX_LEN {
+            return Err(TaskIdParseError::InvalidLength {
+                got: raw.to_string(),
+                len: raw.len(),
+            });
+        }
+        if !raw
+            .chars()
+            .all(|c| c.is_ascii_digit() || matches!(c, 'a'..='f'))
+        {
+            return Err(TaskIdParseError::InvalidChars {
+                got: raw.to_string(),
+            });
+        }
+        Ok(Self(raw.to_string()))
+    }
+
     pub fn as_str(&self) -> &str {
         &self.0
     }
+}
+
+/// Length of a deterministic task id (lowercase hex prefix of SHA-256).
+pub const TASK_ID_HEX_LEN: usize = 12;
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum TaskIdParseError {
+    #[error(
+        "invalid task id '{got}': expected 12 lowercase hex characters (e.g. 'a1b2c3d4e5f6'), got {len} characters"
+    )]
+    InvalidLength { got: String, len: usize },
+
+    #[error("invalid task id '{got}': must contain only lowercase hex characters [0-9a-f]")]
+    InvalidChars { got: String },
 }
 
 impl std::fmt::Display for TaskId {
@@ -117,5 +159,48 @@ mod tests {
         assert_eq!(slug("hello   world!!!"), "hello-world");
         assert_eq!(slug("---abc---"), "abc");
         assert_eq!(slug("foo/bar.baz"), "foo-bar-baz");
+    }
+
+    #[test]
+    fn parse_accepts_canonical_form() {
+        let id = TaskId::parse("a1b2c3d4e5f6").unwrap();
+        assert_eq!(id.as_str(), "a1b2c3d4e5f6");
+    }
+
+    #[test]
+    fn parse_rejects_wrong_length() {
+        let err = TaskId::parse("abc").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("12 lowercase hex"), "msg: {msg}");
+        assert!(msg.contains("got 3 characters"), "msg: {msg}");
+    }
+
+    #[test]
+    fn parse_rejects_uppercase() {
+        let err = TaskId::parse("A1B2C3D4E5F6").unwrap_err();
+        assert!(err.to_string().contains("lowercase hex"));
+    }
+
+    #[test]
+    fn parse_rejects_non_hex_chars() {
+        let err = TaskId::parse("g1b2c3d4e5f6").unwrap_err();
+        assert!(err.to_string().contains("lowercase hex"));
+    }
+
+    #[test]
+    fn parse_rejects_typo() {
+        // The kind of input the task description warned about: an 11-char
+        // id (typo from copy/paste) should be rejected with an actionable
+        // length message rather than silently accepted by the store.
+        let err = TaskId::parse("a1b2c3d4e5f").unwrap_err();
+        assert!(err.to_string().contains("got 11 characters"));
+    }
+
+    #[test]
+    fn parse_accepts_deterministic_output() {
+        // The deterministic generator's output must round-trip through parse —
+        // that's the contract that makes parse() a safe gate on user input.
+        let id = TaskId::new_deterministic("e", "## section", "requirement");
+        TaskId::parse(id.as_str()).expect("deterministic id must parse");
     }
 }

--- a/plugins/github-autopilot/cli/tests/cli_e2e.rs
+++ b/plugins/github-autopilot/cli/tests/cli_e2e.rs
@@ -1,0 +1,114 @@
+//! End-to-end black-box tests for the `autopilot` binary.
+//!
+//! Unlike the in-process tests under `tests/*_tests.rs` (which construct
+//! `TaskService` directly and exercise pure Rust APIs), these tests **spawn
+//! the actual binary** via `assert_cmd`. They cover the `clap` argparse
+//! layer, the routing in `main.rs`, and the real `stdout` / `stderr` /
+//! exit-code surface that operators see — the gap C1 of `cli-ux-hardening`
+//! is filling.
+//!
+//! Each test owns a `TempDir` workspace and points the binary's SQLite
+//! store there via `AUTOPILOT_DB_PATH` (the env var honored by
+//! `task_store_db_path` in `main.rs`). The temp dir is also used as the
+//! process `current_dir` so that `Config::load` does not accidentally pick
+//! up an `autopilot.toml` from the developer's checkout.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+/// Isolated workspace for a single test invocation.
+///
+/// Holds a `TempDir` (kept alive for the duration of the test) and hands
+/// out fresh `Command` builders preconfigured with:
+/// - `AUTOPILOT_DB_PATH` -> `<tempdir>/state.db` so the SQLite store is
+///   private to this test.
+/// - `current_dir` set to the tempdir so the binary does not pick up the
+///   repository's `autopilot.toml` via the default lookup in
+///   `load_config`.
+///
+/// Designed so that follow-up tasks (C2/C3/C4) can write 1- to 2-line
+/// scenarios on top: `Workspace::new().cmd().args([...]).assert()...`.
+pub struct Workspace {
+    dir: TempDir,
+}
+
+impl Workspace {
+    /// Create a fresh isolated workspace.
+    pub fn new() -> Self {
+        let dir = TempDir::new().expect("create tempdir for autopilot e2e workspace");
+        Self { dir }
+    }
+
+    /// Path to the SQLite store this workspace will use. The binary
+    /// honors `AUTOPILOT_DB_PATH` (see `main.rs::task_store_db_path`) and
+    /// will create the file lazily on first command.
+    pub fn db_path(&self) -> std::path::PathBuf {
+        self.dir.path().join("state.db")
+    }
+
+    /// Build a fresh `Command` for the `autopilot` binary, scoped to this
+    /// workspace. Each call returns a new builder so callers may chain
+    /// `.args(...)` without leaking state between invocations.
+    pub fn cmd(&self) -> Command {
+        let mut cmd = Command::cargo_bin("autopilot").expect("locate `autopilot` cargo binary");
+        cmd.current_dir(self.dir.path())
+            .env("AUTOPILOT_DB_PATH", self.db_path());
+        cmd
+    }
+}
+
+impl Default for Workspace {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[test]
+fn e2e_help_subcommand_exits_zero() {
+    // Sanity: the binary boots, clap renders its help, exit code is 0,
+    // and stdout mentions the binary name. If this fails the harness
+    // itself is broken — every other e2e scenario depends on it.
+    let ws = Workspace::new();
+    ws.cmd()
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("autopilot"));
+}
+
+#[test]
+fn e2e_task_add_then_list_shows_task() {
+    // Happy-path round-trip across three commands sharing one SQLite
+    // store: `epic create` bootstraps the epic, `task add` inserts a
+    // watch-style task, `task list` renders it. Validates that argparse
+    // routing, the env-var-driven store path, and the task table format
+    // line up end-to-end. Subsequent C2/C3/C4 scenarios layer assertions
+    // about UX edges on top of this same shape.
+    let ws = Workspace::new();
+    let task_id = "abc123def456"; // 12 hex chars, matches deterministic id format
+    let title = "c1 demo task";
+
+    ws.cmd()
+        .args([
+            "epic",
+            "create",
+            "--name",
+            "demo",
+            "--spec",
+            "specs/demo.md",
+        ])
+        .assert()
+        .success();
+
+    ws.cmd()
+        .args(["task", "add", task_id, "--epic", "demo", "--title", title])
+        .assert()
+        .success();
+
+    ws.cmd()
+        .args(["task", "list", "--epic", "demo"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(task_id).and(predicate::str::contains(title)));
+}

--- a/plugins/github-autopilot/cli/tests/cli_e2e.rs
+++ b/plugins/github-autopilot/cli/tests/cli_e2e.rs
@@ -13,9 +13,11 @@
 //! process `current_dir` so that `Config::load` does not accidentally pick
 //! up an `autopilot.toml` from the developer's checkout.
 
+use std::io::Write;
+
 use assert_cmd::Command;
 use predicates::prelude::*;
-use tempfile::TempDir;
+use tempfile::{NamedTempFile, TempDir};
 
 /// Isolated workspace for a single test invocation.
 ///
@@ -111,4 +113,443 @@ fn e2e_task_add_then_list_shows_task() {
         .assert()
         .success()
         .stdout(predicate::str::contains(task_id).and(predicate::str::contains(title)));
+}
+
+// ---------- C2: command-surface lifecycle scenarios ----------
+//
+// The scenarios below exercise multi-command flows end-to-end, asserting that
+// adjacent subcommands compose naturally and that state transitions are
+// observable through the public CLI surface (no peeking at the SQLite file).
+// They are deliberately written against **current** behavior — sharp edges
+// (e.g. lax id validation, silent path acceptance) are flagged with
+// `TODO(C3)` so the validation pass can flip the assertion.
+
+/// 1. Full task lifecycle: epic create → task add → list (ready) → claim
+///    (Ready→Wip) → list (wip) → complete (Wip→Done) → list (done). Exercises
+///    every state transition the watch-style task takes through its life.
+#[test]
+fn e2e_task_lifecycle_full_flow() {
+    let ws = Workspace::new();
+    let task_id = "abc123def456";
+
+    ws.cmd()
+        .args([
+            "epic",
+            "create",
+            "--name",
+            "demo",
+            "--spec",
+            "specs/demo.md",
+        ])
+        .assert()
+        .success();
+
+    ws.cmd()
+        .args([
+            "task",
+            "add",
+            task_id,
+            "--epic",
+            "demo",
+            "--title",
+            "lifecycle task",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("inserted task"));
+
+    // Fresh watch task starts Ready (no deps).
+    ws.cmd()
+        .args(["task", "list", "--epic", "demo"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(task_id).and(predicate::str::contains("ready")));
+
+    // claim flips Ready -> Wip and renders the claimed task.
+    ws.cmd()
+        .args(["task", "claim", "--epic", "demo"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(task_id).and(predicate::str::contains("status:")));
+
+    ws.cmd()
+        .args(["task", "list", "--epic", "demo"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("wip"));
+
+    // complete flips Wip -> Done and reports unblocked dependents (none here).
+    ws.cmd()
+        .args(["task", "complete", task_id, "--pr", "42"])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("completed task")
+                .and(predicate::str::contains("newly ready: (none)")),
+        );
+
+    ws.cmd()
+        .args(["task", "list", "--epic", "demo"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("done"));
+
+    // Once Done, no more ready work — claim signals "no ready tasks" via exit 1.
+    ws.cmd()
+        .args(["task", "claim", "--epic", "demo"])
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains("no ready tasks"));
+}
+
+/// 2. `task add` is fingerprint-idempotent: re-adding the same fingerprint
+///    (with a different task id, simulating a watcher firing twice) does not
+///    create a duplicate row, exits 0, and reports "duplicate of <id>". The
+///    final `task list` shows one task, not two.
+///
+/// TODO(C3): exit code is 0 for "duplicate fingerprint, different id" but 1
+/// for "duplicate id" — both are arguably "already present". C3 should
+/// decide whether to unify these and/or surface the distinction explicitly.
+#[test]
+fn e2e_task_add_same_fingerprint_is_idempotent() {
+    let ws = Workspace::new();
+
+    ws.cmd()
+        .args([
+            "epic",
+            "create",
+            "--name",
+            "demo",
+            "--spec",
+            "specs/demo.md",
+        ])
+        .assert()
+        .success();
+
+    let fingerprint = "0xDEADBEEFCAFEBABE";
+
+    ws.cmd()
+        .args([
+            "task",
+            "add",
+            "aaa111aaa111",
+            "--epic",
+            "demo",
+            "--title",
+            "first watcher hit",
+            "--fingerprint",
+            fingerprint,
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("inserted task aaa111aaa111"));
+
+    // Same fingerprint, fresh id — store recognizes the dedup and reports it
+    // as a duplicate of the original. Exit 0: this is the happy "watcher fired
+    // again, no new work" path, not a user error.
+    ws.cmd()
+        .args([
+            "task",
+            "add",
+            "bbb222bbb222",
+            "--epic",
+            "demo",
+            "--title",
+            "second watcher hit (same fingerprint)",
+            "--fingerprint",
+            fingerprint,
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("duplicate of task aaa111aaa111"));
+
+    // Only one task should be visible in the list — the second add was deduped.
+    ws.cmd()
+        .args(["task", "list", "--epic", "demo"])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("aaa111aaa111")
+                .and(predicate::str::contains("bbb222bbb222").not()),
+        );
+}
+
+/// 3. Epic lifecycle: create → get (active) → status (zeroed counts) →
+///    complete → get (completed, with completed_at) → list filtered by
+///    `--status active` (empty) and `--status completed` (shows it). The
+///    binary has no separate `activate` step — `epic create` produces an
+///    Active epic directly, so the natural lifecycle is create → use →
+///    complete (or abandon).
+#[test]
+fn e2e_epic_create_status_complete_flow() {
+    let ws = Workspace::new();
+
+    ws.cmd()
+        .args([
+            "epic",
+            "create",
+            "--name",
+            "demo",
+            "--spec",
+            "specs/demo.md",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("epic 'demo' created"));
+
+    // TODO(C3): `epic create --spec` accepts a path that does not exist on
+    // disk. C3 should decide whether to validate or document the behavior.
+
+    ws.cmd()
+        .args(["epic", "get", "demo"])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("name:")
+                .and(predicate::str::contains("demo"))
+                .and(predicate::str::contains("status:"))
+                .and(predicate::str::contains("active")),
+        );
+
+    // Empty epic — every status bucket should be 0.
+    ws.cmd()
+        .args(["epic", "status", "demo"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("demo").and(predicate::str::contains("active")));
+
+    ws.cmd()
+        .args(["epic", "complete", "demo"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("epic 'demo' completed"));
+
+    // After completion, `get` reflects the new status and surfaces completed_at.
+    ws.cmd()
+        .args(["epic", "get", "demo"])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("completed").and(predicate::str::contains("completed_at:")),
+        );
+
+    // Filtering by status: completed epic disappears from `--status active`
+    // and reappears under `--status completed`.
+    ws.cmd()
+        .args(["epic", "list", "--status", "active"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("(no epics)"));
+
+    ws.cmd()
+        .args(["epic", "list", "--status", "completed"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("demo"));
+}
+
+/// 4. Block / unblock: a child task that depends on a parent starts Pending
+///    and is **not** claimable; only the parent (Ready) gets claimed. Once
+///    the parent is `complete`d, the store auto-promotes the child to Ready
+///    (reported on the completion line as "newly ready: <child>") and the
+///    next `claim` picks it up.
+///
+///    Note: the binary surfaces deps only via `epic reconcile <plan.jsonl>`
+///    — `task add` itself has no `--blocked-by` flag (deps come from spec
+///    decomposition, never from watcher inserts). This test uses the JSONL
+///    plan that `reconcile` consumes to set up the dependency.
+#[test]
+fn e2e_blocked_task_becomes_claimable_after_parent_completes() {
+    let ws = Workspace::new();
+
+    ws.cmd()
+        .args([
+            "epic",
+            "create",
+            "--name",
+            "demo",
+            "--spec",
+            "specs/demo.md",
+        ])
+        .assert()
+        .success();
+
+    // Reconcile plan: parent (aaaa) and child (bbbb) where bbbb depends on aaaa.
+    let mut plan_file = NamedTempFile::new().expect("create reconcile plan tempfile");
+    writeln!(
+        plan_file,
+        r#"{{"kind":"task","id":"aaaaaaaaaaaa","title":"parent","source":"decompose"}}"#
+    )
+    .unwrap();
+    writeln!(
+        plan_file,
+        r#"{{"kind":"task","id":"bbbbbbbbbbbb","title":"child","source":"decompose"}}"#
+    )
+    .unwrap();
+    writeln!(
+        plan_file,
+        r#"{{"kind":"dep","task":"bbbbbbbbbbbb","depends_on":"aaaaaaaaaaaa"}}"#
+    )
+    .unwrap();
+    plan_file.flush().unwrap();
+
+    ws.cmd()
+        .args([
+            "epic",
+            "reconcile",
+            "--name",
+            "demo",
+            "--plan",
+            plan_file.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    // Parent starts Ready, child starts Pending (blocked on parent).
+    ws.cmd()
+        .args(["task", "list", "--epic", "demo", "--status", "ready"])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("aaaaaaaaaaaa")
+                .and(predicate::str::contains("bbbbbbbbbbbb").not()),
+        );
+    ws.cmd()
+        .args(["task", "list", "--epic", "demo", "--status", "pending"])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("bbbbbbbbbbbb")
+                .and(predicate::str::contains("aaaaaaaaaaaa").not()),
+        );
+
+    // First claim picks up only the parent.
+    ws.cmd()
+        .args(["task", "claim", "--epic", "demo"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("aaaaaaaaaaaa"));
+
+    // Second claim — child is still Pending, so claim signals "no ready" via exit 1.
+    ws.cmd()
+        .args(["task", "claim", "--epic", "demo"])
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains("no ready tasks"));
+
+    // Completing the parent unblocks the child. The completion line itself
+    // surfaces the newly-ready set — agents rely on this to chain work.
+    ws.cmd()
+        .args(["task", "complete", "aaaaaaaaaaaa", "--pr", "7"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("newly ready: bbbbbbbbbbbb"));
+
+    // Now the child is claimable.
+    ws.cmd()
+        .args(["task", "claim", "--epic", "demo"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("bbbbbbbbbbbb"));
+}
+
+/// 5. `task list` filter sanity: `--epic` scopes to one epic, `--status`
+///    narrows further. Two epics with mixed-status tasks make the filter
+///    semantics observable in a single workspace.
+#[test]
+fn e2e_task_list_filters_by_epic_and_status() {
+    let ws = Workspace::new();
+
+    for epic in ["alpha", "beta"] {
+        ws.cmd()
+            .args([
+                "epic",
+                "create",
+                "--name",
+                epic,
+                "--spec",
+                &format!("specs/{epic}.md"),
+            ])
+            .assert()
+            .success();
+    }
+
+    // Two tasks on alpha (one will be claimed -> Wip), one on beta (stays Ready).
+    ws.cmd()
+        .args([
+            "task",
+            "add",
+            "aaa000000001",
+            "--epic",
+            "alpha",
+            "--title",
+            "alpha-1",
+        ])
+        .assert()
+        .success();
+    ws.cmd()
+        .args([
+            "task",
+            "add",
+            "aaa000000002",
+            "--epic",
+            "alpha",
+            "--title",
+            "alpha-2",
+        ])
+        .assert()
+        .success();
+    ws.cmd()
+        .args([
+            "task",
+            "add",
+            "bbb000000001",
+            "--epic",
+            "beta",
+            "--title",
+            "beta-1",
+        ])
+        .assert()
+        .success();
+
+    // Claim one task on alpha so we have at least one Wip and one Ready under alpha.
+    ws.cmd()
+        .args(["task", "claim", "--epic", "alpha"])
+        .assert()
+        .success();
+
+    // --epic alpha must not leak the beta task.
+    ws.cmd()
+        .args(["task", "list", "--epic", "alpha"])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("aaa000000001")
+                .and(predicate::str::contains("aaa000000002"))
+                .and(predicate::str::contains("bbb000000001").not()),
+        );
+
+    // --status ready under alpha shows exactly the un-claimed alpha task.
+    ws.cmd()
+        .args(["task", "list", "--epic", "alpha", "--status", "ready"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("ready"));
+
+    // --status wip under alpha shows exactly the claimed task.
+    ws.cmd()
+        .args(["task", "list", "--epic", "alpha", "--status", "wip"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("wip"));
+
+    // --epic beta is independent — only the beta task surfaces.
+    ws.cmd()
+        .args(["task", "list", "--epic", "beta"])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("bbb000000001")
+                .and(predicate::str::contains("aaa000000001").not()),
+        );
 }

--- a/plugins/github-autopilot/cli/tests/cli_e2e.rs
+++ b/plugins/github-autopilot/cli/tests/cli_e2e.rs
@@ -17,6 +17,7 @@ use std::io::Write;
 
 use assert_cmd::Command;
 use predicates::prelude::*;
+use serde_json::Value;
 use tempfile::{NamedTempFile, TempDir};
 
 /// Isolated workspace for a single test invocation.
@@ -57,6 +58,19 @@ impl Workspace {
         cmd.current_dir(self.dir.path())
             .env("AUTOPILOT_DB_PATH", self.db_path());
         cmd
+    }
+
+    /// Create an empty file at `relative_path` inside the workspace,
+    /// creating parent directories as needed. Useful for satisfying
+    /// `epic create`'s "spec file must exist" precondition without
+    /// hard-coding contents the ledger never reads.
+    pub fn touch(&self, relative_path: &str) -> std::path::PathBuf {
+        let abs = self.dir.path().join(relative_path);
+        if let Some(parent) = abs.parent() {
+            std::fs::create_dir_all(parent).expect("create parent dirs for spec file");
+        }
+        std::fs::File::create(&abs).expect("create spec file");
+        abs
     }
 }
 
@@ -552,4 +566,499 @@ fn e2e_task_list_filters_by_epic_and_status() {
             predicate::str::contains("bbb000000001")
                 .and(predicate::str::contains("aaa000000001").not()),
         );
+}
+
+// ---------------------------------------------------------------------------
+// JSON output schema lock-in (C4)
+// ---------------------------------------------------------------------------
+//
+// Agents that integrate with this CLI parse the `--json` payloads — every
+// field rename, removal, or type change is a breaking change for them.
+// The tests below assert each documented field explicitly so that any such
+// shift forces an explicit update here, rather than silently slipping
+// through. Snapshot libraries are deliberately avoided: the verbosity is
+// the lock.
+//
+// Non-deterministic fields (timestamps, sub-second-derived ids) are
+// asserted only by type / format, not by exact value.
+
+/// Helper: capture stdout from `cmd` and parse it as JSON. Panics with
+/// useful context if the binary did not exit 0 or the output was not JSON.
+fn run_json(cmd: &mut Command) -> Value {
+    let output = cmd.output().expect("spawn autopilot binary");
+    assert!(
+        output.status.success(),
+        "expected exit 0, got {:?}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("stdout utf-8");
+    serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("stdout was not JSON: {e}\nstdout:\n{stdout}"))
+}
+
+/// Bring up an epic + a single Ready task in `ws`, returning the task id.
+/// Used by the schema tests as the minimal shared scaffolding.
+fn seed_epic_with_task(ws: &Workspace, epic: &str, task_id: &str, title: &str) {
+    let spec_rel = format!("specs/{epic}.md");
+    // `epic create` requires the spec file to exist on disk; the ledger
+    // never reads it, so an empty stub is enough.
+    ws.touch(&spec_rel);
+    ws.cmd()
+        .args(["epic", "create", "--name", epic, "--spec", &spec_rel])
+        .assert()
+        .success();
+    ws.cmd()
+        .args([
+            "task",
+            "add",
+            task_id,
+            "--epic",
+            epic,
+            "--title",
+            title,
+            "--body",
+            "demo body",
+        ])
+        .assert()
+        .success();
+}
+
+/// Assert the field set of the canonical `Task` JSON shape (used by
+/// `task list`, `task get`, `task list-stale`, `task claim`,
+/// `task find-by-pr`). Centralized so a Task field rename forces *one*
+/// explicit edit visible across every consumer test.
+fn assert_task_shape(task: &Value, expected_id: &str, expected_epic: &str, expected_title: &str) {
+    // ---- string fields with stable values ----
+    assert_eq!(task["id"], expected_id, "task.id");
+    assert_eq!(task["epic_name"], expected_epic, "task.epic_name");
+    assert_eq!(task["title"], expected_title, "task.title");
+
+    // ---- enum-ish strings (value range pinned at the assertion site) ----
+    assert!(task["source"].is_string(), "task.source must be string");
+    assert!(task["status"].is_string(), "task.status must be string");
+
+    // ---- numbers ----
+    assert!(
+        task["attempts"].is_u64(),
+        "task.attempts must be unsigned int, got {:?}",
+        task["attempts"]
+    );
+
+    // ---- nullable strings / numbers — type lock only ----
+    assert!(
+        task["fingerprint"].is_string() || task["fingerprint"].is_null(),
+        "task.fingerprint must be string-or-null"
+    );
+    assert!(
+        task["body"].is_string() || task["body"].is_null(),
+        "task.body must be string-or-null"
+    );
+    assert!(
+        task["branch"].is_string() || task["branch"].is_null(),
+        "task.branch must be string-or-null"
+    );
+    assert!(
+        task["pr_number"].is_u64() || task["pr_number"].is_null(),
+        "task.pr_number must be unsigned int-or-null"
+    );
+    assert!(
+        task["escalated_issue"].is_u64() || task["escalated_issue"].is_null(),
+        "task.escalated_issue must be unsigned int-or-null"
+    );
+
+    // ---- timestamps — RFC3339 strings, exact value not pinned ----
+    let created_at = task["created_at"].as_str().expect("task.created_at string");
+    assert!(
+        chrono::DateTime::parse_from_rfc3339(created_at).is_ok(),
+        "task.created_at not RFC3339: {created_at}"
+    );
+    let updated_at = task["updated_at"].as_str().expect("task.updated_at string");
+    assert!(
+        chrono::DateTime::parse_from_rfc3339(updated_at).is_ok(),
+        "task.updated_at not RFC3339: {updated_at}"
+    );
+}
+
+#[test]
+fn json_schema_task_list() {
+    // Lock: `task list --json` -> JSON array of Task objects with the
+    // canonical field set. Initial `task add` produces a Ready task with
+    // attempts=0 and source=human (per the `--source` default).
+    let ws = Workspace::new();
+    let task_id = "abc123def456";
+    let title = "schema demo";
+    seed_epic_with_task(&ws, "demo", task_id, title);
+
+    let json = run_json(ws.cmd().args(["task", "list", "--epic", "demo", "--json"]));
+
+    assert!(json.is_array(), "task list --json must emit a JSON array");
+    let tasks = json.as_array().unwrap();
+    assert_eq!(tasks.len(), 1, "exactly one task seeded");
+
+    let task = &tasks[0];
+    assert_task_shape(task, task_id, "demo", title);
+    assert_eq!(task["status"], "ready");
+    assert_eq!(task["source"], "human");
+    assert_eq!(task["attempts"], 0);
+    assert_eq!(task["body"], "demo body");
+    assert!(task["branch"].is_null());
+    assert!(task["pr_number"].is_null());
+    assert!(task["escalated_issue"].is_null());
+}
+
+#[test]
+fn json_schema_task_get() {
+    // Lock: `task get --json` -> single Task object. Same field set as
+    // `task list` elements (both go through `render_task`).
+    let ws = Workspace::new();
+    let task_id = "abc123def456";
+    let title = "schema demo";
+    seed_epic_with_task(&ws, "demo", task_id, title);
+
+    let json = run_json(ws.cmd().args(["task", "get", task_id, "--json"]));
+
+    assert!(json.is_object(), "task get --json must emit a JSON object");
+    assert_task_shape(&json, task_id, "demo", title);
+    assert_eq!(json["status"], "ready");
+    assert_eq!(json["attempts"], 0);
+}
+
+#[test]
+fn json_schema_task_claim() {
+    // Lock: `task claim --json` -> single Task object, status flipped to
+    // "wip" and attempts incremented to 1. Schema is identical to
+    // `task get`, but we additionally pin the post-claim values.
+    let ws = Workspace::new();
+    let task_id = "abc123def456";
+    let title = "claim demo";
+    seed_epic_with_task(&ws, "demo", task_id, title);
+
+    let json = run_json(ws.cmd().args(["task", "claim", "--epic", "demo", "--json"]));
+
+    assert!(json.is_object());
+    assert_task_shape(&json, task_id, "demo", title);
+    assert_eq!(json["status"], "wip", "claim must transition to wip");
+    assert_eq!(json["attempts"], 1, "claim must increment attempts");
+}
+
+#[test]
+fn json_schema_task_list_stale() {
+    // Lock: `task list-stale --json` -> JSON array of Task objects. Same
+    // shape as `task list`, just filtered to stale Wip claims. Empty case
+    // is `[]` (always-emitted, even when no candidates) — that's also
+    // part of the contract agents rely on.
+    let ws = Workspace::new();
+    let task_id = "abc123def456";
+    let title = "stale demo";
+    seed_epic_with_task(&ws, "demo", task_id, title);
+
+    // Empty case: nothing is Wip yet.
+    let empty = run_json(
+        ws.cmd()
+            .args(["task", "list-stale", "--before", "1s", "--json"]),
+    );
+    assert!(empty.is_array(), "list-stale --json must emit an array");
+    assert_eq!(empty.as_array().unwrap().len(), 0, "no Wip tasks => empty");
+
+    // Populate: claim flips Ready -> Wip with updated_at = now.
+    ws.cmd()
+        .args(["task", "claim", "--epic", "demo"])
+        .assert()
+        .success();
+
+    // Wait long enough that the Wip claim is older than the cutoff.
+    std::thread::sleep(std::time::Duration::from_millis(1100));
+
+    let json = run_json(
+        ws.cmd()
+            .args(["task", "list-stale", "--before", "1s", "--json"]),
+    );
+    assert!(json.is_array());
+    let stale = json.as_array().unwrap();
+    assert_eq!(stale.len(), 1, "one stale Wip task expected");
+    assert_task_shape(&stale[0], task_id, "demo", title);
+    assert_eq!(stale[0]["status"], "wip");
+}
+
+#[test]
+fn json_schema_task_release_stale() {
+    // Lock: `task release-stale --json` -> JSON **array of task id
+    // strings**, NOT an array of Task objects. This is the one place the
+    // CLI emits a "thin" id list rather than full Task records, so we
+    // pin both shape and element type.
+    let ws = Workspace::new();
+    let task_id = "abc123def456";
+    seed_epic_with_task(&ws, "demo", task_id, "release-stale demo");
+    ws.cmd()
+        .args(["task", "claim", "--epic", "demo"])
+        .assert()
+        .success();
+    std::thread::sleep(std::time::Duration::from_millis(1100));
+
+    let json = run_json(
+        ws.cmd()
+            .args(["task", "release-stale", "--before", "1s", "--json"]),
+    );
+    assert!(
+        json.is_array(),
+        "release-stale --json must emit an array of ids"
+    );
+    let ids = json.as_array().unwrap();
+    assert_eq!(ids.len(), 1, "one task should be released");
+    let id = ids[0]
+        .as_str()
+        .expect("release-stale --json elements must be strings");
+    assert_eq!(id, task_id);
+}
+
+#[test]
+fn json_schema_task_find_by_pr() {
+    // Lock: `task find-by-pr --json` -> single Task object. After
+    // `task complete`, the task carries pr_number == requested PR and
+    // status == "done"; everything else stays canonical.
+    let ws = Workspace::new();
+    let task_id = "abc123def456";
+    seed_epic_with_task(&ws, "demo", task_id, "pr demo");
+    ws.cmd()
+        .args(["task", "claim", "--epic", "demo"])
+        .assert()
+        .success();
+    ws.cmd()
+        .args(["task", "complete", task_id, "--pr", "42"])
+        .assert()
+        .success();
+
+    let json = run_json(ws.cmd().args(["task", "find-by-pr", "42", "--json"]));
+    assert!(json.is_object());
+    assert_task_shape(&json, task_id, "demo", "pr demo");
+    assert_eq!(json["status"], "done");
+    assert_eq!(json["pr_number"], 42);
+}
+
+#[test]
+fn json_schema_task_fail() {
+    // Lock: `task fail` always emits JSON (no `--json` toggle): a
+    // {outcome, attempts} record. `outcome` is one of "retried" /
+    // "escalated"; `attempts` is u32. First failure on a fresh task is
+    // always "retried".
+    let ws = Workspace::new();
+    let task_id = "abc123def456";
+    seed_epic_with_task(&ws, "demo", task_id, "fail demo");
+    ws.cmd()
+        .args(["task", "claim", "--epic", "demo"])
+        .assert()
+        .success();
+
+    let json = run_json(ws.cmd().args(["task", "fail", task_id]));
+    assert!(json.is_object(), "task fail emits a JSON object");
+    assert_eq!(json["outcome"], "retried");
+    assert!(
+        json["attempts"].is_u64(),
+        "attempts must be unsigned int, got {:?}",
+        json["attempts"]
+    );
+    assert_eq!(json["attempts"], 1);
+}
+
+/// Assert the canonical `Epic` JSON shape (used by `epic list`,
+/// `epic get`, `epic find-by-spec-path`).
+fn assert_epic_shape(epic: &Value, expected_name: &str) {
+    assert_eq!(epic["name"], expected_name, "epic.name");
+    // `spec_path` serializes via `PathBuf`'s Display, which on Unix is the
+    // raw path string. We pin the type, not the absolute exact value, since
+    // path normalization may differ across platforms.
+    assert!(
+        epic["spec_path"].is_string(),
+        "epic.spec_path must be string"
+    );
+    assert!(epic["branch"].is_string(), "epic.branch must be string");
+    assert!(epic["status"].is_string(), "epic.status must be string");
+    let created_at = epic["created_at"].as_str().expect("epic.created_at string");
+    assert!(
+        chrono::DateTime::parse_from_rfc3339(created_at).is_ok(),
+        "epic.created_at not RFC3339: {created_at}"
+    );
+    // `completed_at` is null while the epic is active; type lock only.
+    assert!(
+        epic["completed_at"].is_string() || epic["completed_at"].is_null(),
+        "epic.completed_at must be RFC3339 string-or-null"
+    );
+}
+
+#[test]
+fn json_schema_epic_list() {
+    // Lock: `epic list --json` -> array of Epic objects.
+    let ws = Workspace::new();
+    seed_epic_with_task(&ws, "demo", "abc123def456", "epic-list demo");
+
+    let json = run_json(ws.cmd().args(["epic", "list", "--json"]));
+    assert!(json.is_array(), "epic list --json must emit array");
+    let epics = json.as_array().unwrap();
+    assert_eq!(epics.len(), 1);
+
+    let epic = &epics[0];
+    assert_epic_shape(epic, "demo");
+    assert_eq!(epic["status"], "active");
+    assert_eq!(epic["branch"], "epic/demo");
+    assert_eq!(epic["spec_path"], "specs/demo.md");
+    assert!(epic["completed_at"].is_null());
+}
+
+#[test]
+fn json_schema_epic_get() {
+    // Lock: `epic get <name> --json` -> single Epic object.
+    let ws = Workspace::new();
+    seed_epic_with_task(&ws, "demo", "abc123def456", "epic-get demo");
+
+    let json = run_json(ws.cmd().args(["epic", "get", "demo", "--json"]));
+    assert!(json.is_object());
+    assert_epic_shape(&json, "demo");
+    assert_eq!(json["status"], "active");
+    assert_eq!(json["branch"], "epic/demo");
+    assert_eq!(json["spec_path"], "specs/demo.md");
+}
+
+#[test]
+fn json_schema_epic_find_by_spec_path() {
+    // Lock: `epic find-by-spec-path <path> --json` -> single Epic object,
+    // identical schema to `epic get`.
+    let ws = Workspace::new();
+    seed_epic_with_task(&ws, "demo", "abc123def456", "find-by-spec demo");
+
+    let json = run_json(
+        ws.cmd()
+            .args(["epic", "find-by-spec-path", "specs/demo.md", "--json"]),
+    );
+    assert!(json.is_object());
+    assert_epic_shape(&json, "demo");
+    assert_eq!(json["status"], "active");
+}
+
+#[test]
+fn json_schema_epic_status() {
+    // Lock: `epic status --json` -> array of EpicStatusReport. Each
+    // element: { epic, status, total, counts: { pending, ready, wip,
+    // blocked, done, escalated } }. The seeded epic has exactly one
+    // Ready task, so total=1 and counts.ready=1; all others 0.
+    let ws = Workspace::new();
+    seed_epic_with_task(&ws, "demo", "abc123def456", "status demo");
+
+    let json = run_json(ws.cmd().args(["epic", "status", "--json"]));
+    assert!(json.is_array(), "epic status --json must emit array");
+    let reports = json.as_array().unwrap();
+    assert_eq!(reports.len(), 1);
+
+    let report = &reports[0];
+    assert_eq!(report["epic"], "demo");
+    assert_eq!(report["status"], "active");
+    // `total` is a usize on the Rust side; serializes as an unsigned int.
+    assert!(
+        report["total"].is_u64(),
+        "report.total must be unsigned int"
+    );
+    assert_eq!(report["total"], 1);
+
+    let counts = &report["counts"];
+    assert!(counts.is_object(), "report.counts must be object");
+    for field in ["pending", "ready", "wip", "blocked", "done", "escalated"] {
+        assert!(
+            counts[field].is_u64(),
+            "report.counts.{field} must be unsigned int, got {:?}",
+            counts[field]
+        );
+    }
+    assert_eq!(counts["pending"], 0);
+    assert_eq!(counts["ready"], 1);
+    assert_eq!(counts["wip"], 0);
+    assert_eq!(counts["blocked"], 0);
+    assert_eq!(counts["done"], 0);
+    assert_eq!(counts["escalated"], 0);
+}
+
+#[test]
+fn json_schema_events_list() {
+    // Lock: `events list --json` -> array of EventRecord objects.
+    // Schema: { at: RFC3339 string, kind: snake_case string, epic:
+    // string-or-null, task: string-or-null, payload: arbitrary JSON
+    // (object/null/etc.) }. We seed one epic + one task, then claim it,
+    // which should produce three deterministic event kinds in order:
+    // epic_started, task_inserted, task_claimed.
+    let ws = Workspace::new();
+    let task_id = "abc123def456";
+    seed_epic_with_task(&ws, "demo", task_id, "events demo");
+    ws.cmd()
+        .args(["task", "claim", "--epic", "demo"])
+        .assert()
+        .success();
+
+    let json = run_json(ws.cmd().args(["events", "list", "--json"]));
+    assert!(json.is_array(), "events list --json must emit array");
+    let events = json.as_array().unwrap();
+    assert_eq!(
+        events.len(),
+        3,
+        "expected epic_started + task_inserted + task_claimed, got {events:?}"
+    );
+
+    for ev in events {
+        // Per-event shape lock.
+        let at = ev["at"].as_str().expect("event.at string");
+        assert!(
+            chrono::DateTime::parse_from_rfc3339(at).is_ok(),
+            "event.at not RFC3339: {at}"
+        );
+        assert!(ev["kind"].is_string(), "event.kind must be string");
+        assert!(
+            ev["epic"].is_string() || ev["epic"].is_null(),
+            "event.epic must be string-or-null"
+        );
+        assert!(
+            ev["task"].is_string() || ev["task"].is_null(),
+            "event.task must be string-or-null"
+        );
+        // payload is intentionally untyped JSON (per Event struct); the
+        // contract is just "key present".
+        assert!(
+            ev.get("payload").is_some(),
+            "event.payload key must be present"
+        );
+    }
+
+    // Pin the canonical kinds + ordering. If a future refactor reorders or
+    // renames events, the failure here points straight at the regression.
+    assert_eq!(events[0]["kind"], "epic_started");
+    assert_eq!(events[0]["epic"], "demo");
+    assert!(events[0]["task"].is_null());
+
+    assert_eq!(events[1]["kind"], "task_inserted");
+    assert_eq!(events[1]["epic"], "demo");
+    assert_eq!(events[1]["task"], task_id);
+
+    assert_eq!(events[2]["kind"], "task_claimed");
+    assert_eq!(events[2]["epic"], "demo");
+    assert_eq!(events[2]["task"], task_id);
+}
+
+#[test]
+fn json_schema_task_list_header_behavior() {
+    // Lock current behavior: when `--json` is NOT passed, `task list`
+    // always prints the human-readable column header
+    // ("ID            STATUS     ATTEMPTS  TITLE"), regardless of
+    // tty / piping. The C4 brief surfaced this as a sharp edge — we
+    // pick option (b): keep current behavior, document it via this
+    // test, defer any `--no-header` / tty-detection work to a future
+    // epic. If the default ever flips, this test failure is the
+    // explicit signal that downstream agents (which today swallow the
+    // header line by string-matching) need to be revisited.
+    let ws = Workspace::new();
+    seed_epic_with_task(&ws, "demo", "abc123def456", "header demo");
+
+    ws.cmd()
+        .args(["task", "list", "--epic", "demo"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "ID            STATUS     ATTEMPTS  TITLE",
+        ));
 }

--- a/plugins/github-autopilot/cli/tests/mock_github.rs
+++ b/plugins/github-autopilot/cli/tests/mock_github.rs
@@ -1,12 +1,18 @@
 #![allow(dead_code)]
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use autopilot::github::{CompletedRun, GitHub, OpenIssue};
+use std::sync::Mutex;
 
 pub struct MockGitHub {
     default_branch: String,
     completed_runs: Vec<CompletedRun>,
     open_issues: Vec<OpenIssue>,
+    /// Remaining number of times `list_open_issues` should return Err.
+    /// Decremented on each call; reaches 0 → returns the configured Ok.
+    fail_issues_remaining: Mutex<u64>,
+    /// Remaining number of times `list_completed_runs` should return Err.
+    fail_runs_remaining: Mutex<u64>,
 }
 
 impl Default for MockGitHub {
@@ -21,6 +27,8 @@ impl MockGitHub {
             default_branch: "main".to_string(),
             completed_runs: vec![],
             open_issues: vec![],
+            fail_issues_remaining: Mutex::new(0),
+            fail_runs_remaining: Mutex::new(0),
         }
     }
 
@@ -38,6 +46,21 @@ impl MockGitHub {
         self.open_issues = issues;
         self
     }
+
+    /// Configures `list_open_issues` to return `Err(...)` for the next
+    /// `n` calls; subsequent calls behave normally and return the
+    /// configured issues. Used by resilience scenarios that simulate a
+    /// transient `gh` failure followed by recovery.
+    pub fn with_fail_issues_first_n(self, n: u64) -> Self {
+        *self.fail_issues_remaining.lock().unwrap() = n;
+        self
+    }
+
+    /// Same as `with_fail_issues_first_n` but for `list_completed_runs`.
+    pub fn with_fail_runs_first_n(self, n: u64) -> Self {
+        *self.fail_runs_remaining.lock().unwrap() = n;
+        self
+    }
 }
 
 impl GitHub for MockGitHub {
@@ -46,10 +69,20 @@ impl GitHub for MockGitHub {
     }
 
     fn list_completed_runs(&self, _limit: u64) -> Result<Vec<CompletedRun>> {
+        let mut remaining = self.fail_runs_remaining.lock().unwrap();
+        if *remaining > 0 {
+            *remaining -= 1;
+            bail!("simulated transient gh failure (list_completed_runs)");
+        }
         Ok(self.completed_runs.clone())
     }
 
     fn list_open_issues(&self, _limit: u64) -> Result<Vec<OpenIssue>> {
+        let mut remaining = self.fail_issues_remaining.lock().unwrap();
+        if *remaining > 0 {
+            *remaining -= 1;
+            bail!("simulated transient gh failure (list_open_issues)");
+        }
         Ok(self.open_issues.clone())
     }
 }

--- a/plugins/github-autopilot/cli/tests/store_conformance.rs
+++ b/plugins/github-autopilot/cli/tests/store_conformance.rs
@@ -342,9 +342,16 @@ fn body_release_claim_rejects_non_wip(store: Arc<dyn TaskStore>) {
     let err = store
         .release_claim(&TaskId::from_raw("A"), t0())
         .unwrap_err();
+    // C3 reworded RequiresStatus to lowercase canonical statuses with
+    // an actionable suffix (`task claim ...` / `task set-status ...`).
+    let msg = format!("{err}");
     assert!(
-        format!("{err}").contains("requires status Wip"),
-        "expected RequiresStatus(_, Wip, _), got: {err}"
+        msg.contains("requires status 'wip'"),
+        "expected RequiresStatus(_, Wip, _), got: {msg}"
+    );
+    assert!(
+        msg.contains("task claim") || msg.contains("set-status"),
+        "expected actionable hint in: {msg}"
     );
 }
 
@@ -418,7 +425,8 @@ fn body_complete_rejects_when_status_not_wip(store: Arc<dyn TaskStore>) {
     let err = store
         .complete_task_and_unblock(&TaskId::from_raw("A"), 1, t0())
         .unwrap_err();
-    assert!(format!("{err}").contains("requires status Wip"));
+    // Match the C3 lowercase canonical-status message.
+    assert!(format!("{err}").contains("requires status 'wip'"));
 }
 
 fn body_failure_below_max_returns_to_ready(store: Arc<dyn TaskStore>) {

--- a/plugins/github-autopilot/cli/tests/task_tests.rs
+++ b/plugins/github-autopilot/cli/tests/task_tests.rs
@@ -775,9 +775,12 @@ fn fail_from_ready_returns_requires_status_error() {
     let mut buf: Vec<u8> = Vec::new();
     let err = svc.fail("aaaaaaaaaaaa", &mut buf).unwrap_err();
     let msg = format!("{err:#}");
+    // C3: RequiresStatus message uses lowercase canonical statuses and an
+    // actionable suffix. Pin both halves so a future copy edit doesn't
+    // silently re-introduce the cryptic `Wip`/`Ready` debug form.
     assert!(
-        msg.contains("requires status Wip") && msg.contains("was Ready"),
-        "expected RequiresStatus(_, Wip, Ready), got: {msg}"
+        msg.contains("requires status 'wip'") && msg.contains("was 'ready'"),
+        "expected RequiresStatus(_, wip, ready), got: {msg}"
     );
 }
 
@@ -790,8 +793,8 @@ fn complete_from_ready_returns_requires_status_error() {
     let err = svc.complete("aaaaaaaaaaaa", 99, &mut buf).unwrap_err();
     let msg = format!("{err:#}");
     assert!(
-        msg.contains("requires status Wip") && msg.contains("was Ready"),
-        "expected RequiresStatus(_, Wip, Ready), got: {msg}"
+        msg.contains("requires status 'wip'") && msg.contains("was 'ready'"),
+        "expected RequiresStatus(_, wip, ready), got: {msg}"
     );
 }
 

--- a/plugins/github-autopilot/cli/tests/watch_scenarios.rs
+++ b/plugins/github-autopilot/cli/tests/watch_scenarios.rs
@@ -28,6 +28,7 @@ use std::sync::Arc;
 use autopilot::cmd::watch::ci::BranchFilter;
 use autopilot::cmd::watch::{TickState, WatchArgs, WatchEvent, WatchService};
 use autopilot::domain::{Epic, EpicStatus, TaskId, TaskSource, TaskStatus};
+use autopilot::fs::FsOps;
 use autopilot::ports::clock::{Clock, FixedClock};
 use autopilot::ports::task_store::{EpicPlan, NewTask, NewWatchTask, TaskStore};
 use autopilot::store::SqliteTaskStore;
@@ -35,6 +36,7 @@ use chrono::{DateTime, Duration, TimeZone, Utc};
 use mock_fs::MockFs;
 use mock_git::MockGit;
 use mock_github::MockGitHub;
+use std::collections::HashSet;
 use tempfile::TempDir;
 
 // ── Fixture ─────────────────────────────────────────────────────────────
@@ -594,5 +596,489 @@ fn scenario_two_epics_emit_independent_events() {
         dones,
         vec![("A", 1)],
         "only A is fully done; B has b2 open. got {evs:?}"
+    );
+}
+
+// ── Resilience helpers ──────────────────────────────────────────────────
+
+/// Returns the path the production code uses for `watch.json` when the
+/// repo name is `test-repo` (matching `MockGit::with_repo_name`).
+///
+/// The format is owned by `WatchService::state_path` — kept inline in
+/// production rather than exposed as a helper. Resilience scenarios that
+/// need to pre-seed `MockFs` with state must mirror that format here.
+fn watch_state_path() -> std::path::PathBuf {
+    std::path::PathBuf::from("/tmp/autopilot-test-repo/state/watch.json")
+}
+
+/// Per-tick env builder that lets resilience scenarios inject a custom
+/// `MockGitHub` and a pre-populated `MockFs`. The store + clock + args
+/// match `Fixture::new` for parity with the happy-path scenarios.
+struct ResilienceEnv {
+    _tmp: TempDir,
+    store: Arc<dyn TaskStore>,
+    clock: Arc<FixedClock>,
+    fs: MockFs,
+    svc: WatchService,
+    args: WatchArgs,
+    ts: TickState,
+}
+
+impl ResilienceEnv {
+    fn build(now: DateTime<Utc>, stale_secs: u64, github: MockGitHub, fs: MockFs) -> Self {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let db_path = tmp.path().join("autopilot.db");
+        let store: Arc<dyn TaskStore> =
+            Arc::new(SqliteTaskStore::open(&db_path).expect("open sqlite"));
+        let clock = Arc::new(FixedClock::new(now));
+        let github = Arc::new(github);
+        let git = MockGit::new().with_repo_name("test-repo");
+        let fs_clone = fs.clone();
+        let svc = WatchService::new(github, Box::new(git), Box::new(fs_clone))
+            .with_store(Arc::clone(&store))
+            .with_clock(Arc::clone(&clock) as Arc<_>);
+        let args = WatchArgs {
+            poll_sec: 0,
+            branch: "main".to_string(),
+            branch_filter: BranchFilter::All,
+            label_prefix: "autopilot:".to_string(),
+            stale_threshold: format!("{stale_secs}s"),
+            ledger_events: true,
+        };
+        let ts = svc.init_tick_state(&args).expect("init tick state");
+        Self {
+            _tmp: tmp,
+            store,
+            clock,
+            fs,
+            svc,
+            args,
+            ts,
+        }
+    }
+
+    fn tick(&mut self) -> Vec<WatchEvent> {
+        self.svc.tick_once(&mut self.ts, &self.args)
+    }
+
+    fn advance(&self, dur: Duration) {
+        self.clock.advance(dur);
+    }
+}
+
+fn new_issues(events: &[WatchEvent]) -> Vec<u64> {
+    events
+        .iter()
+        .filter_map(|e| match e {
+            WatchEvent::NewIssue { number, .. } => Some(*number),
+            _ => None,
+        })
+        .collect()
+}
+
+// ── Scenario 8 (resilience): GitHub fetch failure recovers ──────────────
+
+/// Tick N: `list_open_issues` returns `Err(...)` (transient gh failure).
+/// Tick N+1: same call returns Ok with an unseen issue. The daemon must
+/// not panic, must not corrupt persisted state, and must emit the
+/// `NEW_ISSUE` exactly once on the recovery tick — as if the failed tick
+/// had not happened.
+///
+/// Issues run on `ISSUE_TICK_INTERVAL` (every 12 ticks at base poll, but
+/// tick 0 always fires). We drive tick 0 with a failing mock and tick 12
+/// with a healthy mock by reconstructing the service — this mirrors how
+/// a real transient failure surfaces: state survives, dedupe set is
+/// rebuilt on next successful poll.
+#[test]
+fn scenario_github_fetch_failure_recovers_on_next_tick() {
+    // First service: failing on the first list_open_issues call.
+    let github_failing = MockGitHub::new().with_fail_issues_first_n(1);
+    let env = ResilienceEnv::build(t0(), 60, github_failing, MockFs::new());
+    let mut env = env;
+
+    // Tick 0 hits the failing list_open_issues path. The daemon must
+    // ignore the error (no panic) and emit no NEW_ISSUE. seen_issue_numbers
+    // also stays whatever init seeded it with (init's seeding path may
+    // also fail, leaving it empty).
+    let evs = env.tick();
+    assert!(
+        new_issues(&evs).is_empty(),
+        "failing list_open_issues must not emit NEW_ISSUE; got {evs:?}"
+    );
+
+    // Sanity: the failed tick must not corrupt watch.json.
+    // (No state-save tick has fired yet; verify no garbage was written.)
+    for (path, content) in env.fs.written_files() {
+        if path.ends_with("watch.json") {
+            // Anything written must be valid JSON.
+            serde_json::from_str::<serde_json::Value>(&content)
+                .expect("any persisted watch.json must be valid JSON");
+        }
+    }
+
+    // Second service: same store, healthy GitHub returning a fresh issue
+    // and one already-seen issue. Tick 0 of this service simulates "next
+    // tick" after recovery — it should emit NEW_ISSUE for the unseen
+    // issue and treat the seen issue as already known.
+    //
+    // We carry forward the prior `seen_issue_numbers` so the recovery
+    // tick's seeding does not silently swallow the new issue (mirroring
+    // the same pattern as `scenario_github_and_ledger_emit_in_same_tick`).
+    env.advance(Duration::seconds(5));
+    let healthy_issues = vec![
+        autopilot::github::OpenIssue {
+            number: 100,
+            title: "Pre-existing".to_string(),
+            labels: vec![],
+        },
+        autopilot::github::OpenIssue {
+            number: 101,
+            title: "Fresh after recovery".to_string(),
+            labels: vec![],
+        },
+    ];
+    // Pretend the prior daemon had already seen issue 100 (e.g. via an
+    // earlier successful poll the test doesn't simulate); only 101 is new.
+    let mut seen_carry: HashSet<u64> = HashSet::new();
+    seen_carry.insert(100);
+
+    let svc2 = WatchService::new(
+        Arc::new(MockGitHub::new().with_issues(healthy_issues)),
+        Box::new(MockGit::new().with_repo_name("test-repo")),
+        Box::new(MockFs::new()),
+    )
+    .with_store(Arc::clone(&env.store))
+    .with_clock(Arc::clone(&env.clock) as Arc<_>);
+    let mut ts2 = svc2.init_tick_state(&env.args).expect("init");
+    ts2.seen_issue_numbers = seen_carry;
+
+    let evs = svc2.tick_once(&mut ts2, &env.args);
+    assert_eq!(
+        new_issues(&evs),
+        vec![101],
+        "recovery tick must emit NEW_ISSUE 101 only; got {evs:?}"
+    );
+}
+
+// ── Scenario 9 (resilience): no prior watch.json ────────────────────────
+
+/// Pre-existing SQLite state (events from prior daemon runs) but no
+/// `watch.json` file at all. `init_tick_state` must seed cursors from
+/// `clock.now()` so historical ledger events are NOT replayed.
+#[test]
+fn scenario_no_prior_watch_json_does_not_replay_history() {
+    // Pre-populate SQLite with a completed task at t0.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let db_path = tmp.path().join("autopilot.db");
+    let store: Arc<dyn TaskStore> = Arc::new(SqliteTaskStore::open(&db_path).expect("open sqlite"));
+    let now = t0();
+    store
+        .insert_epic_with_tasks(
+            EpicPlan {
+                epic: epic("e9", now),
+                tasks: vec![new_task("t1", "T1")],
+                deps: vec![],
+            },
+            now,
+        )
+        .expect("insert");
+    store.claim_next_task("e9", now).expect("claim");
+    store
+        .complete_task_and_unblock(&TaskId::from_raw("t1"), 1, now)
+        .expect("complete");
+
+    // Fresh daemon: empty MockFs (load_state returns default), clock
+    // advanced past the historical events.
+    let later = now + Duration::seconds(60);
+    let clock = Arc::new(FixedClock::new(later));
+    let github = Arc::new(MockGitHub::new());
+    let git = MockGit::new().with_repo_name("test-repo");
+    let fs = MockFs::new(); // no watch.json present
+    assert!(
+        !fs.file_exists(&watch_state_path()),
+        "precondition: watch.json must not exist"
+    );
+    let svc = WatchService::new(github, Box::new(git), Box::new(fs))
+        .with_store(Arc::clone(&store))
+        .with_clock(Arc::clone(&clock) as Arc<_>);
+    let args = WatchArgs {
+        poll_sec: 0,
+        branch: "main".to_string(),
+        branch_filter: BranchFilter::All,
+        label_prefix: "autopilot:".to_string(),
+        stale_threshold: "60s".to_string(),
+        ledger_events: true,
+    };
+    let mut ts = svc.init_tick_state(&args).expect("init");
+
+    let evs = svc.tick_once(&mut ts, &args);
+    assert!(
+        ready(&evs).is_empty() && epic_done(&evs).is_empty(),
+        "fresh daemon with absent watch.json must not backfill history; got {evs:?}"
+    );
+}
+
+// ── Scenario 10 (resilience): corrupted watch.json ──────────────────────
+
+/// `watch.json` exists but is invalid JSON. Current behavior (documented
+/// here so the contract is explicit): `load_state` swallows the parse
+/// error and falls back to default, which means the daemon recovers
+/// silently — historical events are NOT replayed because the cursor is
+/// re-seeded to `now`.
+///
+/// This is a deliberate UX choice: a corrupted cursor file should not
+/// brick the daemon. If the policy ever changes (e.g. fail-loud), this
+/// test must change with it.
+#[test]
+fn scenario_corrupted_watch_json_recovers_gracefully() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let db_path = tmp.path().join("autopilot.db");
+    let store: Arc<dyn TaskStore> = Arc::new(SqliteTaskStore::open(&db_path).expect("open sqlite"));
+
+    // Pre-existing completed task — would replay if cursor were treated
+    // as "from beginning of time".
+    let now = t0();
+    store
+        .insert_epic_with_tasks(
+            EpicPlan {
+                epic: epic("e10", now),
+                tasks: vec![new_task("t1", "T1")],
+                deps: vec![],
+            },
+            now,
+        )
+        .expect("insert");
+    store.claim_next_task("e10", now).expect("claim");
+    store
+        .complete_task_and_unblock(&TaskId::from_raw("t1"), 1, now)
+        .expect("complete");
+
+    // MockFs pre-seeded with garbage at the watch.json path.
+    let fs = MockFs::new().with_file(
+        watch_state_path().to_str().expect("utf-8 watch.json path"),
+        "{this is not valid json,,,",
+    );
+    let later = now + Duration::seconds(60);
+    let clock = Arc::new(FixedClock::new(later));
+    let github = Arc::new(MockGitHub::new());
+    let git = MockGit::new().with_repo_name("test-repo");
+
+    let svc = WatchService::new(github, Box::new(git), Box::new(fs))
+        .with_store(Arc::clone(&store))
+        .with_clock(Arc::clone(&clock) as Arc<_>);
+    let args = WatchArgs {
+        poll_sec: 0,
+        branch: "main".to_string(),
+        branch_filter: BranchFilter::All,
+        label_prefix: "autopilot:".to_string(),
+        stale_threshold: "60s".to_string(),
+        ledger_events: true,
+    };
+
+    // init_tick_state must not panic on corrupted JSON.
+    let mut ts = svc.init_tick_state(&args).expect("init must not error");
+
+    // First tick: no replay, no panic.
+    let evs = svc.tick_once(&mut ts, &args);
+    assert!(
+        ready(&evs).is_empty() && epic_done(&evs).is_empty(),
+        "corrupted watch.json must fall back to fresh state, not replay; got {evs:?}"
+    );
+}
+
+// ── Scenario 11 (event integrity): same NEW_ISSUE seen twice ────────────
+
+/// `MockGitHub` returns the same open issue on tick 0 and the next
+/// issue-poll tick. The dedupe via `seen_issue_numbers` must ensure
+/// `NEW_ISSUE` is emitted at most once across both ticks.
+///
+/// Note: `init_tick_state` seeds `seen_issue_numbers` from the first
+/// successful `list_open_issues`, so a pre-existing issue is treated as
+/// already-known on tick 0. We start with an empty list, then introduce
+/// the issue between ticks — this is the closest analogue to "PR seen on
+/// two consecutive ticks" the watch surface supports.
+#[test]
+fn scenario_same_issue_seen_twice_emits_once() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let db = tmp.path().join("autopilot.db");
+    let store: Arc<dyn TaskStore> = Arc::new(SqliteTaskStore::open(&db).expect("open"));
+    let clock = Arc::new(FixedClock::new(t0()));
+    let args = WatchArgs {
+        poll_sec: 0,
+        branch: "main".to_string(),
+        branch_filter: BranchFilter::All,
+        label_prefix: "autopilot:".to_string(),
+        stale_threshold: "60s".to_string(),
+        ledger_events: true,
+    };
+
+    // First service: empty issue list at init time so seeding doesn't
+    // pre-mark anything.
+    let svc1 = WatchService::new(
+        Arc::new(MockGitHub::new()),
+        Box::new(MockGit::new().with_repo_name("test-repo")),
+        Box::new(MockFs::new()),
+    )
+    .with_store(Arc::clone(&store))
+    .with_clock(Arc::clone(&clock) as Arc<_>);
+    let mut ts1 = svc1.init_tick_state(&args).expect("init");
+    let _ = svc1.tick_once(&mut ts1, &args);
+
+    // Second service: introduces issue 7. First poll → emits NEW_ISSUE 7.
+    clock.advance(Duration::seconds(1));
+    let svc2 = WatchService::new(
+        Arc::new(
+            MockGitHub::new().with_issues(vec![autopilot::github::OpenIssue {
+                number: 7,
+                title: "First sighting".to_string(),
+                labels: vec![],
+            }]),
+        ),
+        Box::new(MockGit::new().with_repo_name("test-repo")),
+        Box::new(MockFs::new()),
+    )
+    .with_store(Arc::clone(&store))
+    .with_clock(Arc::clone(&clock) as Arc<_>);
+    let mut ts2 = svc2.init_tick_state(&args).expect("init");
+    ts2.seen_issue_numbers = ts1.seen_issue_numbers.clone(); // carry empty
+    let evs_first = svc2.tick_once(&mut ts2, &args);
+    assert_eq!(
+        new_issues(&evs_first),
+        vec![7],
+        "first sighting must emit NEW_ISSUE 7; got {evs_first:?}"
+    );
+
+    // Same issue persists on the next tick. With the standard tick
+    // intervals issue polling fires at tick % ISSUE_TICK_INTERVAL == 0;
+    // we drive the next poll explicitly by resetting tick to 0 (the
+    // service has no public API to fast-forward, so we rely on the fact
+    // that the seeded `seen_issue_numbers` already covers this case).
+    ts2.tick = 0; // force next tick to hit the issue-poll branch
+    let evs_second = svc2.tick_once(&mut ts2, &args);
+    assert!(
+        new_issues(&evs_second).is_empty(),
+        "duplicate sighting must not re-emit NEW_ISSUE; got {evs_second:?}"
+    );
+}
+
+// ── Scenario 12 (event integrity): ready→claim same tick, no STALE_WIP ──
+
+/// Two-part integrity guard for the "Ready → claim in the same tick
+/// window" race:
+///
+/// **Part A** — a task inserted and immediately claimed (both at the
+/// same logical `now`) before any tick fires. The detector reads
+/// **current** task status, so `TASK_READY` is intentionally suppressed
+/// for the already-Wip task (this is a deliberate design choice; the
+/// detector does not replay historical Ready transitions). What matters
+/// is the negative invariant: `STALE_WIP` MUST NOT fire, because the
+/// task's `updated_at` is `now`, not `now - threshold`.
+///
+/// **Part B** — a task whose `TASK_READY` already fired on tick N then
+/// gets claimed before tick N+1. Tick N+1 must emit neither `TASK_READY`
+/// (already emitted) nor `STALE_WIP` (just claimed).
+///
+/// This guards the time-ordering invariant: `STALE_WIP` derives from
+/// `list_stale(now - threshold)` over current Wip rows; a freshly
+/// claimed task must never qualify, regardless of how many ledger events
+/// fire on the same tick.
+#[test]
+fn scenario_ready_then_claim_same_tick_no_stale_wip() {
+    // ── Part A: insert + claim before any tick ──
+    let mut fx = Fixture::new(/*stale_secs=*/ 5);
+    ensure_epic(&fx.store, "e12a", fx.now());
+    fx.store
+        .upsert_watch_task(watch_task("t1", "e12a"), fx.now())
+        .expect("upsert");
+    fx.store
+        .claim_next_task("e12a", fx.now())
+        .expect("claim")
+        .expect("ready task to claim");
+
+    let evs = fx.tick();
+    assert!(
+        ready(&evs).is_empty(),
+        "TASK_READY must be suppressed when task is already Wip at observation time; got {evs:?}"
+    );
+    assert!(
+        stale(&evs).is_empty(),
+        "STALE_WIP must not fire for a task claimed `now`; got {evs:?}"
+    );
+
+    // ── Part B: insert → tick (READY) → claim → tick (no STALE_WIP) ──
+    let mut fx2 = Fixture::new(/*stale_secs=*/ 5);
+    ensure_epic(&fx2.store, "e12b", fx2.now());
+    fx2.store
+        .upsert_watch_task(watch_task("t2", "e12b"), fx2.now())
+        .expect("upsert");
+
+    let evs = fx2.tick();
+    assert_eq!(
+        ready(&evs),
+        vec![("e12b", "t2")],
+        "TASK_READY must fire on first tick when status is Ready; got {evs:?}"
+    );
+    assert!(stale(&evs).is_empty());
+
+    // External CLI claims between ticks; very little time passes.
+    fx2.advance(Duration::seconds(1));
+    fx2.store
+        .claim_next_task("e12b", fx2.now())
+        .expect("claim")
+        .expect("ready task to claim");
+
+    let evs = fx2.tick();
+    assert!(
+        ready(&evs).is_empty(),
+        "TASK_READY must not re-emit; got {evs:?}"
+    );
+    assert!(
+        stale(&evs).is_empty(),
+        "STALE_WIP must not fire for a task claimed within the threshold; got {evs:?}"
+    );
+}
+
+// ── Scenario 13 (event integrity): clock-skew protection ────────────────
+
+/// Documents a known limitation: if `last_event_at` in `watch.json` is
+/// somehow ahead of `clock.now()` (system clock moved backward, or the
+/// state file was copied from another machine), the SQLite query
+/// `at >= since` will silently filter out events whose `at == now`.
+/// `TASK_READY` / `EPIC_DONE` then stop firing until real time catches
+/// up to the stored future cursor.
+///
+/// Per the C5 task brief, this scenario is **deferred** — fixing it is a
+/// judgment call that should be made alongside a concrete recovery
+/// policy (e.g. clamp `since` to `min(last_event_at, now)`, or warn and
+/// re-anchor). The test below describes the desired behavior and is
+/// marked `#[ignore]` so CI passes while the policy is decided.
+///
+/// To reproduce the bug interactively, remove `#[ignore]` and run
+/// `cargo test -p autopilot scenario_clock_skew_does_not_freeze_emission`.
+#[test]
+#[ignore = "TODO(C5): clock-skew re-anchor policy not yet implemented; see PR body"]
+fn scenario_clock_skew_does_not_freeze_emission() {
+    let mut fx = Fixture::new(/*stale_secs=*/ 60);
+
+    // Force the ledger cursor into the future by 1 hour. In production
+    // this happens when the system clock jumps backward between daemon
+    // restarts.
+    fx.ts.state.ledger.last_event_at = Some(fx.now() + Duration::hours(1));
+
+    // Insert a task at the (logical) current time.
+    ensure_epic(&fx.store, "e13", fx.now());
+    fx.store
+        .upsert_watch_task(watch_task("t1", "e13"), fx.now())
+        .expect("upsert");
+
+    // Desired behavior: the daemon detects the future cursor, re-anchors
+    // to `now`, and emits TASK_READY for t1. Current behavior: the SQL
+    // filter `at >= since` excludes the freshly inserted row, and no
+    // event fires until real time catches up an hour later.
+    let evs = fx.tick();
+    assert_eq!(
+        ready(&evs),
+        vec![("e13", "t1")],
+        "clock-skew must not freeze TASK_READY emission; got {evs:?}"
     );
 }


### PR DESCRIPTION
## Summary

Closes the CLI UX hardening epic (`epic/cli-ux-hardening`). Adds end-to-end test infrastructure for the `autopilot` binary and uses it to lock down lifecycle flows, JSON output schemas, watch-daemon resilience, and domain-error recovery hints.

## What landed

| PR | Scope |
|----|-------|
| #705 | C1: e2e test infrastructure — `assert_cmd` + `predicates` dev-deps; `Workspace` helper (TempDir + `AUTOPILOT_DB_PATH` env + cwd pinning); 2 sanity scenarios |
| #706 | C2: 5 lifecycle scenarios — task add→list→claim→complete; idempotent dedup; epic create→activate→complete; blocked-task unblock via reconcile; `--epic` / `--status` filters |
| #707 | C4: 13 `--json` output schema lock-ins — `task list/get/claim/list-stale/release-stale/find-by-pr/fail`, `epic list/get/find-by-spec-path/status`, `events list`, plus tty-header behavior. Verbose field-by-field assertions, no snapshot lib |
| #708 | C5: watch daemon resilience — GitHub-fetch failure recovery, missing/corrupted `watch.json` graceful handling, dedup across consecutive ticks, ready-then-claim same-tick interaction. One ignored scenario documents a clock-skew bug for follow-up |
| #709 | C3: domain validation foundation — `TaskId::parse` (12-hex validator), `UserInputError` marker, recovery hints in `IllegalTransition` / `RequiresStatus` |

## Follow-ups (not blocking this rollup)

C3 introduced validation primitives but did not wire them into the CLI surface — committed as foundation in #709 with the wiring left explicit:

- Wire `TaskId::parse` into `cmd::task::add` so a typoed id fails at the boundary instead of silently inserting garbage.
- Validate `--spec` path existence in `cmd::epic::create` before inserting the epic row.
- Add e2e scenarios in `cli_e2e.rs` locking stderr text + exit code for the wired paths above.

Other surfaced edges captured in PR bodies above: clock-skew freeze in `WatchService` (#708 ignored test), payload-untyped events shape (#707 PR body), `release-stale --json` vs `list-stale --json` shape asymmetry (#707).

## Test plan

- [x] All 5 sub-PRs passed quality gate (fmt / clippy / test) at merge time
- [x] Full `cargo test -p autopilot` green on epic tip
- [x] `cli_e2e.rs` totals 20 tests (7 lifecycle + 13 JSON schema), all passing
- [x] `watch_scenarios.rs` totals 13 (12 active + 1 ignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)