### PR TITLE
refactor(github-autopilot): drop pr-merger from stats canonical doc

### DIFF
--- a/plugins/github-autopilot/cli/src/cmd/mod.rs
+++ b/plugins/github-autopilot/cli/src/cmd/mod.rs
@@ -381,8 +381,8 @@ pub enum StatsCommands {
     /// Update statistics for a command
     Update {
         /// Command name. Canonical: build-issues, gap-watch, qa-boost,
-        /// ci-watch, pr-merger, merge-prs, work-ledger. Unknown but
-        /// well-formed names are accepted with a stderr warning.
+        /// ci-watch, merge-prs, work-ledger. Unknown but well-formed
+        /// names are accepted with a stderr warning.
         #[arg(long)]
         command: String,
         /// Number of issues processed this cycle


### PR DESCRIPTION
## Summary
- PR #735 후속 — `KNOWN_COMMANDS` 와 `StatsCommands::Update.command` 닥주석을 일치시킴.
- `cli/src/cmd/mod.rs` 의 canonical 목록에서 `pr-merger` 제거 후 라인 폭 ~80 으로 자연스럽게 흘림.

## Why
`KNOWN_COMMANDS` 상수는 PR #735 에서 `pr-merger` 를 제거했지만, 같은 인자의 doc comment 는 여전히 canonical 목록에 포함하고 있어 코드와 문서가 어긋남.

## Acceptance
- [x] `cli/src/cmd/mod.rs` 단일 파일 변경
- [x] `cargo fmt --check` 통과
- [x] `cargo clippy --tests -- -D warnings` 통과
- [x] `cargo test` 통과 (117 tests, stats 관련 포함)