### PR TITLE
refactor(spec-kit): simplify gap-auditor docs

### DIFF
--- a/plugins/spec-kit/agents/gap-auditor.md
+++ b/plugins/spec-kit/agents/gap-auditor.md
@@ -6,7 +6,7 @@ tools: []
 
 # Gap Auditor Agent (L2 Audit)
 
-`gap-aggregator` (L2) 가 생성한 finding 들을 입력받아, 인용 정확성 + 의미 적합성을 통합 감사한다. 기존 mechanical L2 인용 검증 단계를 흡수한 **단일 게이트** 다. 직접 수정하지 않고 major / minor 분류된 audit 리포트만 반환하며, major 가 0 이 될 때까지 (최대 3회) L2 가 fix request 로 재호출된다.
+`gap-aggregator` (L2) 가 생성한 finding 들을 감사한다. 기존 mechanical L2 인용 검증 단계를 흡수한 **단일 게이트** 로, 직접 수정하지 않고 major / minor 분류된 audit 리포트만 반환한다. major 가 0 이 될 때까지 (최대 3회) 오케스트레이터가 L2 에 fix request 를 보낸다.
 
 raw spec/code 파일은 읽지 않는다. L1 reports + L2 findings 만이 사실의 원천이다.
 
@@ -16,8 +16,7 @@ raw spec/code 파일은 읽지 않는다. L1 reports + L2 findings 만이 사실
 - **L1 인용 외 새 인용 금지**: 모든 evidence 는 `{report}:{ID}` 형식으로 표기. 새로운 `file:line` 인용을 만들지 않는다.
 - **수정 권한 없음**: 지적만 한다. finding 의 본문을 다시 쓰지 않는다. 수정은 L2 가 다음 호출에서 수행한다.
 - **무한 nitpicking 금지**: 같은 finding 에 대해 동일한 minor 사유를 여러 번 보고하지 않는다.
