### PR TITLE
fix(github-autopilot): guard pr-merger agent merge with exit-code check

### DIFF
--- a/plugins/github-autopilot/agents/pr-merger.md
+++ b/plugins/github-autopilot/agents/pr-merger.md
@@ -66,40 +66,87 @@ gh api repos/{owner}/{repo}/pulls/${PR_NUMBER}/comments --jq '.[] | {path, body,
 
 ### 3. 머지 시도
 
-모든 문제 해결 후:
+모든 문제 해결 후 머지를 시도합니다.
+
+**중요**: `gh pr merge` 의 종료 코드를 반드시 검사해야 합니다. 머지가 실패한 경우 (예: `Base branch was modified`, `Pull Request is not mergeable`, 필수 리뷰 누락 등) ledger close, `Closes #N` 이슈 close, worktree 정리는 **실행되지 않아야** 합니다. 이 agent 는 머지 실패 시 후처리를 모두 스킵하고 호출자에게 `merge_failed` 로 보고한 뒤 종료합니다 (conflict / changes-requested 분류는 호출 측에서 별도 단계로 다룹니다).
 
 ```bash
-gh pr merge ${PR_NUMBER} --squash --delete-branch
-```
+MERGE_STDERR=$(mktemp)
+if gh pr merge ${PR_NUMBER} --squash --delete-branch 2>"${MERGE_STDERR}"; then
+  # === 머지 성공 경로 ===
+  # 아래 후속 작업은 모두 머지가 실제로 성공했을 때만 실행합니다.
 
-### 4. Ledger Close-the-Loop (best-effort)
-
-머지 성공 시, 해당 PR을 소유한 task가 있으면 `Wip → Done` 으로 전환합니다.
-**Ledger 호출은 best-effort 입니다 — 실패해도 머지 결과 자체에는 영향을 주지 않습니다.**
-
-```bash
-# set -e 가 켜져 있어도 모든 ledger 실패를 흡수하기 위해 호출 전체를 if/then 으로 감쌉니다.
-# - `if cmd; then` 컨텍스트에서는 cmd 실패가 set -e 를 트리거하지 않습니다.
-# - jq 가 부재하거나 JSON 이 깨져도 `|| true` 로 빈 문자열로 흘려보냅니다.
-if FIND_OUT=$(autopilot task find-by-pr "${PR_NUMBER}" --json 2>/dev/null); then
-  TASK_ID=$(printf '%s' "${FIND_OUT}" | jq -r '.id // empty' 2>/dev/null || true)
-  if [ -n "${TASK_ID}" ]; then
-    if autopilot task complete "${TASK_ID}" --pr "${PR_NUMBER}"; then
-      echo "[INFO] ledger: completed task ${TASK_ID} for PR #${PR_NUMBER}"
+  # ---------------------------------------------------------------------
+  # (1) Ledger Close-the-Loop (best-effort)
+  #     PR을 소유한 ledger task 가 있으면 Wip → Done 으로 전환합니다.
+  #     이 단계의 어떤 실패도 머지 결과 자체에는 영향을 주지 않습니다.
+  # ---------------------------------------------------------------------
+  # set -e 가 켜져 있어도 모든 ledger 실패를 흡수하기 위해 호출 전체를 if/then 으로 감쌉니다.
+  # - `if cmd; then` 컨텍스트에서는 cmd 실패가 set -e 를 트리거하지 않습니다.
+  # - jq 가 부재하거나 JSON 이 깨져도 `|| true` 로 빈 문자열로 흘려보냅니다.
+  LEDGER_CLOSED=false
+  if FIND_OUT=$(autopilot task find-by-pr "${PR_NUMBER}" --json 2>/dev/null); then
+    TASK_ID=$(printf '%s' "${FIND_OUT}" | jq -r '.id // empty' 2>/dev/null || true)
+    if [ -n "${TASK_ID}" ]; then
+      if autopilot task complete "${TASK_ID}" --pr "${PR_NUMBER}"; then
+        echo "[INFO] ledger: completed task ${TASK_ID} for PR #${PR_NUMBER}"
+        LEDGER_CLOSED=true
+      else
+        echo "[WARN] ledger: task complete failed for ${TASK_ID} (PR #${PR_NUMBER}) — continuing" >&2
+      fi
     else
-      echo "[WARN] ledger: task complete failed for ${TASK_ID} (PR #${PR_NUMBER}) — continuing" >&2
+      echo "[WARN] ledger: could not parse task id from find-by-pr output for PR #${PR_NUMBER} — skipping" >&2
     fi
   else
-    echo "[WARN] ledger: could not parse task id from find-by-pr output for PR #${PR_NUMBER} — skipping" >&2
+    # find-by-pr exit 1 = pre-ledger PR (소유한 task 없음). 정상 케이스이므로 INFO.
+    # 그 외 exit 코드(DB 오류, 바이너리 부재 등)도 동일하게 흡수합니다 — best-effort.
+    echo "[INFO] ledger: no task owns PR #${PR_NUMBER} (or ledger unavailable) — skipping complete" >&2
   fi
+
+  # ---------------------------------------------------------------------
+  # (2) 관련 이슈 자동 close
+  #     PR body 의 모든 `Closes #N` 패턴을 추출하여 명시적으로 close 합니다.
+  #     `--squash` 머지 시 GitHub auto-close 가 동작하지 않을 수 있으므로 fallback.
+  #     **머지 실패 경로에서는 절대 실행되지 않아야 합니다** (이슈 오close 방지 — #643).
+  # ---------------------------------------------------------------------
+  ISSUE_NUMBERS=$(gh pr view ${PR_NUMBER} --json body --jq '.body' | grep -oE 'Closes #[0-9]+' | grep -oE '[0-9]+')
+  for ISSUE_NUMBER in $ISSUE_NUMBERS; do
+    STATE=$(gh issue view "$ISSUE_NUMBER" --json state --jq '.state' 2>/dev/null || echo "")
+    if [ "$STATE" = "OPEN" ]; then
+      if ! gh issue close "$ISSUE_NUMBER" --comment "Closed by PR #${PR_NUMBER} merge (autopilot)" 2>/dev/null; then
+        echo "[WARN] gh issue close failed for #${ISSUE_NUMBER} (PR #${PR_NUMBER}) — manual close may be required" >&2
+      fi
+    fi
+  done
+
+  # ---------------------------------------------------------------------
+  # (3) 로컬 worktree 자동 정리
+  #     머지된 브랜치에 연결된 worktree 가 남아있으면 후속 브랜치 삭제가 실패합니다.
+  # ---------------------------------------------------------------------
+  HEAD_BRANCH=$(gh pr view ${PR_NUMBER} --json headRefName --jq '.headRefName')
+  autopilot worktree cleanup --branch "${HEAD_BRANCH}"
+
+  rm -f "${MERGE_STDERR}"
+  MERGE_STATUS="merged"
 else
