### PR TITLE
fix(github-autopilot): clamp future last_event_at to prevent watch freeze

### DIFF
--- a/plugins/github-autopilot/cli/src/cmd/watch/ledger.rs
+++ b/plugins/github-autopilot/cli/src/cmd/watch/ledger.rs
@@ -59,6 +59,34 @@ impl LedgerState {
             self.last_event_at = Some(now);
         }
     }
+
+    /// Clamps a future `last_event_at` cursor down to `now` and clears
+    /// any dedupe keys tied to the now-stale boundary timestamp.
+    ///
+    /// Returns the original future timestamp when a clamp happens (so
+    /// callers can warn once), or `None` when the cursor is already
+    /// `<= now` (the normal case — no-op, no warn).
+    ///
+    /// Why this exists: `last_event_at` is loaded from `watch.json` and
+    /// fed to `TaskStore::list_events` as `WHERE at >= since`. If it's
+    /// ever in the future (NTP correction, OS clock manipulation,
+    /// `watch.json` copied across hosts), every freshly-inserted event
+    /// gets filtered out and `TASK_READY` / `EPIC_DONE` / `STALE_WIP`
+    /// emission freezes until real time catches up. Clamping at the read
+    /// boundary unfreezes emission immediately while preserving history.
+    pub fn clamp_future_cursor(&mut self, now: DateTime<Utc>) -> Option<DateTime<Utc>> {
+        match self.last_event_at {
+            Some(at) if at > now => {
+                self.last_event_at = Some(now);
+                // The dedupe set is keyed by the (now-stale) future
+                // timestamp; clearing avoids accidentally suppressing
+                // legitimate events that happen to land at `now`.
+                self.seen_keys.clear();
+                Some(at)
+            }
+            _ => None,
+        }
+    }
 }
 
 fn key_of(kind: EventKind, task_id: Option<&TaskId>, at: DateTime<Utc>) -> String {

--- a/plugins/github-autopilot/cli/src/cmd/watch/mod.rs
+++ b/plugins/github-autopilot/cli/src/cmd/watch/mod.rs
@@ -320,10 +320,23 @@ impl WatchService {
         // Ledger: every tick (when enabled and a store is attached)
         if args.ledger_events {
             if let Some(store) = self.store.as_ref() {
+                let now = self.clock.now();
+                // Clock-skew defense: if `last_event_at` is in the future
+                // (NTP rollback, watch.json copied across hosts, OS clock
+                // manipulation), the SQLite filter `at >= since` will drop
+                // every fresh event and freeze emission until real time
+                // catches up. Clamp at the read boundary, warn once, and
+                // let the next periodic save persist the corrected cursor.
+                if let Some(future) = ts.state.ledger.clamp_future_cursor(now) {
+                    eprintln!(
+                        "watch.json clock skew detected: last_event_at={future} > now={now}; \
+                         clamping. Likely cause: NTP correction or watch.json copied across hosts."
+                    );
+                }
                 let events = ledger::detect_ledger_events(
                     store.as_ref(),
                     &mut ts.state.ledger,
-                    self.clock.now(),
+                    now,
                     ts.stale_threshold_secs,
                 );
                 out.extend(events);

--- a/plugins/github-autopilot/cli/tests/watch_scenarios.rs
+++ b/plugins/github-autopilot/cli/tests/watch_scenarios.rs
@@ -1040,45 +1040,112 @@ fn scenario_ready_then_claim_same_tick_no_stale_wip() {
 
 // ── Scenario 13 (event integrity): clock-skew protection ────────────────
 
-/// Documents a known limitation: if `last_event_at` in `watch.json` is
-/// somehow ahead of `clock.now()` (system clock moved backward, or the
-/// state file was copied from another machine), the SQLite query
-/// `at >= since` will silently filter out events whose `at == now`.
-/// `TASK_READY` / `EPIC_DONE` then stop firing until real time catches
-/// up to the stored future cursor.
+/// `last_event_at` in `watch.json` can end up ahead of `clock.now()`
+/// when the system clock moves backward (NTP correction, OS clock
+/// manipulation) or when the state file is copied from a host with a
+/// faster clock. The naive SQL filter `at >= since` then drops every
+/// freshly-inserted row and `TASK_READY` / `EPIC_DONE` / `STALE_WIP`
+/// emission stays frozen until wall-clock catches up to the stored
+/// cursor — potentially hours.
 ///
-/// Per the C5 task brief, this scenario is **deferred** — fixing it is a
-/// judgment call that should be made alongside a concrete recovery
-/// policy (e.g. clamp `since` to `min(last_event_at, now)`, or warn and
-/// re-anchor). The test below describes the desired behavior and is
-/// marked `#[ignore]` so CI passes while the policy is decided.
-///
-/// To reproduce the bug interactively, remove `#[ignore]` and run
-/// `cargo test -p autopilot scenario_clock_skew_does_not_freeze_emission`.
+/// Policy (clamp + warn): when the cursor is detected in the future at
+/// the read boundary (`tick_once`), clamp it down to `now`, emit a
+/// single stderr warning, and let the next periodic `save_state` persist
+/// the corrected value so the warn does not re-fire on every tick.
 #[test]
-#[ignore = "TODO(C5): clock-skew re-anchor policy not yet implemented; see PR body"]
 fn scenario_clock_skew_does_not_freeze_emission() {
     let mut fx = Fixture::new(/*stale_secs=*/ 60);
 
     // Force the ledger cursor into the future by 1 hour. In production
     // this happens when the system clock jumps backward between daemon
     // restarts.
-    fx.ts.state.ledger.last_event_at = Some(fx.now() + Duration::hours(1));
+    let future = fx.now() + Duration::hours(1);
+    fx.ts.state.ledger.last_event_at = Some(future);
 
-    // Insert a task at the (logical) current time.
+    // Insert a task at the (logical) current time. With the bug active
+    // this row's `at` would be filtered out by `WHERE at >= future`.
     ensure_epic(&fx.store, "e13", fx.now());
     fx.store
         .upsert_watch_task(watch_task("t1", "e13"), fx.now())
         .expect("upsert");
 
-    // Desired behavior: the daemon detects the future cursor, re-anchors
-    // to `now`, and emits TASK_READY for t1. Current behavior: the SQL
-    // filter `at >= since` excludes the freshly inserted row, and no
-    // event fires until real time catches up an hour later.
+    // First tick: clamp triggers, emission resumes, TASK_READY fires.
     let evs = fx.tick();
     assert_eq!(
         ready(&evs),
         vec![("e13", "t1")],
         "clock-skew must not freeze TASK_READY emission; got {evs:?}"
+    );
+
+    // Cursor was clamped: the in-memory ledger state must no longer hold
+    // the future timestamp — otherwise the next tick would re-freeze.
+    let cursor = fx
+        .ts
+        .state
+        .ledger
+        .last_event_at
+        .expect("cursor present after tick");
+    assert!(
+        cursor <= fx.now(),
+        "expected clamped cursor <= now ({}), got {cursor}",
+        fx.now()
+    );
+    assert!(
+        cursor < future,
+        "expected cursor < original future ({future}), got {cursor}"
+    );
+
+    // Second tick at the same logical time: warn-once contract — the
+    // clamp must be idempotent and emission must keep flowing for any
+    // newly-arriving rows. We add another task and expect TASK_READY.
+    fx.advance(Duration::seconds(1));
+    fx.store
+        .upsert_watch_task(watch_task("t2", "e13"), fx.now())
+        .expect("upsert");
+    let evs = fx.tick();
+    assert_eq!(
+        ready(&evs),
+        vec![("e13", "t2")],
+        "post-clamp tick must keep emitting; got {evs:?}"
+    );
+}
+
+/// Negative case for the clamp: when `last_event_at <= now` (the normal
+/// progression), `tick_once` must NOT mutate the cursor and must NOT
+/// warn. Locks the warn-frequency contract — the production warn fires
+/// only on actual skew, never on healthy ticks.
+#[test]
+fn scenario_normal_clock_progression_does_not_clamp() {
+    let mut fx = Fixture::new(/*stale_secs=*/ 60);
+
+    // Cursor parked one second in the past (a typical post-event state).
+    let cursor_before = fx.now() - Duration::seconds(1);
+    fx.ts.state.ledger.last_event_at = Some(cursor_before);
+
+    ensure_epic(&fx.store, "e13b", fx.now());
+    fx.store
+        .upsert_watch_task(watch_task("t1", "e13b"), fx.now())
+        .expect("upsert");
+
+    let evs = fx.tick();
+    assert_eq!(
+        ready(&evs),
+        vec![("e13b", "t1")],
+        "normal-case emission must work; got {evs:?}"
+    );
+
+    // The cursor will advance from `cursor_before` to the inserted row's
+    // `at` (== fx.now()) — that is normal forward progression by
+    // `detect_ledger_events`, NOT a clamp. The contract we lock here is
+    // only that the cursor never exceeds `now`.
+    let cursor_after = fx
+        .ts
+        .state
+        .ledger
+        .last_event_at
+        .expect("cursor present after tick");
+    assert!(
+        cursor_after <= fx.now(),
+        "cursor must remain <= now after normal tick, got {cursor_after}"
     );
 }

--- a/plugins/github-autopilot/cli/tests/watch_tests.rs
+++ b/plugins/github-autopilot/cli/tests/watch_tests.rs
@@ -628,3 +628,66 @@ fn ledger_state_round_trips_through_json() {
         "restart must not replay; got {after_restart:?}"
     );
 }
+
+// ── Clock-skew clamp: unit tests for `LedgerState::clamp_future_cursor` ──
+
+#[test]
+fn clamp_future_cursor_returns_original_and_clears_dedupe() {
+    let now = ledger_base_time();
+    let future = now + Duration::hours(1);
+    let mut state = LedgerState {
+        last_event_at: Some(future),
+        ..Default::default()
+    };
+    // Seed a stale dedupe key tied to the future timestamp.
+    state
+        .seen_keys
+        .insert(format!("task_inserted|t1|{}", future.timestamp_micros()));
+
+    let result = state.clamp_future_cursor(now);
+
+    assert_eq!(result, Some(future), "clamp must return original future");
+    assert_eq!(
+        state.last_event_at,
+        Some(now),
+        "cursor must be clamped to now"
+    );
+    assert!(
+        state.seen_keys.is_empty(),
+        "dedupe keys tied to the stale boundary must be cleared"
+    );
+}
+
+#[test]
+fn clamp_future_cursor_is_noop_when_cursor_at_now() {
+    let now = ledger_base_time();
+    let mut state = LedgerState {
+        last_event_at: Some(now),
+        ..Default::default()
+    };
+    let result = state.clamp_future_cursor(now);
+    assert_eq!(result, None, "cursor == now is healthy, not skew");
+    assert_eq!(state.last_event_at, Some(now));
+}
+
+#[test]
+fn clamp_future_cursor_is_noop_when_cursor_in_past() {
+    let now = ledger_base_time();
+    let past = now - Duration::hours(1);
+    let mut state = LedgerState {
+        last_event_at: Some(past),
+        ..Default::default()
+    };
+    let result = state.clamp_future_cursor(now);
+    assert_eq!(result, None);
+    assert_eq!(state.last_event_at, Some(past));
+}
+
+#[test]
+fn clamp_future_cursor_is_noop_when_cursor_unset() {
+    let now = ledger_base_time();
+    let mut state = LedgerState::default();
+    let result = state.clamp_future_cursor(now);
+    assert_eq!(result, None, "no cursor → nothing to clamp");
+    assert_eq!(state.last_event_at, None);
+}


### PR DESCRIPTION
## Summary

- Clamp `last_event_at` to `now` at the watch tick read boundary when it is in the future, restoring `TASK_READY` / `EPIC_DONE` / `STALE_WIP` emission immediately instead of waiting for real time to catch up.
- Emit a single stderr warn line with both timestamps and a cause hint; clear the dedupe set tied to the stale boundary so legitimate `at == now` events are not suppressed.
- Activate the previously-`#[ignore]`d `scenario_clock_skew_does_not_freeze_emission` and add a positive counterpart that locks the warn-frequency contract.

## Bug

`WatchService::tick_once` reads `last_event_at` from `watch.json` and queries `SqliteTaskStore::list_events` with `WHERE at >= since`. If the cursor is ever in the future, every fresh ledger event's `at` is `< last_event_at` and gets filtered out — emission stays frozen until wall-clock catches up.

One-line repro: set `last_event_at` in `watch.json` to a future timestamp; insert a task; observe `TASK_READY` does not fire.

This shows up in production after NTP corrections that move the clock backward, after OS clock manipulation, or when `watch.json` is copied between hosts with skewed clocks.

## Policy chosen: clamp + warn

Considered options:
- Clamp without warn — loses observability, on-call cannot see why.
- Reset / delete `watch.json` — destructive (loses dedupe history), explicitly rejected.
- **Clamp + warn (chosen)** — heals emission immediately, preserves history, surfaces the event once.

Implementation:
- New helper `LedgerState::clamp_future_cursor(now)` returns `Some(future)` when a clamp happened, `None` otherwise. Mutates `last_event_at = now` and clears `seen_keys` (which were keyed by the now-stale future timestamp; leaving them would suppress legitimate same-`at` events).
- Called in `WatchService::tick_once` right before `detect_ledger_events`, using the injected `Clock` so `FixedClock` drives the test.
- Warn-once contract: after clamp, the in-memory cursor is `<= now`, so the next tick's `clamp_future_cursor` returns `None` and stays silent. The next `save_state` (every `STATE_SAVE_INTERVAL` ticks) persists the corrected value, so a daemon restart also stays silent.

## Warn message text

```
watch.json clock skew detected: last_event_at=<future> > now=<now>; clamping. Likely cause: NTP correction or watch.json copied across hosts.
```

## Tests

- `scenario_clock_skew_does_not_freeze_emission` — was `#[ignore]`d as a documented bug; now active. Asserts that emission resumes on the first tick, the in-memory cursor is `<= now` (and strictly `<` the original future), and a follow-up tick keeps emitting for newly-inserted rows.
- `scenario_normal_clock_progression_does_not_clamp` — new positive case. Cursor parked one second in the past, normal forward progression, no clamp triggered.
- `clamp_future_cursor_*` (4 unit tests) — direct contract tests on the helper: returns original future + clears dedupe / no-op for `==`, `<`, and `None`.

## Non-obvious code shape

- The clamp lives in `tick_once` (per-tick read boundary), not `init_tick_state` (boot-only), because the test injects the future cursor *after* `init_tick_state` runs. Per-tick placement also catches mid-process clock jumps, not just startup-time skew.
- `seen_keys` is cleared on clamp because every key in it has the stale future timestamp encoded — keeping them would silently suppress legitimate `at == now` events.

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --tests -- -D warnings` passes
- [x] `cargo test -p autopilot` — all suites green; `0 ignored`; activated scenario passes
- [x] Production fix uses injected `Clock`, not `Utc::now()` directly