### PR TITLE
refactor(github-autopilot): drop pr-merger from stats KNOWN_COMMANDS

### DIFF
--- a/plugins/github-autopilot/cli/Cargo.lock
+++ b/plugins/github-autopilot/cli/Cargo.lock
@@ -111,7 +111,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autopilot"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/plugins/github-autopilot/cli/src/cmd/stats.rs
+++ b/plugins/github-autopilot/cli/src/cmd/stats.rs
@@ -20,7 +20,6 @@ pub const KNOWN_COMMANDS: &[&str] = &[
     "gap-watch",
     "qa-boost",
     "ci-watch",
-    "pr-merger",
     "merge-prs",
     "work-ledger",
 ];


### PR DESCRIPTION
## Summary

`KNOWN_COMMANDS` in `plugins/github-autopilot/cli/src/cmd/stats.rs` lists the canonical loop / cron command names that emit stats updates. `pr-merger` was included, but it is an agent spec (`agents/pr-merger.md`), not a command — no caller invokes `stats update --command pr-merger`. The actual merge-tracking command is `merge-prs`.

Leaving `pr-merger` in the canonical list silently accepted typo'd inputs (a user who wrote `--command pr-merger` would not get the "not in canonical list" warning), defeating the warning's purpose.

## Changes

- Remove `"pr-merger"` from `KNOWN_COMMANDS` in `cli/src/cmd/stats.rs`.
- The warning message at `stats.rs:78-82` joins `KNOWN_COMMANDS` dynamically and updates automatically.
- `Cargo.lock` picked up the existing `autopilot 0.28.0 → 0.29.0` drift to match `Cargo.toml`; included for consistency.

## Impact

- External behavior unchanged: stats recording still accepts any well-formed name; only the warning surface changes.
- Typo'd `--command pr-merger` invocations now correctly emit the canonical-list warning.

## Acceptance

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p autopilot --tests -- -D warnings` clean
- [x] `cargo test -p autopilot stats` passes (2 unit + 3 integration)

## Out of scope

- `cli/src/cmd/mod.rs:384` doc comment still references `pr-merger` in the `--command` help text. Not touched in this single-file cleanup; can follow up separately.