-  # find-by-pr exit 1 = pre-ledger PR (소유한 task 없음). 정상 케이스이므로 INFO.
-  # 그 외 exit 코드(DB 오류, 바이너리 부재 등)도 동일하게 흡수합니다 — best-effort.
-  echo "[INFO] ledger: no task owns PR #${PR_NUMBER} (or ledger unavailable) — skipping complete" >&2
+  # === 머지 실패 경로 ===
+  # `gh pr merge` 가 비-zero 로 종료 (예: Base branch was modified, not mergeable,
+  # required reviews missing 등). ledger close / Closes #N / worktree cleanup 은 모두 스킵하고
+  # 호출자에게 merge_failed 로 보고한 뒤 종료합니다.
+  #
+  # 과거(#643)에는 이 경로에서도 후속 작업이 무조건 실행되어 머지에 실패한 PR 의
+  # 연결 이슈가 잘못 close 되거나 worktree 가 잘못 제거되는 버그가 있었습니다.
+  MERGE_FAILURE_REASON=$(cat "${MERGE_STDERR}" 2>/dev/null || echo "")
+  rm -f "${MERGE_STDERR}"
+  echo "[ERROR] merge failed for PR #${PR_NUMBER}: ${MERGE_FAILURE_REASON}" >&2
+  echo "[INFO] skipping ledger close / Closes #N / worktree cleanup — handing back to caller" >&2
+  MERGE_STATUS="merge_failed"
 fi
 ```
 
-**Failure isolation 원칙:**
+**머지 종료 코드 가드 (#643):** 위 `if gh pr merge ...; then ... else ... fi` 구조는 머지 실패 시 후속 작업이 무조건 실행되어 이슈가 잘못 close 되거나 worktree 가 잘못 제거되는 것을 방지합니다. 동일한 가드가 `commands/merge-prs.md` Step 4 (fast-path) 에도 적용되어 있습니다.
+
+**Failure isolation 원칙 (머지 성공 경로의 ledger close-the-loop):**
 
 | 케이스 | 동작 |
 |--------|------|
@@ -109,9 +156,11 @@ fi
 | `jq` 부재 또는 JSON 파싱 실패 | `\|\| true` 로 빈 id 처리 → WARN 로그 후 skip |
 | `task complete` 실패 (이미 done, not found 등) | WARN 로그 후 skip |
 
-> 이 단계의 어떤 실패도 PR 머지 상태(`"status": "merged"`)를 변경하지 않습니다.
+> 이 단계의 어떤 실패도 머지 성공 경로의 PR 머지 상태(`"status": "merged"`)를 변경하지 않습니다.
 
-### 5. 결과 보고
+### 4. 결과 보고
+
+머지 성공 시:
 
 ```json
 {
@@ -124,15 +173,32 @@ fi
 }
 ```
 
+머지 실패 시 (`gh pr merge` 가 비-zero exit):
+
+```json
+{
+  "pr_number": 50,
+  "status": "merge_failed",
+  "resolved_problems": ["conflict"],
+  "unresolved_problems": [],
+  "commits_added": 2,
+  "ledger_closed": false,
+  "failure_reason": "Pull Request is not mergeable: Base branch was modified"
+}
+```
+
 `ledger_closed`:
-- `true`: `task complete` 가 성공 (Wip → Done 전환됨)
-- `false`: PR 을 소유한 task 가 없거나 ledger 호출 실패 (머지 성공과 무관)
+- `true`: 머지 성공 + `task complete` 성공 (Wip → Done 전환됨)
+- `false`: 머지 실패 / PR 을 소유한 task 가 없음 / ledger 호출 실패 (`status` 와 무관)
+
+`failure_reason` 은 머지 실패 시에만 포함하며, `gh pr merge` 의 stderr 를 그대로 캡처한 값입니다.
 
 ## 에러 처리
 
 - 확신 없는 충돌: 해결하지 않고 보고 (`"status": "needs_human_review"`)
 - 권한 문제: skip + 보고
-- Ledger 호출 (Step 4) 실패: WARN/INFO 로그만 남기고 계속 진행 — 머지 결과를 절대 실패로 바꾸지 않음
+- `gh pr merge` 비-zero exit (Step 3): ledger close / `Closes #N` / worktree cleanup 을 모두 스킵하고 `"status": "merge_failed"` 로 호출자에게 반환 — 후처리는 호출 측 책임 (#643)
+- Ledger 호출 (머지 성공 경로 내부) 실패: WARN/INFO 로그만 남기고 계속 진행 — 머지 결과를 절대 실패로 바꾸지 않음
 
 ## 주의사항
 


