### PR TITLE
feat(github-autopilot): add --max-parallel capacity check to pipeline idle

### DIFF
--- a/plugins/github-autopilot/cli/Cargo.lock
+++ b/plugins/github-autopilot/cli/Cargo.lock
@@ -111,7 +111,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autopilot"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/plugins/github-autopilot/cli/src/cmd/mod.rs
+++ b/plugins/github-autopilot/cli/src/cmd/mod.rs
@@ -354,11 +354,23 @@ pub enum LoopStatus {
 
 #[derive(Subcommand)]
 pub enum PipelineCommands {
-    /// Check if the autopilot pipeline is idle
+    /// Check if the autopilot pipeline is idle.
+    ///
+    /// Exit codes:
+    ///   0 — idle (no ready, wip, or open autopilot PRs)
+    ///   1 — active (work in flight, capacity check skipped or below cap)
+    ///   3 — at-capacity (only when --max-parallel is set and wip >= N).
+    ///       Skip dispatching new work; the in-flight cycle is still running.
     Idle {
         /// Label prefix (default: "autopilot:")
         #[arg(long, default_value = "autopilot:")]
         label_prefix: String,
+        /// Optional WIP capacity. When set, exit `3` is returned if the
+        /// number of `:wip` issues already meets/exceeds this value (i.e.
+        /// the pipeline is active and at-capacity). Without this flag the
+        /// command falls back to the legacy idle/active contract.
+        #[arg(long)]
+        max_parallel: Option<u64>,
     },
 }
 

--- a/plugins/github-autopilot/cli/src/cmd/pipeline.rs
+++ b/plugins/github-autopilot/cli/src/cmd/pipeline.rs
@@ -3,9 +3,19 @@ use std::sync::Arc;
 
 use crate::gh::{self, GhOps};
 
-/// Check if the autopilot pipeline is idle (no active issues or PRs).
-/// Returns exit code: 0 = idle, 1 = active.
-pub fn idle(client: Arc<dyn GhOps>, label_prefix: &str) -> Result<i32> {
+/// Check the autopilot pipeline state.
+///
+/// Exit codes:
+/// - `0` idle: `ready + wip + prs == 0`
+/// - `3` at-capacity: `--max-parallel <N>` supplied AND `wip >= N` (skip new
+///   dispatch — capacity is full, in-flight cycle still running)
+/// - `1` active: pipeline has work in flight but capacity remains, OR
+///   `--max-parallel` not supplied (caller hasn't opted into capacity check)
+///
+/// `max_parallel` is `None` when the caller did not pass `--max-parallel`,
+/// in which case the at-capacity branch is disabled and behavior matches
+/// the original `idle/active` contract.
+pub fn idle(client: Arc<dyn GhOps>, label_prefix: &str, max_parallel: Option<u64>) -> Result<i32> {
     use super::labels;
     let ready_label = labels::with_prefix(label_prefix, labels::READY);
     let wip_label = labels::with_prefix(label_prefix, labels::WIP);
@@ -50,22 +60,35 @@ pub fn idle(client: Arc<dyn GhOps>, label_prefix: &str) -> Result<i32> {
         }),
     ]);
 
-    let ready = results[0].as_ref().map_err(|e| anyhow::anyhow!("{e}"))?;
-    let wip = results[1].as_ref().map_err(|e| anyhow::anyhow!("{e}"))?;
-    let prs = results[2].as_ref().map_err(|e| anyhow::anyhow!("{e}"))?;
+    let ready = *results[0].as_ref().map_err(|e| anyhow::anyhow!("{e}"))?;
+    let wip = *results[1].as_ref().map_err(|e| anyhow::anyhow!("{e}"))?;
+    let prs = *results[2].as_ref().map_err(|e| anyhow::anyhow!("{e}"))?;
 
     let is_idle = ready + wip + prs == 0;
+    // at-capacity is only meaningful when caller specified the cap. Without
+    // --max-parallel we don't know what "capacity" means, so we fall back to
+    // the original idle/active contract.
+    let at_capacity = match max_parallel {
+        Some(n) if !is_idle => wip >= n,
+        _ => false,
+    };
 
