### PR TITLE
feat(github-autopilot): wire input validation into CLI commands

### DIFF
--- a/plugins/github-autopilot/cli/Cargo.lock
+++ b/plugins/github-autopilot/cli/Cargo.lock
@@ -111,7 +111,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autopilot"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/plugins/github-autopilot/cli/src/cmd/epic.rs
+++ b/plugins/github-autopilot/cli/src/cmd/epic.rs
@@ -141,6 +141,11 @@ impl<'a> EpicService<'a> {
     /// `idempotent` is true *and* its `spec_path` matches the requested one.
     /// A name collision with a different spec path is still reported as an
     /// error (exit 1) — semantic mismatch must not be silently accepted.
+    ///
+    /// Validates that `spec_path` exists on disk before any store mutation —
+    /// a typo'd `--spec` argument would otherwise silently land an epic
+    /// pointing at nothing. Returns a [`UserInputError`] (exit code 1) when
+    /// the path is missing.
     pub fn create_with_options(
         &self,
         name: &str,
@@ -149,6 +154,14 @@ impl<'a> EpicService<'a> {
         idempotent: bool,
         out: &mut dyn Write,
     ) -> Result<i32> {
+        if !spec_path.try_exists().unwrap_or(false) {
+            return Err(anyhow::Error::new(crate::domain::UserInputError::new(
+                format!(
+                    "epic create: spec file '{}' does not exist",
+                    spec_path.display()
+                ),
+            )));
+        }
         let now = self.clock.now();
         let epic = Epic {
             name: name.to_string(),

--- a/plugins/github-autopilot/cli/src/cmd/task.rs
+++ b/plugins/github-autopilot/cli/src/cmd/task.rs
@@ -165,6 +165,13 @@ impl<'a> TaskService<'a> {
     /// Inserts (or detects duplicate of) a watch-style task on `epic`.
     /// Auto-derives a fingerprint from `title + body` when `fingerprint` is
     /// `None`, so callers don't need to mirror the simhash recipe.
+    ///
+    /// Validates `task_id` via [`TaskId::parse`] before any store mutation
+    /// so a typoed id is rejected as a `UserInputError` (exit code 1) rather
+    /// than silently inserting a row whose id will never match the
+    /// deterministic form. Read-only lookups (`task show`, `task release`,
+    /// ...) keep using [`TaskId::from_raw`] — there a missing-id lookup
+    /// already surfaces the typo without corrupting state.
     #[allow(clippy::too_many_arguments)]
     pub fn add(
         &self,
@@ -176,12 +183,14 @@ impl<'a> TaskService<'a> {
         source: TaskSourceArg,
         out: &mut dyn Write,
     ) -> Result<i32> {
+        let id = TaskId::parse(task_id)
+            .map_err(|e| anyhow::Error::new(crate::domain::UserInputError::new(e.to_string())))?;
         let now = self.clock.now();
         let fp = fingerprint
             .map(str::to_string)
             .unwrap_or_else(|| derive_fingerprint(title, body));
         let nt = NewWatchTask {
-            id: TaskId::from_raw(task_id),
+            id,
             epic_name: epic.to_string(),
             source: source.into(),
             fingerprint: fp,
@@ -231,13 +240,20 @@ impl<'a> TaskService<'a> {
                 })?,
                 None => TaskSource::Human,
             };
+            let id = TaskId::parse(&parsed.id).map_err(|e| {
+                anyhow::Error::new(crate::domain::UserInputError::new(format!(
+                    "{} (line {})",
+                    e,
+                    lineno + 1
+                )))
+            })?;
             let title = parsed.title;
             let body = parsed.body;
             let fp = parsed
                 .fingerprint
                 .unwrap_or_else(|| derive_fingerprint(&title, body.as_deref()));
             let nt = NewWatchTask {
-                id: TaskId::from_raw(&parsed.id),
+                id,
                 epic_name: epic.to_string(),
                 source,
                 fingerprint: fp,

--- a/plugins/github-autopilot/cli/src/main.rs
+++ b/plugins/github-autopilot/cli/src/main.rs
@@ -3,7 +3,7 @@ use autopilot::cmd::{
     StatsCommands, TaskCommands, WorktreeCommands,
 };
 use autopilot::config::Config;
-use autopilot::domain::DomainError;
+use autopilot::domain::{DomainError, UserInputError};
 use autopilot::ports::task_store::TaskStoreError;
 use autopilot::store::SqliteTaskStore;
 use autopilot::{cmd, fs, gh, git, github};
@@ -308,6 +308,9 @@ fn main() {
 /// `2` (default) for transient / unexpected failures.
 fn exit_code_for(e: &anyhow::Error) -> i32 {
     for cause in e.chain() {
+        if cause.downcast_ref::<UserInputError>().is_some() {
+            return 1;
+        }
         if let Some(domain) = cause.downcast_ref::<DomainError>() {
             if matches!(domain, DomainError::DuplicateTaskId(_)) {
                 return 1;

--- a/plugins/github-autopilot/cli/tests/cli_e2e.rs
+++ b/plugins/github-autopilot/cli/tests/cli_e2e.rs
@@ -93,6 +93,163 @@ fn e2e_help_subcommand_exits_zero() {
         .stdout(predicate::str::contains("autopilot"));
 }
 
+// ---------- F1: input validation wiring ----------
+//
+// These scenarios lock in the F1 (cli-ux-finish) wiring of `TaskId::parse`
+// and `--spec` existence checks into the `task add` and `epic create`
+// CLI handlers. The validation primitives have been on `main` since PR
+// #709; F1 just makes them visible at the binary surface so a typoed id
+// or missing path surfaces as exit code 1 with an actionable stderr
+// instead of silently inserting garbage.
+
+#[test]
+fn e2e_task_add_rejects_non_hex_id() {
+    // Lock: 12-char id with non-hex chars => `UserInputError` mapped to
+    // exit code 1, stderr names the offending input and the expected
+    // shape. Stdout stays empty (no row inserted, no "inserted task" line).
+    let ws = Workspace::new();
+    ws.touch("specs/demo.md");
+    ws.cmd()
+        .args([
+            "epic",
+            "create",
+            "--name",
+            "demo",
+            "--spec",
+            "specs/demo.md",
+        ])
+        .assert()
+        .success();
+
+    ws.cmd()
+        .args([
+            "task",
+            "add",
+            "ZZZZZZZZZZZZ",
+            "--epic",
+            "demo",
+            "--title",
+            "non-hex id",
+        ])
+        .assert()
+        .code(1)
+        .stdout(predicate::str::is_empty())
+        .stderr(
+            predicate::str::contains("invalid task id")
+                .and(predicate::str::contains("lowercase hex")),
+        );
+
+    // Confirm no row landed under that id (or any other) — `task list`
+    // should report the empty-state placeholder.
+    ws.cmd()
+        .args(["task", "list", "--epic", "demo"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("(no tasks)"));
+}
+
+#[test]
+fn e2e_task_add_rejects_wrong_length_id() {
+    // Lock: shorter-than-12 id surfaces the length-specific error message
+    // from `TaskIdParseError::InvalidLength` so an operator can tell
+    // whether they truncated vs. fat-fingered a hex char.
+    let ws = Workspace::new();
+    ws.touch("specs/demo.md");
+    ws.cmd()
+        .args([
+            "epic",
+            "create",
+            "--name",
+            "demo",
+            "--spec",
+            "specs/demo.md",
+        ])
+        .assert()
+        .success();
+
+    ws.cmd()
+        .args([
+            "task", "add", "abc", "--epic", "demo", "--title", "short id",
+        ])
+        .assert()
+        .code(1)
+        .stderr(
+            predicate::str::contains("invalid task id")
+                .and(predicate::str::contains("3 characters")),
+        );
+}
+
+#[test]
+fn e2e_task_add_accepts_valid_hex_id() {
+    // Counter-test: the validation gate must not regress the happy path —
+    // a canonical 12-char lowercase hex id still inserts and round-trips
+    // through `task list`.
+    let ws = Workspace::new();
+    ws.touch("specs/demo.md");
+    ws.cmd()
+        .args([
+            "epic",
+            "create",
+            "--name",
+            "demo",
+            "--spec",
+            "specs/demo.md",
+        ])
+        .assert()
+        .success();
+
+    ws.cmd()
+        .args([
+            "task",
+            "add",
+            "a1b2c3d4e5f6",
+            "--epic",
+            "demo",
+            "--title",
+            "valid hex id",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("inserted task a1b2c3d4e5f6"));
+
+    ws.cmd()
+        .args(["task", "list", "--epic", "demo"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("a1b2c3d4e5f6"));
+}
+
+#[test]
+fn e2e_epic_create_rejects_missing_spec() {
+    // Lock: `--spec <path>` that doesn't exist on disk surfaces a
+    // `UserInputError` (exit 1) with a message naming the missing path,
+    // and **does not** insert an epic row.
+    let ws = Workspace::new();
+    // Deliberately *not* calling `ws.touch` — the spec path must not exist.
+    ws.cmd()
+        .args([
+            "epic",
+            "create",
+            "--name",
+            "foo",
+            "--spec",
+            "specs/does-not-exist.md",
+        ])
+        .assert()
+        .code(1)
+        .stderr(
+            predicate::str::contains("does not exist")
+                .and(predicate::str::contains("specs/does-not-exist.md")),
+        );
+
+    // Confirm the rejection happened before the insert.
+    ws.cmd()
+        .args(["epic", "list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("(no epics)"));
+}
+
 #[test]
 fn e2e_task_add_then_list_shows_task() {
     // Happy-path round-trip across three commands sharing one SQLite
@@ -105,6 +262,7 @@ fn e2e_task_add_then_list_shows_task() {
     let task_id = "abc123def456"; // 12 hex chars, matches deterministic id format
     let title = "c1 demo task";
 
+    ws.touch("specs/demo.md");
     ws.cmd()
         .args([
             "epic",
@@ -146,6 +304,7 @@ fn e2e_task_lifecycle_full_flow() {
     let ws = Workspace::new();
     let task_id = "abc123def456";
 
+    ws.touch("specs/demo.md");
     ws.cmd()
         .args([
             "epic",
@@ -228,6 +387,7 @@ fn e2e_task_lifecycle_full_flow() {
 fn e2e_task_add_same_fingerprint_is_idempotent() {
     let ws = Workspace::new();
 
+    ws.touch("specs/demo.md");
     ws.cmd()
         .args([
             "epic",
@@ -298,6 +458,7 @@ fn e2e_task_add_same_fingerprint_is_idempotent() {
 fn e2e_epic_create_status_complete_flow() {
     let ws = Workspace::new();
 
+    ws.touch("specs/demo.md");
     ws.cmd()
         .args([
             "epic",
@@ -311,8 +472,8 @@ fn e2e_epic_create_status_complete_flow() {
         .success()
         .stdout(predicate::str::contains("epic 'demo' created"));
 
-    // TODO(C3): `epic create --spec` accepts a path that does not exist on
-    // disk. C3 should decide whether to validate or document the behavior.
+    // F1 (cli-ux-finish) wired in the spec-existence check — see
+    // `e2e_epic_create_rejects_missing_spec` for the rejection path.
 
     ws.cmd()
         .args(["epic", "get", "demo"])
@@ -376,6 +537,7 @@ fn e2e_epic_create_status_complete_flow() {
 fn e2e_blocked_task_becomes_claimable_after_parent_completes() {
     let ws = Workspace::new();
 
+    ws.touch("specs/demo.md");
     ws.cmd()
         .args([
             "epic",
@@ -475,6 +637,7 @@ fn e2e_task_list_filters_by_epic_and_status() {
     let ws = Workspace::new();
 
     for epic in ["alpha", "beta"] {
+        ws.touch(&format!("specs/{epic}.md"));
         ws.cmd()
             .args([
                 "epic",

--- a/plugins/github-autopilot/cli/tests/epic_tests.rs
+++ b/plugins/github-autopilot/cli/tests/epic_tests.rs
@@ -1,5 +1,5 @@
 use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use autopilot::cmd::epic::{EpicService, EpicStatusFilter};
@@ -8,7 +8,34 @@ use autopilot::ports::clock::{Clock, FixedClock};
 use autopilot::ports::task_store::{EpicPlan, EventFilter, NewTask, TaskStore};
 use autopilot::store::InMemoryTaskStore;
 use chrono::{TimeZone, Utc};
-use tempfile::NamedTempFile;
+use tempfile::{NamedTempFile, TempDir};
+
+/// Per-test scratch dir that materializes spec files on disk so
+/// `EpicService::create` (which now validates `--spec` existence) accepts
+/// them. Holds the `TempDir` so the files persist for the test's lifetime.
+struct SpecDir {
+    dir: TempDir,
+}
+
+impl SpecDir {
+    fn new() -> Self {
+        Self {
+            dir: TempDir::new().expect("create tempdir for spec files"),
+        }
+    }
+
+    /// Create an empty spec file at `<tempdir>/spec/<name>.md` and return
+    /// the absolute path. The ledger never reads the file's contents — the
+    /// validation gate only checks existence.
+    fn make(&self, name: &str) -> PathBuf {
+        let abs = self.dir.path().join("spec").join(format!("{name}.md"));
+        if let Some(parent) = abs.parent() {
+            std::fs::create_dir_all(parent).expect("create spec parent dir");
+        }
+        std::fs::File::create(&abs).expect("create spec file");
+        abs
+    }
+}
 
 fn fixture() -> (Arc<dyn TaskStore>, FixedClock) {
     let store: Arc<dyn TaskStore> = Arc::new(InMemoryTaskStore::new());
@@ -33,9 +60,9 @@ where
     format!("{:#}", f(&mut buf).unwrap_err())
 }
 
-fn seed_epic(svc: &EpicService, name: &str) {
-    let path = format!("spec/{name}.md");
-    let _ = capture(|w| svc.create(name, Path::new(&path), None, w));
+fn seed_epic(svc: &EpicService, specs: &SpecDir, name: &str) {
+    let path = specs.make(name);
+    let _ = capture(|w| svc.create(name, &path, None, w));
 }
 
 fn write_plan_jsonl(lines: &[&str]) -> NamedTempFile {
@@ -51,8 +78,10 @@ fn write_plan_jsonl(lines: &[&str]) -> NamedTempFile {
 fn create_persists_epic_and_emits_started_event() {
     let (store, clock) = fixture();
     let svc = EpicService::new(store.as_ref(), &clock);
+    let specs = SpecDir::new();
+    let spec = specs.make("e");
 
-    let (code, out) = capture(|w| svc.create("e", Path::new("spec/e.md"), None, w));
+    let (code, out) = capture(|w| svc.create("e", &spec, None, w));
     assert_eq!(code, 0, "stdout: {out}");
 
     let epics = store.list_epics(None).unwrap();
@@ -60,7 +89,7 @@ fn create_persists_epic_and_emits_started_event() {
     assert_eq!(epics[0].name, "e");
     assert_eq!(epics[0].status, EpicStatus::Active);
     assert_eq!(epics[0].branch, "epic/e");
-    assert_eq!(epics[0].spec_path, PathBuf::from("spec/e.md"));
+    assert_eq!(epics[0].spec_path, spec);
 
     let events = store
         .list_events(EventFilter {
@@ -76,7 +105,9 @@ fn create_persists_epic_and_emits_started_event() {
 fn create_uses_explicit_branch_override() {
     let (store, clock) = fixture();
     let svc = EpicService::new(store.as_ref(), &clock);
-    let (_code, _) = capture(|w| svc.create("e", Path::new("spec/e.md"), Some("custom/x"), w));
+    let specs = SpecDir::new();
+    let spec = specs.make("e");
+    let (_code, _) = capture(|w| svc.create("e", &spec, Some("custom/x"), w));
     let e = store.get_epic("e").unwrap().unwrap();
     assert_eq!(e.branch, "custom/x");
 }
@@ -85,8 +116,10 @@ fn create_uses_explicit_branch_override() {
 fn create_returns_exit_1_when_epic_already_exists() {
     let (store, clock) = fixture();
     let svc = EpicService::new(store.as_ref(), &clock);
-    let _ = capture(|w| svc.create("e", Path::new("spec/e.md"), None, w));
-    let (code, out) = capture(|w| svc.create("e", Path::new("spec/e.md"), None, w));
+    let specs = SpecDir::new();
+    let spec = specs.make("e");
+    let _ = capture(|w| svc.create("e", &spec, None, w));
+    let (code, out) = capture(|w| svc.create("e", &spec, None, w));
     assert_eq!(code, 1);
     assert!(out.contains("already exists"), "stdout: {out}");
 }
@@ -95,23 +128,25 @@ fn create_returns_exit_1_when_epic_already_exists() {
 fn create_idempotent_creates_when_epic_missing() {
     let (store, clock) = fixture();
     let svc = EpicService::new(store.as_ref(), &clock);
+    let specs = SpecDir::new();
+    let spec = specs.make("e");
 
-    let (code, out) =
-        capture(|w| svc.create_with_options("e", Path::new("spec/e.md"), None, true, w));
+    let (code, out) = capture(|w| svc.create_with_options("e", &spec, None, true, w));
     assert_eq!(code, 0, "stdout: {out}");
     assert!(out.contains("created"), "stdout: {out}");
     let e = store.get_epic("e").unwrap().unwrap();
-    assert_eq!(e.spec_path, PathBuf::from("spec/e.md"));
+    assert_eq!(e.spec_path, spec);
 }
 
 #[test]
 fn create_idempotent_succeeds_when_epic_exists_with_same_spec() {
     let (store, clock) = fixture();
     let svc = EpicService::new(store.as_ref(), &clock);
-    let _ = capture(|w| svc.create("e", Path::new("spec/e.md"), None, w));
+    let specs = SpecDir::new();
+    let spec = specs.make("e");
+    let _ = capture(|w| svc.create("e", &spec, None, w));
 
-    let (code, out) =
-        capture(|w| svc.create_with_options("e", Path::new("spec/e.md"), None, true, w));
+    let (code, out) = capture(|w| svc.create_with_options("e", &spec, None, true, w));
     assert_eq!(code, 0, "stdout: {out}");
     assert!(out.contains("already exists (idempotent)"), "stdout: {out}");
     // Single epic — no duplicate row inserted.
@@ -122,10 +157,12 @@ fn create_idempotent_succeeds_when_epic_exists_with_same_spec() {
 fn create_idempotent_errors_when_epic_exists_with_different_spec() {
     let (store, clock) = fixture();
     let svc = EpicService::new(store.as_ref(), &clock);
-    let _ = capture(|w| svc.create("e", Path::new("spec/e.md"), None, w));
+    let specs = SpecDir::new();
+    let spec = specs.make("e");
+    let other = specs.make("other");
+    let _ = capture(|w| svc.create("e", &spec, None, w));
 
-    let (code, out) =
-        capture(|w| svc.create_with_options("e", Path::new("spec/other.md"), None, true, w));
+    let (code, out) = capture(|w| svc.create_with_options("e", &other, None, true, w));
     assert_eq!(code, 1, "stdout: {out}");
     assert!(
         out.contains("different spec_path"),
@@ -133,15 +170,32 @@ fn create_idempotent_errors_when_epic_exists_with_different_spec() {
     );
     // Existing epic untouched.
     let e = store.get_epic("e").unwrap().unwrap();
-    assert_eq!(e.spec_path, PathBuf::from("spec/e.md"));
+    assert_eq!(e.spec_path, spec);
+}
+
+#[test]
+fn create_rejects_missing_spec_file() {
+    // F1 wiring lock: `epic create --spec <path>` must reject a path that
+    // doesn't exist on disk before any store mutation. Surfaces as a
+    // `UserInputError` (anyhow chain) so `main::exit_code_for` maps it to
+    // exit code 1.
+    let (store, clock) = fixture();
+    let svc = EpicService::new(store.as_ref(), &clock);
+    let missing = PathBuf::from("/tmp/autopilot-no-such-dir-xyz/spec/missing.md");
+    let msg = expect_err(|w| svc.create("e", &missing, None, w));
+    assert!(msg.contains("does not exist"), "error: {msg}");
+    assert!(msg.contains("missing.md"), "error must name path: {msg}");
+    // No epic was inserted.
+    assert!(store.list_epics(None).unwrap().is_empty());
 }
 
 #[test]
 fn list_filters_by_status_and_renders_json() {
     let (store, clock) = fixture();
     let svc = EpicService::new(store.as_ref(), &clock);
-    let _ = capture(|w| svc.create("a", Path::new("spec/a.md"), None, w));
-    let _ = capture(|w| svc.create("b", Path::new("spec/b.md"), None, w));
+    let specs = SpecDir::new();
+    let _ = capture(|w| svc.create("a", &specs.make("a"), None, w));
+    let _ = capture(|w| svc.create("b", &specs.make("b"), None, w));
     store
         .set_epic_status("b", EpicStatus::Completed, clock.now())
         .unwrap();
@@ -222,7 +276,8 @@ fn status_groups_tasks_by_state() {
 fn complete_marks_epic_completed_and_records_event() {
     let (store, clock) = fixture();
     let svc = EpicService::new(store.as_ref(), &clock);
-    let _ = capture(|w| svc.create("e", Path::new("spec/e.md"), None, w));
+    let specs = SpecDir::new();
+    let _ = capture(|w| svc.create("e", &specs.make("e"), None, w));
 
     let (code, _) = capture(|w| svc.complete("e", w));
     assert_eq!(code, 0);
@@ -250,7 +305,8 @@ fn complete_returns_exit_1_when_epic_missing() {
 fn abandon_marks_epic_abandoned() {
     let (store, clock) = fixture();
     let svc = EpicService::new(store.as_ref(), &clock);
-    let _ = capture(|w| svc.create("e", Path::new("spec/e.md"), None, w));
+    let specs = SpecDir::new();
+    let _ = capture(|w| svc.create("e", &specs.make("e"), None, w));
     let (code, _) = capture(|w| svc.abandon("e", w));
     assert_eq!(code, 0);
     assert_eq!(
@@ -263,8 +319,10 @@ fn abandon_marks_epic_abandoned() {
 fn find_by_spec_path_matches_active_epic() {
     let (store, clock) = fixture();
     let svc = EpicService::new(store.as_ref(), &clock);
-    let _ = capture(|w| svc.create("e", Path::new("spec/e.md"), None, w));
-    let (code, out) = capture(|w| svc.find_by_spec_path(Path::new("spec/e.md"), true, w));
+    let specs = SpecDir::new();
+    let spec = specs.make("e");
+    let _ = capture(|w| svc.create("e", &spec, None, w));
+    let (code, out) = capture(|w| svc.find_by_spec_path(&spec, true, w));
     assert_eq!(code, 0);
     let v: serde_json::Value = serde_json::from_str(out.trim()).unwrap();
     assert_eq!(v["name"], "e");
@@ -274,7 +332,9 @@ fn find_by_spec_path_matches_active_epic() {
 fn find_by_spec_path_returns_exit_1_when_no_match() {
     let (store, clock) = fixture();
     let svc = EpicService::new(store.as_ref(), &clock);
-    let (code, _) = capture(|w| svc.find_by_spec_path(Path::new("spec/none.md"), false, w));
+    let specs = SpecDir::new();
+    let none_spec = specs.make("none");
+    let (code, _) = capture(|w| svc.find_by_spec_path(&none_spec, false, w));
     assert_eq!(code, 1);
 }
 
@@ -303,7 +363,8 @@ fn find_by_spec_path_returns_exit_3_on_inconsistency() {
             .unwrap();
     }
     let svc = EpicService::new(store.as_ref(), &clock);
-    let (code, out) = capture(|w| svc.find_by_spec_path(Path::new("spec/shared.md"), false, w));
+    let (code, out) =
+        capture(|w| svc.find_by_spec_path(std::path::Path::new("spec/shared.md"), false, w));
     assert_eq!(code, 3);
     assert!(out.contains("inconsistency"), "stdout: {out}");
 }
@@ -312,7 +373,8 @@ fn find_by_spec_path_returns_exit_3_on_inconsistency() {
 fn reconcile_applies_jsonl_plan_and_is_idempotent() {
     let (store, clock) = fixture();
     let svc = EpicService::new(store.as_ref(), &clock);
-    let _ = capture(|w| svc.create("e", Path::new("spec/e.md"), None, w));
+    let specs = SpecDir::new();
+    let _ = capture(|w| svc.create("e", &specs.make("e"), None, w));
 
     let plan = NamedTempFile::new().unwrap();
     let lines = [
@@ -374,7 +436,8 @@ fn reconcile_returns_exit_1_when_epic_missing() {
 fn reconcile_rejects_duplicate_task_id_in_plan() {
     let (store, clock) = fixture();
     let svc = EpicService::new(store.as_ref(), &clock);
-    seed_epic(&svc, "e");
+    let specs = SpecDir::new();
+    seed_epic(&svc, &specs, "e");
 
     let plan = write_plan_jsonl(&[
         r#"{"kind":"task","id":"aaaaaaaaaaaa","title":"first"}"#,
@@ -393,7 +456,8 @@ fn reconcile_rejects_duplicate_task_id_in_plan() {
 fn reconcile_rejects_unknown_task_source() {
     let (store, clock) = fixture();
     let svc = EpicService::new(store.as_ref(), &clock);
-    seed_epic(&svc, "e");
+    let specs = SpecDir::new();
+    seed_epic(&svc, &specs, "e");
 
     let plan = write_plan_jsonl(&[
         r#"{"kind":"task","id":"aaaaaaaaaaaa","title":"x","source":"telepathy"}"#,
@@ -408,7 +472,8 @@ fn reconcile_rejects_unknown_task_source() {
 fn reconcile_skips_blank_and_comment_lines() {
     let (store, clock) = fixture();
     let svc = EpicService::new(store.as_ref(), &clock);
-    seed_epic(&svc, "e");
+    let specs = SpecDir::new();
+    seed_epic(&svc, &specs, "e");
 
     // The `#`-prefixed line is itself valid JSON; if the parser stripped `#`
     // *after* trying to deserialize it would either error or insert task
@@ -431,7 +496,8 @@ fn reconcile_skips_blank_and_comment_lines() {
 fn list_renders_human_table_when_not_json() {
     let (store, clock) = fixture();
     let svc = EpicService::new(store.as_ref(), &clock);
-    seed_epic(&svc, "alpha");
+    let specs = SpecDir::new();
+    seed_epic(&svc, &specs, "alpha");
     let (code, out) = capture(|w| svc.list(None, false, w));
     assert_eq!(code, 0);
     assert!(out.contains("alpha"));

--- a/plugins/github-autopilot/cli/tests/task_tests.rs
+++ b/plugins/github-autopilot/cli/tests/task_tests.rs
@@ -247,6 +247,52 @@ fn add_detects_duplicate_fingerprint_and_returns_same_id() {
     assert_eq!(dup_events.len(), 1);
 }
 
+#[test]
+fn add_rejects_invalid_task_id_before_store_mutation() {
+    // F1 wiring lock: a non-canonical id (wrong length / non-hex chars) is
+    // rejected via `TaskId::parse` before any store mutation, surfacing as
+    // an anyhow error chain that carries the parser message. The store
+    // remains empty so the typo cannot land a phantom row.
+    let (store, clock) = fixture();
+    let svc = TaskService::new(store.as_ref(), &clock);
+
+    // Wrong length.
+    let mut buf: Vec<u8> = Vec::new();
+    let err = svc
+        .add(
+            "e",
+            "abc",
+            "title",
+            None,
+            Some("0xDEADBEEF"),
+            TaskSourceArg::Human,
+            &mut buf,
+        )
+        .unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(msg.contains("invalid task id"), "error: {msg}");
+    assert!(msg.contains("3 characters"), "error: {msg}");
+
+    // Non-hex chars.
+    let mut buf: Vec<u8> = Vec::new();
+    let err = svc
+        .add(
+            "e",
+            "ZZZZZZZZZZZZ",
+            "title",
+            None,
+            Some("0xDEADBEEF"),
+            TaskSourceArg::Human,
+            &mut buf,
+        )
+        .unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(msg.contains("lowercase hex"), "error: {msg}");
+
+    // Store stayed clean across both rejections.
+    assert!(store.list_tasks_by_epic("e", None).unwrap().is_empty());
+}
+
 // ---------- add-batch ----------
 
 #[test]


### PR DESCRIPTION
## Summary

F1 of `epic/cli-ux-hardening-finish` — finishes the wiring left undone by PR #709. The validation primitives (`TaskId::parse`, `UserInputError`) and the e2e infrastructure (`Workspace::touch`) already shipped to `main`, but the CLI handlers did not actually call them. This PR routes them through.

## Production wiring

- `plugins/github-autopilot/cli/src/cmd/task.rs::TaskService::add` — replaced `TaskId::from_raw(task_id)` with `TaskId::parse(task_id).map_err(... UserInputError ...)`. A typoed id is now rejected before any store mutation rather than silently inserting a row whose id will never match the deterministic form. Read-only paths (`show`, `release`, `complete`, `escalate`, `fail`, `force_status`) keep `TaskId::from_raw` per the doc on `TaskId::parse` — there a missing-id lookup already surfaces the typo without corrupting state.
- `plugins/github-autopilot/cli/src/cmd/task.rs::TaskService::add_batch` — same gate, applied per JSONL line; the line number is woven into the error message so an operator can locate the bad row.
- `plugins/github-autopilot/cli/src/cmd/epic.rs::EpicService::create_with_options` — checks `spec_path.try_exists()` before insert. Returns `UserInputError("epic create: spec file '<path>' does not exist")`.

## Exit code mapping decision

`UserInputError` was always intended to map to exit 1 (per its doc comment), but `main::exit_code_for` previously only special-cased `DomainError::DuplicateTaskId`. Extended `exit_code_for` with one extra `cause.downcast_ref::<UserInputError>()` arm so any handler raising a `UserInputError` (current or future) gets exit 1 automatically — minimal, principled, matches the existing shape.

## New e2e scenarios

In `plugins/github-autopilot/cli/tests/cli_e2e.rs`:

- `e2e_task_add_rejects_non_hex_id` — `task add ZZZZZZZZZZZZ` → exit 1, stderr contains `invalid task id` + `lowercase hex`, stdout empty, `task list` shows `(no tasks)`.
- `e2e_task_add_rejects_wrong_length_id` — `task add abc` → exit 1, stderr contains `3 characters`.
- `e2e_task_add_accepts_valid_hex_id` — counter-test: `task add a1b2c3d4e5f6` still succeeds.
- `e2e_epic_create_rejects_missing_spec` — exit 1, stderr names the missing path, no epic row inserted (`epic list` shows `(no epics)`).

Also added `add_rejects_invalid_task_id_before_store_mutation` (service-level unit test) in `tests/task_tests.rs` and `create_rejects_missing_spec_file` in `tests/epic_tests.rs` so the rejection is covered in-process too.

## Test fixture refactors (necessary for the spec-existence gate)

- `tests/cli_e2e.rs`: every existing test that called `epic create` now calls `Workspace::touch(spec_path)` first (5 tests).
- `tests/epic_tests.rs`: introduced a `SpecDir` helper that materializes spec files in a per-test `TempDir`. All `Path::new("spec/X.md")` literals were replaced with `SpecDir::make("X")` so the validation gate sees a real file. Behavioral assertions (status, branch, names, idempotency) are preserved.

## Quality gate

- `cargo fmt --check` clean
- `cargo clippy -p autopilot --tests -- -D warnings` clean
- `cargo test -p autopilot` — all suites green (e2e `cli_e2e.rs` 24 tests, `epic_tests.rs` 23, `task_tests.rs` 25, etc.)

## Test plan

- [ ] CI green
- [ ] Spot-check that the new error messages render readably when piping `task add foo --epic e --title t 2>&1` against a real workspace

## Out of scope

- F2 (watch daemon clock skew) — parallel.
- JSON schema / output format changes.
- `cmd::watch` surface untouched.