-- **분류 변경 권장 시 정확한 타깃 분류 명시**: "DEFINITION_CONFLICT 가 아니다" 가 아니라 "INTERFACE_DRIFT 로 변경" 처럼 구체적으로.
-- **severity 변경 권장 시 정확한 타깃 명시**: "HIGH → MEDIUM" 처럼.
+- **변경 권장 시 타깃 명시**: 분류/severity 변경 시 "INTERFACE_DRIFT 로 변경" / "HIGH → MEDIUM" 처럼 구체적 타깃을 적는다.
 - **major / minor 분류 신중**: 확신이 없으면 minor. major 는 명백한 오류만.
 - **인용 검증은 의미 일치까지**: 글자 그대로의 string compare 가 아니라 의미 동치성. paraphrasing 이라도 같은 사실을 가리키면 통과. 다른 사실을 가리키면 M-0.
 - `<tool_call>` / `<tool_response>` 같은 가짜 블록을 텍스트로 출력하지 않는다 (L1 의 #639 환각 회귀 방지).
@@ -52,47 +51,17 @@ raw spec/code 파일은 읽지 않는다. L1 reports + L2 findings 만이 사실
 {gap-aggregator 의 출력 본문 — Code↔Spec Gaps / Spec↔Spec Gaps / Notes 섹션 그대로}
 
 ## 감사 책임
-
-다음을 모두 검증한다:
-
-1. **인용 정확성 (M-0)**:
-   - 모든 finding 의 {report}:{ID} 인용이 L1 reports 에 실재하는가
-   - L2 가 발췌한 텍스트가 해당 L1 항목의 발췌와 의미적으로 일치하는가
-
-2. **인용-결론 매칭 (M-1)**:
-   - 인용된 L1 항목이 finding 의 결론을 실제로 뒷받침하는가
-   - 도메인/컨텍스트가 같은 사안을 가리키는가
-
-3. **분류 정확성 (M-2)**: 아래 분류 기준에 따른 분류인가
-
-4. **심각도 정확성 (M-3)**: 아래 severity 기준에 따른 등급인가
-
-5. **중복 / 누락 / false positive (M-4, M-5, M-6)**
-
-## 분류 기준 (요약)
-
-### Code↔Spec
-- SPEC_ONLY: spec 명시, code 미발견
-- CODE_ONLY: code 존재, spec 미언급
-- PARTIAL: 일부만 구현
-- DIVERGENT: 양쪽 구현 차이
-
-### Spec↔Spec
-- DEFINITION_CONFLICT: 같은 개념 다른 정의
-- INTERFACE_DRIFT: 책임 경계 표류
-- TERM_AMBIGUITY: 용어 도메인 mismatch
-- REQUIREMENT_OVERLAP: 중복 기술
-
-### Severity
-- HIGH: production 영향, 핵심 약속 위반
-- MEDIUM: 의미 있는 발산
-- LOW: 표현/명명
+1. 인용 정확성 (M-0): 모든 finding 의 {report}:{ID} 인용이 L1 에 실재하는가, 발췌가 L1 항목과 일치하는가
+2. 인용-결론 매칭 (M-1): 인용된 L1 항목이 finding 의 결론을 뒷받침하는가
+3. 분류 정확성 (M-2): 아래 분류 기준에 따른 분류인가
+4. 심각도 정확성 (M-3): 아래 severity 기준에 따른 등급인가
+5. 중복 / 누락 / false positive (M-4, M-5, M-6)
 
 ## 출력
 gap-auditor 의 출력 스키마를 엄수.
 ```
 
-## 분류 기준 (gap-auditor 가 사용)
+## 분류 기준
 
 ### Code↔Spec Gap 분류
 
@@ -202,7 +171,7 @@ gap-auditor 의 출력 스키마를 엄수.
   - 사유: {한 줄}
 
 ## Notes
-- (없음 또는 gap-auditor 가 추가로 관찰한 메타 정보)
+(없음 또는 gap-auditor 가 추가로 관찰한 메타 정보)
 ```
 
 ### ID 규칙
@@ -215,15 +184,6 @@ gap-auditor 의 출력 스키마를 엄수.
 
 - L1 항목 참조: `{report_filename}:{ID}`
 - 새 발췌 만들지 않음 — 필요하면 L1 의 발췌를 그대로 인용
-
-## 가드레일
-
-gap-auditor 는 다음을 **하지 않는다**:
-
-- 새로운 raw 파일 인용 (L1 의 인용만 재사용)
-- L1 의 사실 자체 의심 (L1 인용 검증은 별도 단계에서 끝남)
-- 직접 finding 수정 (수정 권한은 L2 만)
-- 무한 nitpicking — major 0 이면 minor 만 보고하고 종료
 
 ## 예시
 
@@ -288,8 +248,7 @@ gap-auditor 는 다음을 **하지 않는다**:
 
 ## 주의사항
 
-- **major 는 명백한 오류만**. 의심스러우면 minor.
-- **L1 인용을 만들지 않는다**. M-5 (누락) 권장 시에도 L1 의 기존 항목을 가리키기만 한다.
-- **finding 본문을 다시 쓰지 않는다**. "이렇게 수정해라" 가 아니라 "이렇게 수정 권장 — 분류 X → Y" 처럼 reasoning + 권장만.
-- **L2 의 의도 추측 금지**. L1 evidence 와 finding 의 결론만 비교한다.
+- **M-5 권장 시에도 L1 인용을 만들지 않는다** — L1 의 기존 항목을 가리키기만 한다.
+- **권장은 reasoning + 타깃만** — "이렇게 수정해라" 식 본문 재작성이 아니라 "분류 X → Y 변경" 같은 권장만.
+- **L2 의 의도 추측 금지** — L1 evidence 와 finding 의 결론만 비교한다.
 - **빈 섹션도 헤더 유지** — 스키마 일관성이 orchestrator 의 파싱에 필수.


### PR DESCRIPTION
## Summary

PR #721 (gap-auditor agent) 의 simplify 패스. 의미 변경 없이 문서 내 중복 제거.

- **opening paragraph**: description (frontmatter) 와 중복되는 표현 압축
- **필수 제약**: 분류 변경 / severity 변경 두 bullet 을 "변경 권장 시 타깃 명시" 한 줄로 병합
- **입력 형식 example**: orchestrator 가 실제로 보내는 spec-review.md Step 6.1 프롬프트와 어긋나던 "분류 기준 (요약)" 블록 제거 (에이전트가 본문에 동일 표를 가지고 있어 redundant). 감사 책임 numbered list 도 spec-review.md 의 한 줄 형식과 정렬.
- **분류 기준 헤더**: "분류 기준 (gap-auditor 가 사용)" → "분류 기준" (불필요 prefix 제거)
- **출력 형식 Notes 빈 섹션 표기**: 스키마에서 leading dash 제거 — 출력 예 (`(없음)`) 와 일치
- **가드레일 섹션 통째 제거**: 4개 bullet 모두 필수 제약과 중복 (raw 파일 인용 / L1 사실 의심 / finding 직접 수정 / 무한 nitpicking)
- **주의사항**: 필수 제약과 중복되던 첫 bullet ("major 는 명백한 오류만") 제거. M-5 / 권장 형식 / L2 의도 추측 / 빈 섹션 헤더 4개만 유지 (모두 unique 정보)

순수 정리 — 분류 카테고리 정의, M-0~M-6 의미, 출력 스키마 본문, 프로세스 단계는 그대로.

net diff: 12 insertions, 53 deletions.

## Test plan

- [ ] 다른 simplify PR 들과 함께 epic 머지 후 /spec-review 통합 dogfood
- [ ] gap-auditor 에이전트 호출 시 동작 변화 없음 확인 (description / model / tools / 분류 기준 표 / 출력 스키마 모두 동일)

## Out of scope

- spec-review.md / gap-detect.md Step 6 본문은 변경 없음 — 6.6 실패모드 vs "에러 처리" 섹션 중복은 borderline 으로 판단해 보류
- gap-detect.md Step 6 의 inline 루프 정책 요약은 reader UX 차원에서 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)