### PR TITLE
feat(github-autopilot): CLI UX hardening — validation wiring + clock-skew fix

### DIFF
--- a/plugins/github-autopilot/cli/Cargo.lock
+++ b/plugins/github-autopilot/cli/Cargo.lock
@@ -111,7 +111,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autopilot"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/plugins/github-autopilot/cli/src/cmd/epic.rs
+++ b/plugins/github-autopilot/cli/src/cmd/epic.rs
@@ -141,6 +141,11 @@ impl<'a> EpicService<'a> {
     /// `idempotent` is true *and* its `spec_path` matches the requested one.
     /// A name collision with a different spec path is still reported as an
     /// error (exit 1) — semantic mismatch must not be silently accepted.
+    ///
+    /// Validates that `spec_path` exists on disk before any store mutation —
+    /// a typo'd `--spec` argument would otherwise silently land an epic
+    /// pointing at nothing. Returns a [`UserInputError`] (exit code 1) when
+    /// the path is missing.
     pub fn create_with_options(
         &self,
         name: &str,
@@ -149,6 +154,14 @@ impl<'a> EpicService<'a> {
         idempotent: bool,
         out: &mut dyn Write,
     ) -> Result<i32> {
+        if !spec_path.try_exists().unwrap_or(false) {
+            return Err(anyhow::Error::new(crate::domain::UserInputError::new(
+                format!(
+                    "epic create: spec file '{}' does not exist",
+                    spec_path.display()
+                ),
+            )));
+        }
         let now = self.clock.now();
         let epic = Epic {
             name: name.to_string(),

--- a/plugins/github-autopilot/cli/src/cmd/task.rs
+++ b/plugins/github-autopilot/cli/src/cmd/task.rs
@@ -165,6 +165,13 @@ impl<'a> TaskService<'a> {
     /// Inserts (or detects duplicate of) a watch-style task on `epic`.
     /// Auto-derives a fingerprint from `title + body` when `fingerprint` is
     /// `None`, so callers don't need to mirror the simhash recipe.
+    ///
+    /// Validates `task_id` via [`TaskId::parse`] before any store mutation
+    /// so a typoed id is rejected as a `UserInputError` (exit code 1) rather
+    /// than silently inserting a row whose id will never match the
+    /// deterministic form. Read-only lookups (`task show`, `task release`,
+    /// ...) keep using [`TaskId::from_raw`] — there a missing-id lookup
+    /// already surfaces the typo without corrupting state.
     #[allow(clippy::too_many_arguments)]
     pub fn add(
         &self,
@@ -176,12 +183,14 @@ impl<'a> TaskService<'a> {
         source: TaskSourceArg,
         out: &mut dyn Write,
     ) -> Result<i32> {
+        let id = TaskId::parse(task_id)
+            .map_err(|e| anyhow::Error::new(crate::domain::UserInputError::new(e.to_string())))?;
         let now = self.clock.now();
         let fp = fingerprint
             .map(str::to_string)
             .unwrap_or_else(|| derive_fingerprint(title, body));
         let nt = NewWatchTask {
-            id: TaskId::from_raw(task_id),
+            id,
             epic_name: epic.to_string(),
             source: source.into(),
             fingerprint: fp,
@@ -231,13 +240,20 @@ impl<'a> TaskService<'a> {
                 })?,
                 None => TaskSource::Human,
             };
+            let id = TaskId::parse(&parsed.id).map_err(|e| {
+                anyhow::Error::new(crate::domain::UserInputError::new(format!(
+                    "{} (line {})",
+                    e,
+                    lineno + 1
+                )))
+            })?;
             let title = parsed.title;
             let body = parsed.body;
             let fp = parsed
                 .fingerprint
                 .unwrap_or_else(|| derive_fingerprint(&title, body.as_deref()));
             let nt = NewWatchTask {
-                id: TaskId::from_raw(&parsed.id),
+                id,
                 epic_name: epic.to_string(),
                 source,
                 fingerprint: fp,

--- a/plugins/github-autopilot/cli/src/cmd/watch/ledger.rs
+++ b/plugins/github-autopilot/cli/src/cmd/watch/ledger.rs
@@ -59,6 +59,34 @@ impl LedgerState {
             self.last_event_at = Some(now);
         }
     }
+
+    /// Clamps a future `last_event_at` cursor down to `now` and clears
+    /// any dedupe keys tied to the now-stale boundary timestamp.
+    ///
+    /// Returns the original future timestamp when a clamp happens (so
+    /// callers can warn once), or `None` when the cursor is already
+    /// `<= now` (the normal case — no-op, no warn).
+    ///
+    /// Why this exists: `last_event_at` is loaded from `watch.json` and
+    /// fed to `TaskStore::list_events` as `WHERE at >= since`. If it's
+    /// ever in the future (NTP correction, OS clock manipulation,
+    /// `watch.json` copied across hosts), every freshly-inserted event
+    /// gets filtered out and `TASK_READY` / `EPIC_DONE` / `STALE_WIP`
+    /// emission freezes until real time catches up. Clamping at the read
+    /// boundary unfreezes emission immediately while preserving history.
+    pub fn clamp_future_cursor(&mut self, now: DateTime<Utc>) -> Option<DateTime<Utc>> {
+        match self.last_event_at {
+            Some(at) if at > now => {
+                self.last_event_at = Some(now);
+                // The dedupe set is keyed by the (now-stale) future
+                // timestamp; clearing avoids accidentally suppressing
+                // legitimate events that happen to land at `now`.
+                self.seen_keys.clear();
+                Some(at)
+            }
+            _ => None,
+        }
+    }
 }
 
 fn key_of(kind: EventKind, task_id: Option<&TaskId>, at: DateTime<Utc>) -> String {

--- a/plugins/github-autopilot/cli/src/cmd/watch/mod.rs
+++ b/plugins/github-autopilot/cli/src/cmd/watch/mod.rs
@@ -320,10 +320,23 @@ impl WatchService {
         // Ledger: every tick (when enabled and a store is attached)
         if args.ledger_events {
             if let Some(store) = self.store.as_ref() {
+                let now = self.clock.now();
+                // Clock-skew defense: if `last_event_at` is in the future
+                // (NTP rollback, watch.json copied across hosts, OS clock
+                // manipulation), the SQLite filter `at >= since` will drop
+                // every fresh event and freeze emission until real time
+                // catches up. Clamp at the read boundary, warn once, and
+                // let the next periodic save persist the corrected cursor.
+                if let Some(future) = ts.state.ledger.clamp_future_cursor(now) {
+                    eprintln!(
+                        "watch.json clock skew detected: last_event_at={future} > now={now}; \
+                         clamping. Likely cause: NTP correction or watch.json copied across hosts."
+                    );
+                }
                 let events = ledger::detect_ledger_events(
                     store.as_ref(),
                     &mut ts.state.ledger,
-                    self.clock.now(),
+                    now,
                     ts.stale_threshold_secs,
                 );
                 out.extend(events);

--- a/plugins/github-autopilot/cli/src/main.rs
+++ b/plugins/github-autopilot/cli/src/main.rs
@@ -3,7 +3,7 @@ use autopilot::cmd::{
     StatsCommands, TaskCommands, WorktreeCommands,
 };
 use autopilot::config::Config;
-use autopilot::domain::DomainError;
+use autopilot::domain::{DomainError, UserInputError};
 use autopilot::ports::task_store::TaskStoreError;
 use autopilot::store::SqliteTaskStore;
 use autopilot::{cmd, fs, gh, git, github};
@@ -308,6 +308,9 @@ fn main() {
 /// `2` (default) for transient / unexpected failures.
 fn exit_code_for(e: &anyhow::Error) -> i32 {
     for cause in e.chain() {
+        if cause.downcast_ref::<UserInputError>().is_some() {
+            return 1;
+        }
         if let Some(domain) = cause.downcast_ref::<DomainError>() {
             if matches!(domain, DomainError::DuplicateTaskId(_)) {
                 return 1;

--- a/plugins/github-autopilot/cli/tests/cli_e2e.rs
+++ b/plugins/github-autopilot/cli/tests/cli_e2e.rs
@@ -93,6 +93,163 @@ fn e2e_help_subcommand_exits_zero() {
         .stdout(predicate::str::contains("autopilot"));
 }
 
+// ---------- F1: input validation wiring ----------
+//
+// These scenarios lock in the F1 (cli-ux-finish) wiring of `TaskId::parse`
+// and `--spec` existence checks into the `task add` and `epic create`
+// CLI handlers. The validation primitives have been on `main` since PR
+// #709; F1 just makes them visible at the binary surface so a typoed id
+// or missing path surfaces as exit code 1 with an actionable stderr
+// instead of silently inserting garbage.
+
+#[test]
+fn e2e_task_add_rejects_non_hex_id() {
+    // Lock: 12-char id with non-hex chars => `UserInputError` mapped to
+    // exit code 1, stderr names the offending input and the expected
+    // shape. Stdout stays empty (no row inserted, no "inserted task" line).
+    let ws = Workspace::new();
+    ws.touch("specs/demo.md");
+    ws.cmd()
+        .args([
+            "epic",
+            "create",
+            "--name",
+            "demo",
+            "--spec",
+            "specs/demo.md",
+        ])
+        .assert()
+        .success();
+
+    ws.cmd()
+        .args([
+            "task",
+            "add",
+            "ZZZZZZZZZZZZ",
+            "--epic",
+            "demo",
+            "--title",
+            "non-hex id",
+        ])
+        .assert()
+        .code(1)
+        .stdout(predicate::str::is_empty())
+        .stderr(
+            predicate::str::contains("invalid task id")
+                .and(predicate::str::contains("lowercase hex")),
+        );
+
+    // Confirm no row landed under that id (or any other) — `task list`
+    // should report the empty-state placeholder.
+    ws.cmd()
+        .args(["task", "list", "--epic", "demo"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("(no tasks)"));
+}
+
+#[test]
+fn e2e_task_add_rejects_wrong_length_id() {
+    // Lock: shorter-than-12 id surfaces the length-specific error message
+    // from `TaskIdParseError::InvalidLength` so an operator can tell
+    // whether they truncated vs. fat-fingered a hex char.
+    let ws = Workspace::new();
+    ws.touch("specs/demo.md");
+    ws.cmd()
+        .args([
+            "epic",
+            "create",
+            "--name",
+            "demo",
+            "--spec",
+            "specs/demo.md",
+        ])
+        .assert()
+        .success();
+
+    ws.cmd()
+        .args([
+            "task", "add", "abc", "--epic", "demo", "--title", "short id",
+        ])
+        .assert()
+        .code(1)
+        .stderr(
+            predicate::str::contains("invalid task id")
+                .and(predicate::str::contains("3 characters")),
+        );
+}
+
+#[test]
+fn e2e_task_add_accepts_valid_hex_id() {
+    // Counter-test: the validation gate must not regress the happy path —
+    // a canonical 12-char lowercase hex id still inserts and round-trips
+    // through `task list`.
+    let ws = Workspace::new();
+    ws.touch("specs/demo.md");
+    ws.cmd()
+        .args([
+            "epic",
+            "create",
+            "--name",
+            "demo",
+            "--spec",
+            "specs/demo.md",
+        ])
+        .assert()
+        .success();
+
+    ws.cmd()
+        .args([
+            "task",
+            "add",
+            "a1b2c3d4e5f6",
+            "--epic",
+            "demo",
+            "--title",
+            "valid hex id",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("inserted task a1b2c3d4e5f6"));
+
+    ws.cmd()
+        .args(["task", "list", "--epic", "demo"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("a1b2c3d4e5f6"));
+}
+
+#[test]
+fn e2e_epic_create_rejects_missing_spec() {
+    // Lock: `--spec <path>` that doesn't exist on disk surfaces a
+    // `UserInputError` (exit 1) with a message naming the missing path,
+    // and **does not** insert an epic row.
+    let ws = Workspace::new();
+    // Deliberately *not* calling `ws.touch` — the spec path must not exist.
+    ws.cmd()
+        .args([
+            "epic",
+            "create",
+            "--name",
+            "foo",
+            "--spec",
+            "specs/does-not-exist.md",
+        ])
+        .assert()
+        .code(1)
+        .stderr(
+            predicate::str::contains("does not exist")
+                .and(predicate::str::contains("specs/does-not-exist.md")),
+        );
+
+    // Confirm the rejection happened before the insert.
+    ws.cmd()
+        .args(["epic", "list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("(no epics)"));
+}
+
 #[test]
 fn e2e_task_add_then_list_shows_task() {
     // Happy-path round-trip across three commands sharing one SQLite
@@ -105,6 +262,7 @@ fn e2e_task_add_then_list_shows_task() {
     let task_id = "abc123def456"; // 12 hex chars, matches deterministic id format
     let title = "c1 demo task";
 
+    ws.touch("specs/demo.md");
     ws.cmd()
         .args([
             "epic",
@@ -146,6 +304,7 @@ fn e2e_task_lifecycle_full_flow() {
     let ws = Workspace::new();
     let task_id = "abc123def456";
 
+    ws.touch("specs/demo.md");
     ws.cmd()
         .args([
             "epic",
@@ -228,6 +387,7 @@ fn e2e_task_lifecycle_full_flow() {
 fn e2e_task_add_same_fingerprint_is_idempotent() {
     let ws = Workspace::new();
 
+    ws.touch("specs/demo.md");
     ws.cmd()
         .args([
             "epic",
@@ -298,6 +458,7 @@ fn e2e_task_add_same_fingerprint_is_idempotent() {
 fn e2e_epic_create_status_complete_flow() {
     let ws = Workspace::new();
 
+    ws.touch("specs/demo.md");
     ws.cmd()
         .args([
             "epic",
@@ -311,8 +472,8 @@ fn e2e_epic_create_status_complete_flow() {
         .success()
         .stdout(predicate::str::contains("epic 'demo' created"));
 
-    // TODO(C3): `epic create --spec` accepts a path that does not exist on
-    // disk. C3 should decide whether to validate or document the behavior.
+    // F1 (cli-ux-finish) wired in the spec-existence check — see
+    // `e2e_epic_create_rejects_missing_spec` for the rejection path.
 
     ws.cmd()
         .args(["epic", "get", "demo"])
@@ -376,6 +537,7 @@ fn e2e_epic_create_status_complete_flow() {
 fn e2e_blocked_task_becomes_claimable_after_parent_completes() {
     let ws = Workspace::new();
 
+    ws.touch("specs/demo.md");
     ws.cmd()
         .args([
             "epic",
@@ -475,6 +637,7 @@ fn e2e_task_list_filters_by_epic_and_status() {
     let ws = Workspace::new();
 
     for epic in ["alpha", "beta"] {
+        ws.touch(&format!("specs/{epic}.md"));
         ws.cmd()
             .args([
                 "epic",

--- a/plugins/github-autopilot/cli/tests/epic_tests.rs
+++ b/plugins/github-autopilot/cli/tests/epic_tests.rs
@@ -1,5 +1,5 @@
 use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use autopilot::cmd::epic::{EpicService, EpicStatusFilter};
@@ -8,7 +8,34 @@ use autopilot::ports::clock::{Clock, FixedClock};
 use autopilot::ports::task_store::{EpicPlan, EventFilter, NewTask, TaskStore};
 use autopilot::store::InMemoryTaskStore;
 use chrono::{TimeZone, Utc};
-use tempfile::NamedTempFile;
+use tempfile::{NamedTempFile, TempDir};
+
+/// Per-test scratch dir that materializes spec files on disk so
+/// `EpicService::create` (which now validates `--spec` existence) accepts
+/// them. Holds the `TempDir` so the files persist for the test's lifetime.
+struct SpecDir {
+    dir: TempDir,
+}
+
+impl SpecDir {
+    fn new() -> Self {
+        Self {
+            dir: TempDir::new().expect("create tempdir for spec files"),
+        }
+    }
+
+    /// Create an empty spec file at `<tempdir>/spec/<name>.md` and return
+    /// the absolute path. The ledger never reads the file's contents — the
+    /// validation gate only checks existence.
+    fn make(&self, name: &str) -> PathBuf {
+        let abs = self.dir.path().join("spec").join(format!("{name}.md"));
+        if let Some(parent) = abs.parent() {
+            std::fs::create_dir_all(parent).expect("create spec parent dir");
+        }
+        std::fs::File::create(&abs).expect("create spec file");
+        abs
+    }
+}
 
 fn fixture() -> (Arc<dyn TaskStore>, FixedClock) {
     let store: Arc<dyn TaskStore> = Arc::new(InMemoryTaskStore::new());
@@ -33,9 +60,9 @@ where
     format!("{:#}", f(&mut buf).unwrap_err())
 }
 
-fn seed_epic(svc: &EpicService, name: &str) {
-    let path = format!("spec/{name}.md");
-    let _ = capture(|w| svc.create(name, Path::new(&path), None, w));
+fn seed_epic(svc: &EpicService, specs: &SpecDir, name: &str) {
+    let path = specs.make(name);
+    let _ = capture(|w| svc.create(name, &path, None, w));
 }
 
 fn write_plan_jsonl(lines: &[&str]) -> NamedTempFile {
@@ -51,8 +78,10 @@ fn write_plan_jsonl(lines: &[&str]) -> NamedTempFile {
 fn create_persists_epic_and_emits_started_event() {
     let (store, clock) = fixture();
     let svc = EpicService::new(store.as_ref(), &clock);
+    let specs = SpecDir::new();
+    let spec = specs.make("e");
 
-    let (code, out) = capture(|w| svc.create("e", Path::new("spec/e.md"), None, w));
+    let (code, out) = capture(|w| svc.create("e", &spec, None, w));
     assert_eq!(code, 0, "stdout: {out}");
 
     let epics = store.list_epics(None).unwrap();
@@ -60,7 +89,7 @@ fn create_persists_epic_and_emits_started_event() {
     assert_eq!(epics[0].name, "e");
     assert_eq!(epics[0].status, EpicStatus::Active);
     assert_eq!(epics[0].branch, "epic/e");
-    assert_eq!(epics[0].spec_path, PathBuf::from("spec/e.md"));
+    assert_eq!(epics[0].spec_path, spec);
 
     let events = store
         .list_events(EventFilter {
@@ -76,7 +105,9 @@ fn create_persists_epic_and_emits_started_event() {
 fn create_uses_explicit_branch_override() {
     let (store, clock) = fixture();
     let svc = EpicService::new(store.as_ref(), &clock);
-    let (_code, _) = capture(|w| svc.create("e", Path::new("spec/e.md"), Some("custom/x"), w));
+    let specs = SpecDir::new();
+    let spec = specs.make("e");
+    let (_code, _) = capture(|w| svc.create("e", &spec, Some("custom/x"), w));
     let e = store.get_epic("e").unwrap().unwrap();
     assert_eq!(e.branch, "custom/x");
 }
@@ -85,8 +116,10 @@ fn create_uses_explicit_branch_override() {
 fn create_returns_exit_1_when_epic_already_exists() {
     let (store, clock) = fixture();
     let svc = EpicService::new(store.as_ref(), &clock);
-    let _ = capture(|w| svc.create("e", Path::new("spec/e.md"), None, w));
-    let (code, out) = capture(|w| svc.create("e", Path::new("spec/e.md"), None, w));
+    let specs = SpecDir::new();
+    let spec = specs.make("e");
+    let _ = capture(|w| svc.create("e", &spec, None, w));
+    let (code, out) = capture(|w| svc.create("e", &spec, None, w));
     assert_eq!(code, 1);
     assert!(out.contains("already exists"), "stdout: {out}");
 }
@@ -95,23 +128,25 @@ fn create_returns_exit_1_when_epic_already_exists() {
 fn create_idempotent_creates_when_epic_missing() {
     let (store, clock) = fixture();
     let svc = EpicService::new(store.as_ref(), &clock);
+    let specs = SpecDir::new();
+    let spec = specs.make("e");
 
-    let (code, out) =
-        capture(|w| svc.create_with_options("e", Path::new("spec/e.md"), None, true, w));
+    let (code, out) = capture(|w| svc.create_with_options("e", &spec, None, true, w));
     assert_eq!(code, 0, "stdout: {out}");
     assert!(out.contains("created"), "stdout: {out}");
     let e = store.get_epic("e").unwrap().unwrap();
-    assert_eq!(e.spec_path, PathBuf::from("spec/e.md"));
+    assert_eq!(e.spec_path, spec);
 }
 
 #[test]
 fn create_idempotent_succeeds_when_epic_exists_with_same_spec() {
     let (store, clock) = fixture();
     let svc = EpicService::new(store.as_ref(), &clock);
-    let _ = capture(|w| svc.create("e", Path::new("spec/e.md"), None, w));
+    let specs = SpecDir::new();
+    let spec = specs.make("e");
+    let _ = capture(|w| svc.create("e", &spec, None, w));
 
-    let (code, out) =
-        capture(|w| svc.create_with_options("e", Path::new("spec/e.md"), None, true, w));
+    let (code, out) = capture(|w| svc.create_with_options("e", &spec, None, true, w));
     assert_eq!(code, 0, "stdout: {out}");
     assert!(out.contains("already exists (idempotent)"), "stdout: {out}");
     // Single epic — no duplicate row inserted.
@@ -122,10 +157,12 @@ fn create_idempotent_succeeds_when_epic_exists_with_same_spec() {
 fn create_idempotent_errors_when_epic_exists_with_different_spec() {
     let (store, clock) = fixture();
     let svc = EpicService::new(store.as_ref(), &clock);
-    let _ = capture(|w| svc.create("e", Path::new("spec/e.md"), None, w));
+    let specs = SpecDir::new();
+    let spec = specs.make("e");
+    let other = specs.make("other");
+    let _ = capture(|w| svc.create("e", &spec, None, w));
 
-    let (code, out) =
-        capture(|w| svc.create_with_options("e", Path::new("spec/other.md"), None, true, w));
+    let (code, out) = capture(|w| svc.create_with_options("e", &other, None, true, w));
     assert_eq!(code, 1, "stdout: {out}");
     assert!(
         out.contains("different spec_path"),
@@ -133,15 +170,32 @@ fn create_idempotent_errors_when_epic_exists_with_different_spec() {
     );
     // Existing epic untouched.
     let e = store.get_epic("e").unwrap().unwrap();
-    assert_eq!(e.spec_path, PathBuf::from("spec/e.md"));
+    assert_eq!(e.spec_path, spec);
+}
+
+#[test]
+fn create_rejects_missing_spec_file() {
+    // F1 wiring lock: `epic create --spec <path>` must reject a path that
+    // doesn't exist on disk before any store mutation. Surfaces as a
+    // `UserInputError` (anyhow chain) so `main::exit_code_for` maps it to
+    // exit code 1.
+    let (store, clock) = fixture();
+    let svc = EpicService::new(store.as_ref(), &clock);
+    let missing = PathBuf::from("/tmp/autopilot-no-such-dir-xyz/spec/missing.md");
+    let msg = expect_err(|w| svc.create("e", &missing, None, w));
+    assert!(msg.contains("does not exist"), "error: {msg}");
+    assert!(msg.contains("missing.md"), "error must name path: {msg}");
+    // No epic was inserted.
+    assert!(store.list_epics(None).unwrap().is_empty());
 }
 
 #[test]
 fn list_filters_by_status_and_renders_json() {
     let (store, clock) = fixture();
     let svc = EpicService::new(store.as_ref(), &clock);
-    let _ = capture(|w| svc.create("a", Path::new("spec/a.md"), None, w));
-    let _ = capture(|w| svc.create("b", Path::new("spec/b.md"), None, w));
+    let specs = SpecDir::new();
+    let _ = capture(|w| svc.create("a", &specs.make("a"), None, w));
+    let _ = capture(|w| svc.create("b", &specs.make("b"), None, w));
     store
         .set_epic_status("b", EpicStatus::Completed, clock.now())
         .unwrap();
@@ -222,7 +276,8 @@ fn status_groups_tasks_by_state() {
 fn complete_marks_epic_completed_and_records_event() {
     let (store, clock) = fixture();
     let svc = EpicService::new(store.as_ref(), &clock);
-    let _ = capture(|w| svc.create("e", Path::new("spec/e.md"), None, w));
+    let specs = SpecDir::new();
+    let _ = capture(|w| svc.create("e", &specs.make("e"), None, w));
 
     let (code, _) = capture(|w| svc.complete("e", w));
     assert_eq!(code, 0);
@@ -250,7 +305,8 @@ fn complete_returns_exit_1_when_epic_missing() {
 fn abandon_marks_epic_abandoned() {
     let (store, clock) = fixture();
     let svc = EpicService::new(store.as_ref(), &clock);
-    let _ = capture(|w| svc.create("e", Path::new("spec/e.md"), None, w));
+    let specs = SpecDir::new();
+    let _ = capture(|w| svc.create("e", &specs.make("e"), None, w));
     let (code, _) = capture(|w| svc.abandon("e", w));
     assert_eq!(code, 0);
     assert_eq!(
@@ -263,8 +319,10 @@ fn abandon_marks_epic_abandoned() {
 fn find_by_spec_path_matches_active_epic() {
     let (store, clock) = fixture();
     let svc = EpicService::new(store.as_ref(), &clock);
-    let _ = capture(|w| svc.create("e", Path::new("spec/e.md"), None, w));
-    let (code, out) = capture(|w| svc.find_by_spec_path(Path::new("spec/e.md"), true, w));
+    let specs = SpecDir::new();
+    let spec = specs.make("e");
+    let _ = capture(|w| svc.create("e", &spec, None, w));
+    let (code, out) = capture(|w| svc.find_by_spec_path(&spec, true, w));
     assert_eq!(code, 0);
     let v: serde_json::Value = serde_json::from_str(out.trim()).unwrap();
     assert_eq!(v["name"], "e");
@@ -274,7 +332,9 @@ fn find_by_spec_path_matches_active_epic() {
 fn find_by_spec_path_returns_exit_1_when_no_match() {
     let (store, clock) = fixture();
     let svc = EpicService::new(store.as_ref(), &clock);
-    let (code, _) = capture(|w| svc.find_by_spec_path(Path::new("spec/none.md"), false, w));
+    let specs = SpecDir::new();
+    let none_spec = specs.make("none");
+    let (code, _) = capture(|w| svc.find_by_spec_path(&none_spec, false, w));
     assert_eq!(code, 1);
 }
 
@@ -303,7 +363,8 @@ fn find_by_spec_path_returns_exit_3_on_inconsistency() {
             .unwrap();
     }
     let svc = EpicService::new(store.as_ref(), &clock);
-    let (code, out) = capture(|w| svc.find_by_spec_path(Path::new("spec/shared.md"), false, w));
+    let (code, out) =
+        capture(|w| svc.find_by_spec_path(std::path::Path::new("spec/shared.md"), false, w));
     assert_eq!(code, 3);
     assert!(out.contains("inconsistency"), "stdout: {out}");
 }
@@ -312,7 +373,8 @@ fn find_by_spec_path_returns_exit_3_on_inconsistency() {
 fn reconcile_applies_jsonl_plan_and_is_idempotent() {
     let (store, clock) = fixture();
     let svc = EpicService::new(store.as_ref(), &clock);
-    let _ = capture(|w| svc.create("e", Path::new("spec/e.md"), None, w));
+    let specs = SpecDir::new();
+    let _ = capture(|w| svc.create("e", &specs.make("e"), None, w));
 
     let plan = NamedTempFile::new().unwrap();
     let lines = [
@@ -374,7 +436,8 @@ fn reconcile_returns_exit_1_when_epic_missing() {
 fn reconcile_rejects_duplicate_task_id_in_plan() {
     let (store, clock) = fixture();
     let svc = EpicService::new(store.as_ref(), &clock);
-    seed_epic(&svc, "e");
+    let specs = SpecDir::new();
+    seed_epic(&svc, &specs, "e");
 
     let plan = write_plan_jsonl(&[
         r#"{"kind":"task","id":"aaaaaaaaaaaa","title":"first"}"#,
@@ -393,7 +456,8 @@ fn reconcile_rejects_duplicate_task_id_in_plan() {
 fn reconcile_rejects_unknown_task_source() {
     let (store, clock) = fixture();
     let svc = EpicService::new(store.as_ref(), &clock);
-    seed_epic(&svc, "e");
+    let specs = SpecDir::new();
+    seed_epic(&svc, &specs, "e");
 
     let plan = write_plan_jsonl(&[
         r#"{"kind":"task","id":"aaaaaaaaaaaa","title":"x","source":"telepathy"}"#,
@@ -408,7 +472,8 @@ fn reconcile_rejects_unknown_task_source() {
 fn reconcile_skips_blank_and_comment_lines() {
     let (store, clock) = fixture();
     let svc = EpicService::new(store.as_ref(), &clock);
-    seed_epic(&svc, "e");
+    let specs = SpecDir::new();
+    seed_epic(&svc, &specs, "e");
 
     // The `#`-prefixed line is itself valid JSON; if the parser stripped `#`
     // *after* trying to deserialize it would either error or insert task
@@ -431,7 +496,8 @@ fn reconcile_skips_blank_and_comment_lines() {
 fn list_renders_human_table_when_not_json() {
     let (store, clock) = fixture();
     let svc = EpicService::new(store.as_ref(), &clock);
-    seed_epic(&svc, "alpha");
+    let specs = SpecDir::new();
+    seed_epic(&svc, &specs, "alpha");
     let (code, out) = capture(|w| svc.list(None, false, w));
     assert_eq!(code, 0);
     assert!(out.contains("alpha"));

--- a/plugins/github-autopilot/cli/tests/task_tests.rs
+++ b/plugins/github-autopilot/cli/tests/task_tests.rs
@@ -247,6 +247,52 @@ fn add_detects_duplicate_fingerprint_and_returns_same_id() {
     assert_eq!(dup_events.len(), 1);
 }
 
+#[test]
+fn add_rejects_invalid_task_id_before_store_mutation() {
+    // F1 wiring lock: a non-canonical id (wrong length / non-hex chars) is
+    // rejected via `TaskId::parse` before any store mutation, surfacing as
+    // an anyhow error chain that carries the parser message. The store
+    // remains empty so the typo cannot land a phantom row.
+    let (store, clock) = fixture();
+    let svc = TaskService::new(store.as_ref(), &clock);
+
+    // Wrong length.
+    let mut buf: Vec<u8> = Vec::new();
+    let err = svc
+        .add(
+            "e",
+            "abc",
+            "title",
+            None,
+            Some("0xDEADBEEF"),
+            TaskSourceArg::Human,
+            &mut buf,
+        )
+        .unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(msg.contains("invalid task id"), "error: {msg}");
+    assert!(msg.contains("3 characters"), "error: {msg}");
+
+    // Non-hex chars.
+    let mut buf: Vec<u8> = Vec::new();
+    let err = svc
+        .add(
+            "e",
+            "ZZZZZZZZZZZZ",
+            "title",
+            None,
+            Some("0xDEADBEEF"),
+            TaskSourceArg::Human,
+            &mut buf,
+        )
+        .unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(msg.contains("lowercase hex"), "error: {msg}");
+
+    // Store stayed clean across both rejections.
+    assert!(store.list_tasks_by_epic("e", None).unwrap().is_empty());
+}
+
 // ---------- add-batch ----------
 
 #[test]

--- a/plugins/github-autopilot/cli/tests/watch_scenarios.rs
+++ b/plugins/github-autopilot/cli/tests/watch_scenarios.rs
@@ -1040,45 +1040,112 @@ fn scenario_ready_then_claim_same_tick_no_stale_wip() {
 
 // ── Scenario 13 (event integrity): clock-skew protection ────────────────
 
-/// Documents a known limitation: if `last_event_at` in `watch.json` is
-/// somehow ahead of `clock.now()` (system clock moved backward, or the
-/// state file was copied from another machine), the SQLite query
-/// `at >= since` will silently filter out events whose `at == now`.
-/// `TASK_READY` / `EPIC_DONE` then stop firing until real time catches
-/// up to the stored future cursor.
+/// `last_event_at` in `watch.json` can end up ahead of `clock.now()`
+/// when the system clock moves backward (NTP correction, OS clock
+/// manipulation) or when the state file is copied from a host with a
+/// faster clock. The naive SQL filter `at >= since` then drops every
+/// freshly-inserted row and `TASK_READY` / `EPIC_DONE` / `STALE_WIP`
+/// emission stays frozen until wall-clock catches up to the stored
+/// cursor — potentially hours.
 ///
-/// Per the C5 task brief, this scenario is **deferred** — fixing it is a
-/// judgment call that should be made alongside a concrete recovery
-/// policy (e.g. clamp `since` to `min(last_event_at, now)`, or warn and
-/// re-anchor). The test below describes the desired behavior and is
-/// marked `#[ignore]` so CI passes while the policy is decided.
-///
-/// To reproduce the bug interactively, remove `#[ignore]` and run
-/// `cargo test -p autopilot scenario_clock_skew_does_not_freeze_emission`.
+/// Policy (clamp + warn): when the cursor is detected in the future at
+/// the read boundary (`tick_once`), clamp it down to `now`, emit a
+/// single stderr warning, and let the next periodic `save_state` persist
+/// the corrected value so the warn does not re-fire on every tick.
 #[test]
-#[ignore = "TODO(C5): clock-skew re-anchor policy not yet implemented; see PR body"]
 fn scenario_clock_skew_does_not_freeze_emission() {
     let mut fx = Fixture::new(/*stale_secs=*/ 60);
 
     // Force the ledger cursor into the future by 1 hour. In production
     // this happens when the system clock jumps backward between daemon
     // restarts.
-    fx.ts.state.ledger.last_event_at = Some(fx.now() + Duration::hours(1));
+    let future = fx.now() + Duration::hours(1);
+    fx.ts.state.ledger.last_event_at = Some(future);
 
-    // Insert a task at the (logical) current time.
+    // Insert a task at the (logical) current time. With the bug active
+    // this row's `at` would be filtered out by `WHERE at >= future`.
     ensure_epic(&fx.store, "e13", fx.now());
     fx.store
         .upsert_watch_task(watch_task("t1", "e13"), fx.now())
         .expect("upsert");
 
-    // Desired behavior: the daemon detects the future cursor, re-anchors
-    // to `now`, and emits TASK_READY for t1. Current behavior: the SQL
-    // filter `at >= since` excludes the freshly inserted row, and no
-    // event fires until real time catches up an hour later.
+    // First tick: clamp triggers, emission resumes, TASK_READY fires.
     let evs = fx.tick();
     assert_eq!(
         ready(&evs),
         vec![("e13", "t1")],
         "clock-skew must not freeze TASK_READY emission; got {evs:?}"
+    );
+
+    // Cursor was clamped: the in-memory ledger state must no longer hold
+    // the future timestamp — otherwise the next tick would re-freeze.
+    let cursor = fx
+        .ts
+        .state
+        .ledger
+        .last_event_at
+        .expect("cursor present after tick");
+    assert!(
+        cursor <= fx.now(),
+        "expected clamped cursor <= now ({}), got {cursor}",
+        fx.now()
+    );
+    assert!(
+        cursor < future,
+        "expected cursor < original future ({future}), got {cursor}"
+    );
+
+    // Second tick at the same logical time: warn-once contract — the
+    // clamp must be idempotent and emission must keep flowing for any
+    // newly-arriving rows. We add another task and expect TASK_READY.
+    fx.advance(Duration::seconds(1));
+    fx.store
+        .upsert_watch_task(watch_task("t2", "e13"), fx.now())
+        .expect("upsert");
+    let evs = fx.tick();
+    assert_eq!(
+        ready(&evs),
+        vec![("e13", "t2")],
+        "post-clamp tick must keep emitting; got {evs:?}"
+    );
+}
+
+/// Negative case for the clamp: when `last_event_at <= now` (the normal
+/// progression), `tick_once` must NOT mutate the cursor and must NOT
+/// warn. Locks the warn-frequency contract — the production warn fires
+/// only on actual skew, never on healthy ticks.
+#[test]
+fn scenario_normal_clock_progression_does_not_clamp() {
+    let mut fx = Fixture::new(/*stale_secs=*/ 60);
+
+    // Cursor parked one second in the past (a typical post-event state).
+    let cursor_before = fx.now() - Duration::seconds(1);
+    fx.ts.state.ledger.last_event_at = Some(cursor_before);
+
+    ensure_epic(&fx.store, "e13b", fx.now());
+    fx.store
+        .upsert_watch_task(watch_task("t1", "e13b"), fx.now())
+        .expect("upsert");
+
+    let evs = fx.tick();
+    assert_eq!(
+        ready(&evs),
+        vec![("e13b", "t1")],
+        "normal-case emission must work; got {evs:?}"
+    );
+
+    // The cursor will advance from `cursor_before` to the inserted row's
+    // `at` (== fx.now()) — that is normal forward progression by
+    // `detect_ledger_events`, NOT a clamp. The contract we lock here is
+    // only that the cursor never exceeds `now`.
+    let cursor_after = fx
+        .ts
+        .state
+        .ledger
+        .last_event_at
+        .expect("cursor present after tick");
+    assert!(
+        cursor_after <= fx.now(),
+        "cursor must remain <= now after normal tick, got {cursor_after}"
     );
 }

--- a/plugins/github-autopilot/cli/tests/watch_tests.rs
+++ b/plugins/github-autopilot/cli/tests/watch_tests.rs
@@ -628,3 +628,66 @@ fn ledger_state_round_trips_through_json() {
         "restart must not replay; got {after_restart:?}"
     );
 }
+
+// ── Clock-skew clamp: unit tests for `LedgerState::clamp_future_cursor` ──
+
+#[test]
+fn clamp_future_cursor_returns_original_and_clears_dedupe() {
+    let now = ledger_base_time();
+    let future = now + Duration::hours(1);
+    let mut state = LedgerState {
+        last_event_at: Some(future),
+        ..Default::default()
+    };
+    // Seed a stale dedupe key tied to the future timestamp.
+    state
+        .seen_keys
+        .insert(format!("task_inserted|t1|{}", future.timestamp_micros()));
+
+    let result = state.clamp_future_cursor(now);
+
+    assert_eq!(result, Some(future), "clamp must return original future");
+    assert_eq!(
+        state.last_event_at,
+        Some(now),
+        "cursor must be clamped to now"
+    );
+    assert!(
+        state.seen_keys.is_empty(),
+        "dedupe keys tied to the stale boundary must be cleared"
+    );
+}
+
+#[test]
+fn clamp_future_cursor_is_noop_when_cursor_at_now() {
+    let now = ledger_base_time();
+    let mut state = LedgerState {
+        last_event_at: Some(now),
+        ..Default::default()
+    };
+    let result = state.clamp_future_cursor(now);
+    assert_eq!(result, None, "cursor == now is healthy, not skew");
+    assert_eq!(state.last_event_at, Some(now));
+}
+
+#[test]
+fn clamp_future_cursor_is_noop_when_cursor_in_past() {
+    let now = ledger_base_time();
+    let past = now - Duration::hours(1);
+    let mut state = LedgerState {
+        last_event_at: Some(past),
+        ..Default::default()
+    };
+    let result = state.clamp_future_cursor(now);
+    assert_eq!(result, None);
+    assert_eq!(state.last_event_at, Some(past));
+}
+
+#[test]
+fn clamp_future_cursor_is_noop_when_cursor_unset() {
+    let now = ledger_base_time();
+    let mut state = LedgerState::default();
+    let result = state.clamp_future_cursor(now);
+    assert_eq!(result, None, "no cursor → nothing to clamp");
+    assert_eq!(state.last_event_at, None);
+}


### PR DESCRIPTION
## Summary

Closes the loose ends from the previous `epic/cli-ux-hardening` (which merged the validation/test foundation but explicitly punted two pieces to follow-ups). This rollup brings those two PRs into main so the epic is end-to-end complete.

## What landed

| PR | Scope |
|----|-------|
| #712 | **F1: validation wiring** — `cmd::task::add` (and `add-batch`) now call `TaskId::parse` instead of `from_raw`, surfacing typoed ids as exit-1 + actionable stderr instead of inserting garbage. `cmd::epic::create --spec` now requires the path to exist. New e2e scenarios pin stderr/exit-code; new unit tests pin service-level rejection. `main::exit_code_for` extended with `UserInputError` mapping |
| #714 | **F2: clock-skew freeze fix** — `LedgerState::clamp_future_cursor(now)` clamps `last_event_at` if it ever exceeds `now` (e.g. NTP rollback, watch.json copied across hosts), clears stale `seen_keys`, emits a one-line stderr warn, and persists. Wired into `WatchService::tick_once` per-tick. Previously-ignored `scenario_clock_skew_does_not_freeze_emission` is now active; positive `scenario_normal_clock_progression_does_not_clamp` added. 4 unit tests on `clamp_future_cursor` directly |

## Why this rollup exists

`epic/cli-ux-hardening` (#710) merged the validation **primitives** (`TaskId::parse`, `UserInputError`, recovery-hint error messages) but the wiring through the CLI surface and the watch clock-skew fix were left as PR-body follow-ups. That violated the epic-completion principle ("epic 내부에서 완결성 있게 마무리"). This rollup restores it.

## Policy decisions noted in PRs

- **Exit code mapping for `UserInputError`**: extended `main::exit_code_for` with one downcast arm (matches existing `DuplicateTaskId` pattern) rather than per-call wrapping.
- **Clock-skew handling**: `clamp + warn` (not silent clamp, not destructive reset). NTP correction and OS clock adjustment are normal scenarios; resetting `watch.json` would lose legitimate progress state.

## Test plan

- [x] F1 quality gate green (fmt / clippy / test)
- [x] F2 quality gate green (fmt / clippy / test, 0 ignored)
- [x] e2e_task_add_rejects_non_hex_id / wrong_length_id / accepts_valid_hex_id
- [x] e2e_epic_create_rejects_missing_spec
- [x] scenario_clock_skew_does_not_freeze_emission (no longer ignored)
- [x] scenario_normal_clock_progression_does_not_clamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)