### PR DESCRIPTION
## Summary

- `agents/pr-merger.md` Section 3 의 `gh pr merge` 호출을 `if/then/else` 로 감싸서 머지 종료 코드를 검사하도록 수정합니다.
- 머지 성공 경로에서만 ledger close-the-loop, `Closes #N` 이슈 close, worktree cleanup 이 실행되도록 후처리를 분기 안쪽으로 이동했습니다.
- 머지 실패 시 후처리를 모두 스킵하고 `"status": "merge_failed"` + stderr 기반 `failure_reason` 으로 호출자에게 반환하도록 결과 보고 스키마를 보강했습니다.

## Context

- 후속: #643 — `gh pr merge` 실패 시에도 후처리가 무조건 진행되어 연결 이슈가 잘못 close 되거나 worktree 가 잘못 제거되는 버그.
- `commands/merge-prs.md` Step 4 (fast-path) 는 이미 동일한 가드가 적용되어 있어 (`#643` 후속 작업), 이번 PR 은 agent 측에도 같은 가드를 일관되게 적용해 두 경로의 동작 계약을 맞춥니다.
- 단일 파일 변경 (`plugins/github-autopilot/agents/pr-merger.md`) — Rust 코드/테스트 변동 없음.

## Pattern Consistency

| 위치 | 구조 |
|------|------|
| `commands/merge-prs.md` Step 4 (fast-path) | `if gh pr merge ...; then <ledger+closes+cleanup>; else <route to Step 5>; fi` |
| `agents/pr-merger.md` Section 3 (이번 PR) | `if gh pr merge ...; then <ledger+closes+cleanup>; else <merge_failed report>; fi` |

agent 톤에 맞춰 변수명(`MERGE_STDERR`, `MERGE_STATUS`, `MERGE_FAILURE_REASON`, `LEDGER_CLOSED`)과 메시지를 단일-PR 처리 흐름으로 조정했습니다. 호출 측이 conflict / changes-requested 분류를 다루므로, agent 는 실패 시 후처리 없이 그대로 종료합니다.

## Test plan

- [ ] 머지 성공 경로: `gh pr merge` 가 0 으로 종료할 때 ledger close-the-loop / `Closes #N` 이슈 close / `autopilot worktree cleanup` 이 모두 실행되고 결과 JSON 의 `status` 가 `merged` 인지 명세상 추적 가능한지 확인.
- [ ] 머지 실패 경로: `gh pr merge` 가 비-zero 로 종료할 때 ledger close / Closes #N / worktree cleanup 이 명세상 모두 스킵되고 결과 JSON 이 `status: merge_failed` + `failure_reason` (stderr 캡처) 을 포함하는지 확인.
- [ ] fenced code block 짝수 (markdown 무결성).
- [ ] 단일 파일 변경 (다른 파일 손대지 않음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)