### PR TITLE
fix(github-autopilot): force issue-implementer worktree to sync from origin

### DIFF
--- a/plugins/github-autopilot/agents/issue-implementer.md
+++ b/plugins/github-autopilot/agents/issue-implementer.md
@@ -25,11 +25,25 @@ skills: ["draft-branch"]
 
 ### Phase 1: 분석
 
-0. **이전 작업 확인**:
+0. **이전 작업 확인 및 origin 동기화**:
+
+   > **WHY**: worktree는 MainAgent의 로컬 base 브랜치 tip에서 생성된다. MainAgent의 로컬이 `origin/{base_branch}`보다 뒤처져 있으면 stale snapshot 위에서 작업하게 되어 "spec/README.md missing" 같은 false `invalid_premise` 실패가 발생한다. 따라서 작업 시작 전 반드시 origin에서 최신 base를 fetch해야 한다.
+
    - `git branch --list draft/issue-{N}`으로 기존 draft 브랜치 존재 여부 확인
-   - 있으면: checkout 후 `git log --oneline -5`로 이전 작업 내용 파악. `wip: partial work` 커밋이 있으면 이전 cycle에서 중단된 작업이므로 이어서 진행
-   - issue_comments에서 최신 failure marker(`<!-- autopilot:failure:N -->`)의 실패 카테고리와 사유를 읽고, 동일한 실수를 반복하지 않도록 접근 방식을 조정
-   - 없으면: base_branch에서 새 draft 브랜치 생성
+   - **있으면 (resume)**: checkout 후 `origin/{base_branch}`로 rebase하여 wip 커밋을 최신 base 위에 다시 올린다.
+     ```bash
+     git fetch origin {base_branch}
+     git checkout draft/issue-{N}
+     git rebase origin/{base_branch}   # wip 커밋 보존, 최신 base에 재적용
+     ```
+     - `git log --oneline -5`로 이전 작업 내용 파악. `wip: partial work` 커밋이 있으면 이전 cycle에서 중단된 작업이므로 이어서 진행
+     - rebase 충돌이 발생하면 freshness 문제가 아니라 실제 의미적 충돌이다. 자동 해결을 시도하지 말고 `failure_category: dependency_error`로 보고 후 중단한다.
+     - issue_comments에서 최신 failure marker(`<!-- autopilot:failure:N -->`)의 실패 카테고리와 사유를 읽고, 동일한 실수를 반복하지 않도록 접근 방식을 조정
+   - **없으면 (new)**: `origin/{base_branch}`에서 새 draft 브랜치 생성한다.
+     ```bash
+     git fetch origin {base_branch}
+     git checkout -b draft/issue-{N} origin/{base_branch}
+     ```
 
 1. **이슈 요구사항 정리**: body와 comments에서 구현 항목, 수용 기준 추출 (comments의 "Autopilot 분석 결과" 섹션에 영향 범위와 구현 가이드가 포함되어 있을 수 있음)
 2. **코드베이스 파악**:

--- a/plugins/github-autopilot/commands/build-issues.md
+++ b/plugins/github-autopilot/commands/build-issues.md
@@ -232,6 +232,8 @@ echo '${COMMENTS_JSON}' | autopilot issue filter-comments
 - base_branch: Step 1에서 결정한 base 브랜치
 - quality_gate_command: 설정에서 읽은 값 (비어있으면 자동 감지)
 
+> **Worktree origin freshness**: implementer는 worktree 진입 시 반드시 `origin/{base_branch}`를 fetch한 뒤 draft 브랜치를 생성/rebase해야 합니다. 자세한 절차는 `agents/issue-implementer.md` Phase 1 Step 0 참조. MainAgent의 로컬 base가 stale일 수 있으므로 base_branch만 전달하고 freshness 보장은 implementer 책임입니다.
+
 ### Step 9: 결과 수집
 
 모든 에이전트의 결과를 수집합니다.


### PR DESCRIPTION
## Summary

Closes #642 (P1, epic/autopilot-stability O2).

issue-implementer worktrees were created from MainAgent's **local** base-branch tip. When MainAgent's local was behind `origin/<base>`, the spawned worktree operated on a stale snapshot — producing false `invalid_premise` failures (e.g. "spec/README.md missing") and wasted retries. Multi-cycle parallel runs amplified the gap because batch 2 wouldn't see batch 1's already-merged work until the next outer cycle re-synced.

## Changes

### `agents/issue-implementer.md` Phase 1 Step 0

**Before:**
```
- 있으면: checkout 후 git log --oneline -5
- 없으면: base_branch에서 새 draft 브랜치 생성
```

**After:**
- New draft (no existing branch):
  ```bash
  git fetch origin {base_branch}
  git checkout -b draft/issue-{N} origin/{base_branch}
  ```
- Resume (existing branch with possible wip commits):
  ```bash
  git fetch origin {base_branch}
  git checkout draft/issue-{N}
  git rebase origin/{base_branch}
  ```
  Rebase preserves wip commits; if it conflicts, implementer reports `dependency_error` and stops (it's a real semantic conflict, not a freshness issue).
- Added a one-line WHY block explaining the stale-snapshot failure mode.

### `commands/build-issues.md` Step 8

Added a single note in the agent-handoff block pointing to `agents/issue-implementer.md` Step 0. The skill stays a pure handoff — base_branch is passed and freshness becomes the implementer's responsibility.

## Test plan

- [ ] Markdown renders: bash code fences inside numbered list items display correctly on GitHub
- [ ] Phase 1 Step 0 reads coherently as one procedure covering both new-draft and resume cases
- [ ] No other Phase 1 / Phase 2 step assumed `git checkout` from local base — verified by reading full file end-to-end
- [ ] In a real autopilot cycle, confirm new worktrees start at `origin/<base>` SHA (not local base SHA)

## Notes

- No other agent template (issue-dependency-analyzer, branch-promoter, analyze-issue) creates worktrees from local base, so this is the only template needing the fix. branch-promoter operates on `draft/issue-{N}` which after this PR is already on `origin/{base}`, so it inherits freshness.
- `skills/branch-sync/SKILL.md` still applies in MainAgent's working tree only, as intended; worktree-side fetch is now explicit in the implementer template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)