-    let out = serde_json::json!({
+    let mut out = serde_json::json!({
         "idle": is_idle,
         "ready": ready,
         "wip": wip,
         "prs": prs,
     });
+    if let Some(n) = max_parallel {
+        out["max_parallel"] = serde_json::json!(n);
+        out["at_capacity"] = serde_json::json!(at_capacity);
+    }
     println!("{out}");
 
     if is_idle {
         Ok(0)
+    } else if at_capacity {
+        Ok(3)
     } else {
         Ok(1)
     }

--- a/plugins/github-autopilot/cli/src/main.rs
+++ b/plugins/github-autopilot/cli/src/main.rs
@@ -78,9 +78,10 @@ fn main() {
         Commands::Pipeline { command } => {
             let client = gh::real();
             match command {
-                PipelineCommands::Idle { label_prefix } => {
-                    cmd::pipeline::idle(client, &label_prefix)
-                }
+                PipelineCommands::Idle {
+                    label_prefix,
+                    max_parallel,
+                } => cmd::pipeline::idle(client, &label_prefix, max_parallel),
             }
         }
         Commands::Check { command } => {

--- a/plugins/github-autopilot/cli/tests/pipeline_tests.rs
+++ b/plugins/github-autopilot/cli/tests/pipeline_tests.rs
@@ -13,7 +13,7 @@ fn idle_returns_0_when_no_active_items() {
             .on_list_containing("autopilot:auto", vec![]),
     );
 
-    let code = autopilot::cmd::pipeline::idle(gh, "autopilot:").unwrap();
+    let code = autopilot::cmd::pipeline::idle(gh, "autopilot:", None).unwrap();
     assert_eq!(code, 0);
 }
 
@@ -29,7 +29,7 @@ fn idle_returns_1_when_ready_issues_exist() {
             .on_list_containing("autopilot:auto", vec![]),
     );
 
-    let code = autopilot::cmd::pipeline::idle(gh, "autopilot:").unwrap();
+    let code = autopilot::cmd::pipeline::idle(gh, "autopilot:", None).unwrap();
     assert_eq!(code, 1);
 }
 
@@ -42,6 +42,117 @@ fn idle_returns_1_when_only_prs_exist() {
             .on_list_containing("autopilot:auto", vec![json!({"number": 5})]),
     );
 
-    let code = autopilot::cmd::pipeline::idle(gh, "autopilot:").unwrap();
+    let code = autopilot::cmd::pipeline::idle(gh, "autopilot:", None).unwrap();
+    assert_eq!(code, 1);
+}
+
+// --- Capacity check (`--max-parallel`) ----------------------------------
+// Exit codes:
+//   0 = idle (ready + wip + prs == 0)
+//   3 = at-capacity (wip >= max_parallel) — only when --max-parallel is set
+//   1 = active and has capacity (or no --max-parallel given)
+
+#[test]
+fn idle_returns_3_when_wip_at_capacity() {
+    // wip == max_parallel, ready > 0 → at-capacity (skip new dispatch)
+    let gh = Arc::new(
+        MockGh::new()
+            .on_list_containing(
+                "autopilot:ready",
+                vec![json!({"number": 10}), json!({"number": 11})],
+            )
+            .on_list_containing(
+                "autopilot:wip",
+                vec![
+                    json!({"number": 1}),
+                    json!({"number": 2}),
+                    json!({"number": 3}),
+                ],
+            )
+            .on_list_containing("autopilot:auto", vec![]),
+    );
+
+    let code = autopilot::cmd::pipeline::idle(gh, "autopilot:", Some(3)).unwrap();
+    assert_eq!(code, 3);
+}
+
+#[test]
+fn idle_returns_3_when_wip_exceeds_capacity() {
+    // wip > max_parallel — still at-capacity
+    let gh = Arc::new(
+        MockGh::new()
+            .on_list_containing("autopilot:ready", vec![])
+            .on_list_containing(
+                "autopilot:wip",
+                vec![
+                    json!({"number": 1}),
+                    json!({"number": 2}),
+                    json!({"number": 3}),
+                    json!({"number": 4}),
+                ],
+            )
+            .on_list_containing("autopilot:auto", vec![]),
+    );
+
+    let code = autopilot::cmd::pipeline::idle(gh, "autopilot:", Some(3)).unwrap();
+    assert_eq!(code, 3);
+}
+
+#[test]
+fn idle_returns_1_when_wip_below_capacity_with_ready() {
+    // wip=2 < max_parallel=3, ready>0 → active, has capacity
+    let gh = Arc::new(
+        MockGh::new()
+            .on_list_containing("autopilot:ready", vec![json!({"number": 10})])
+            .on_list_containing(
+                "autopilot:wip",
+                vec![json!({"number": 1}), json!({"number": 2})],
+            )
+            .on_list_containing("autopilot:auto", vec![]),
+    );
+
+    let code = autopilot::cmd::pipeline::idle(gh, "autopilot:", Some(3)).unwrap();
+    assert_eq!(code, 1);
+}
+
+#[test]
+fn idle_returns_0_when_fully_idle_regardless_of_capacity() {
+    // wip=0, ready=0, prs=0 → idle wins even with --max-parallel set
+    let gh = Arc::new(
+        MockGh::new()
+            .on_list_containing("autopilot:ready", vec![])
+            .on_list_containing("autopilot:wip", vec![])
+            .on_list_containing("autopilot:auto", vec![]),
+    );
+
+    let code = autopilot::cmd::pipeline::idle(gh, "autopilot:", Some(3)).unwrap();
+    assert_eq!(code, 0);
+}
+
+#[test]
+fn idle_without_max_parallel_treats_high_wip_as_active() {
+    // No --max-parallel → backward compat: any wip is just "active" (exit 1).
+    let gh = Arc::new(
+        MockGh::new()
+            .on_list_containing("autopilot:ready", vec![])
+            .on_list_containing(
+                "autopilot:wip",
+                vec![
+                    json!({"number": 1}),
+                    json!({"number": 2}),
+                    json!({"number": 3}),
+                    json!({"number": 4}),
+                    json!({"number": 5}),
+                    json!({"number": 6}),
+                    json!({"number": 7}),
+                    json!({"number": 8}),
+                    json!({"number": 9}),
+                    json!({"number": 10}),
+                ],
+            )
+            .on_list_containing("autopilot:auto", vec![]),
+    );
+
+    let code = autopilot::cmd::pipeline::idle(gh, "autopilot:", None).unwrap();
     assert_eq!(code, 1);
 }

--- a/plugins/github-autopilot/commands/build-issues.md
+++ b/plugins/github-autopilot/commands/build-issues.md
@@ -33,15 +33,24 @@ autopilot 라벨이 붙은 GitHub 이슈를 가져와 의존성을 분석하고,
 
 - `max_parallel_agents`: 동시에 실행할 최대 에이전트 수 (기본값: 3)
 
-### Step 3: Pipeline Idle Check
+### Step 3: Pipeline Idle / Capacity Check
+
+Step 2에서 읽은 `max_parallel_agents`를 capacity로 전달합니다. wip 라벨 수가 capacity에 도달했는지 한 번의 호출로 함께 판정하여, 동시 실행 충돌을 사전에 차단합니다.
 
 ```bash
-autopilot pipeline idle --label-prefix "{label_prefix}"
+autopilot pipeline idle \
+  --label-prefix "{label_prefix}" \
+  --max-parallel ${max_parallel_agents}
 ```
 
-- **exit 0 (idle)**: `notification` 설정이 있으면 "autopilot 파이프라인 완료 — build-issues cycle 중단" 알림 발송 후 종료합니다.
-- **exit 2 (error)**: 스크립트 실행 환경 오류. 에러 메시지를 출력하고 이번 cycle을 skip합니다.
-- **exit 1 (active)**: Step 4부터 정상 진행
+| exit code | 의미 | 동작 |
+|-----------|------|------|
+| `0` (idle) | `ready + wip + prs == 0` | `notification` 설정이 있으면 "autopilot 파이프라인 완료 — build-issues cycle 중단" 알림 발송 후 종료합니다. |
+| `1` (active, 여유 있음) | wip < `max_parallel_agents` | Step 4부터 정상 진행합니다. |
+| `3` (at-capacity) | wip ≥ `max_parallel_agents` | "capacity full (wip: ${WIP_COUNT}/${max_parallel_agents}) — next cron tick에 재시도"를 출력하고 **즉시 종료**합니다. dependency-analyzer / filter-comments / issue-implementer 등 모든 agent 호출을 건너뜁니다. (이번 cycle에서는 이슈 분석/dispatch 비용을 발생시키지 않습니다.) |
+| `2` (error) | 스크립트 실행 환경 오류 | 에러 메시지를 출력하고 이번 cycle을 skip합니다. |
+
+> `--max-parallel`을 생략하면 기존 idle/active 동작으로 동작하지만, build-issues는 항상 capacity를 함께 검사해야 하므로 이 인자를 필수로 전달합니다.
 
 ### Step 3.5: Idle Count Check + Adaptive Throttling
 


### PR DESCRIPTION
## Summary

`build-issues` cron tick (default `*/15`) previously couldn't tell "active with capacity" from "active at capacity". When `wip == max_parallel_agents`, the next tick still proceeded through `dependency-analyzer` / `filter-comments` and launched a second batch that competed with the in-flight cycle (user manually skipped 4 times in one session).

This PR adds a `--max-parallel <N>` flag to `autopilot pipeline idle` and a new exit code `3` (at-capacity) so build-issues can short-circuit before any agent dispatch.

Closes #644

## Exit-code contract (final)

| exit | meaning | condition |
|------|---------|-----------|
| `0` | idle | `ready + wip + prs == 0` |
| `1` | active, has capacity (or `--max-parallel` not supplied) | otherwise |
| `2` | runtime error | (unchanged) |
| `3` | **at-capacity (NEW)** | `--max-parallel N` supplied AND `wip >= N` |

`--max-parallel` is opt-in. Without the flag, behavior is unchanged (exit 0 idle, exit 1 active) so the other 6 callers (`merge-prs`, `qa-boost`, `ci-watch`, `ci-fix`, `gap-watch`, `test-watch`) keep working with no edits.

## Production code

- `plugins/github-autopilot/cli/src/cmd/pipeline.rs` — `idle()` now takes `max_parallel: Option<u64>`; computes `at_capacity = wip >= n` (only when not idle); JSON output adds `max_parallel`/`at_capacity` fields when flag is set; new exit branch returns `3`.
- `plugins/github-autopilot/cli/src/cmd/mod.rs` — `PipelineCommands::Idle` gets `--max-parallel <N>` clap arg + multi-line doc covering all 4 exit codes (visible in `--help`).
- `plugins/github-autopilot/cli/src/main.rs` — pattern-matches new field, threads it into `pipeline::idle`.
- `plugins/github-autopilot/commands/build-issues.md` Step 3 — passes `--max-parallel ${max_parallel_agents}`, branches on exit 3 to skip the cycle silently with a brief "capacity full (wip: ${WIP_COUNT}/${N}) — next cron tick에 재시도" message and **no agent calls**.

## New tests (`cli/tests/pipeline_tests.rs`)

- `idle_returns_3_when_wip_at_capacity` — wip=3, ready>0, max_parallel=3 → exit 3
- `idle_returns_3_when_wip_exceeds_capacity` — wip=4 > max_parallel=3 → exit 3
- `idle_returns_1_when_wip_below_capacity_with_ready` — wip=2 < 3, ready>0 → exit 1
- `idle_returns_0_when_fully_idle_regardless_of_capacity` — wip=0, ready=0, prs=0, max_parallel=3 → exit 0
- `idle_without_max_parallel_treats_high_wip_as_active` — wip=10, no flag → exit 1 (back-compat)

Existing 3 pipeline tests updated to pass `None` for the new param and continue to pass.

## Build-issues Step 3 — before / after

**Before:**
\`\`\`
exit 0 (idle) → notify + exit
exit 1 (active) → proceed to Step 4+
\`\`\`

**After:**
\`\`\`
exit 0 (idle) → notify + exit
exit 1 (active, has capacity) → proceed to Step 4+
exit 3 (at-capacity) → print "capacity full ... next cron tick에 재시도" + exit (no agent dispatch)
\`\`\`

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -p autopilot --tests -- -D warnings` passes
- [x] `cargo test -p autopilot` — all 8 pipeline tests pass + full suite green (no regressions)
- [ ] Manual: run `autopilot pipeline idle --label-prefix "autopilot:" --max-parallel 3` against a repo with `wip == 3` and verify exit code `3` + JSON has `at_capacity: true`
- [ ] Manual: confirm callers without `--max-parallel` (e.g. `merge-prs`) still see exit 0/1 and never exit 3

## Notes for reviewers

- 6 other callers of `pipeline idle` (merge-prs, qa-boost, ci-watch, ci-fix, gap-watch, test-watch + README) continue to omit `--max-parallel`. They will never observe exit 3 — by design, since their cycles don't dispatch concurrent worktree-bound implementer agents and don't need capacity gating.
- `max_parallel` typed as `u64` to match `count_items` return type and avoid casts.
- Output JSON only includes `max_parallel` / `at_capacity` when the flag is present, keeping legacy callers' output bytes-stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)