### PR TITLE
fix(github-autopilot): pr-merger guard tail and stats cleanups

### DIFF
--- a/plugins/github-autopilot/agents/pr-merger.md
+++ b/plugins/github-autopilot/agents/pr-merger.md
@@ -144,7 +144,7 @@ else
 fi
 ```
 
-**머지 종료 코드 가드 (#643):** 위 `if gh pr merge ...; then ... else ... fi` 구조는 머지 실패 시 후속 작업이 무조건 실행되어 이슈가 잘못 close 되거나 worktree 가 잘못 제거되는 것을 방지합니다. 동일한 가드가 `commands/merge-prs.md` Step 4 (fast-path) 에도 적용되어 있습니다.
+**머지 종료 코드 가드 (#643):** 위 `if gh pr merge ...; then ... else ... fi` 구조는 머지 실패 시 후속 작업이 무조건 실행되어 이슈가 잘못 close 되거나 worktree 가 잘못 제거되는 것을 방지합니다.
 
 **Failure isolation 원칙 (머지 성공 경로의 ledger close-the-loop):**
 

--- a/plugins/github-autopilot/agents/pr-merger.md
+++ b/plugins/github-autopilot/agents/pr-merger.md
@@ -66,40 +66,87 @@ gh api repos/{owner}/{repo}/pulls/${PR_NUMBER}/comments --jq '.[] | {path, body,
 
 ### 3. 머지 시도
 
-모든 문제 해결 후:
+모든 문제 해결 후 머지를 시도합니다.
+
+**중요**: `gh pr merge` 의 종료 코드를 반드시 검사해야 합니다. 머지가 실패한 경우 (예: `Base branch was modified`, `Pull Request is not mergeable`, 필수 리뷰 누락 등) ledger close, `Closes #N` 이슈 close, worktree 정리는 **실행되지 않아야** 합니다. 이 agent 는 머지 실패 시 후처리를 모두 스킵하고 호출자에게 `merge_failed` 로 보고한 뒤 종료합니다 (conflict / changes-requested 분류는 호출 측에서 별도 단계로 다룹니다).
 
 ```bash
-gh pr merge ${PR_NUMBER} --squash --delete-branch
-```
+MERGE_STDERR=$(mktemp)
+if gh pr merge ${PR_NUMBER} --squash --delete-branch 2>"${MERGE_STDERR}"; then
+  # === 머지 성공 경로 ===
+  # 아래 후속 작업은 모두 머지가 실제로 성공했을 때만 실행합니다.
 
-### 4. Ledger Close-the-Loop (best-effort)
-
-머지 성공 시, 해당 PR을 소유한 task가 있으면 `Wip → Done` 으로 전환합니다.
-**Ledger 호출은 best-effort 입니다 — 실패해도 머지 결과 자체에는 영향을 주지 않습니다.**
-
-```bash
-# set -e 가 켜져 있어도 모든 ledger 실패를 흡수하기 위해 호출 전체를 if/then 으로 감쌉니다.
-# - `if cmd; then` 컨텍스트에서는 cmd 실패가 set -e 를 트리거하지 않습니다.
-# - jq 가 부재하거나 JSON 이 깨져도 `|| true` 로 빈 문자열로 흘려보냅니다.
-if FIND_OUT=$(autopilot task find-by-pr "${PR_NUMBER}" --json 2>/dev/null); then
-  TASK_ID=$(printf '%s' "${FIND_OUT}" | jq -r '.id // empty' 2>/dev/null || true)
-  if [ -n "${TASK_ID}" ]; then
-    if autopilot task complete "${TASK_ID}" --pr "${PR_NUMBER}"; then
-      echo "[INFO] ledger: completed task ${TASK_ID} for PR #${PR_NUMBER}"
+  # ---------------------------------------------------------------------
+  # (1) Ledger Close-the-Loop (best-effort)
+  #     PR을 소유한 ledger task 가 있으면 Wip → Done 으로 전환합니다.
+  #     이 단계의 어떤 실패도 머지 결과 자체에는 영향을 주지 않습니다.
+  # ---------------------------------------------------------------------
+  # set -e 가 켜져 있어도 모든 ledger 실패를 흡수하기 위해 호출 전체를 if/then 으로 감쌉니다.
+  # - `if cmd; then` 컨텍스트에서는 cmd 실패가 set -e 를 트리거하지 않습니다.
+  # - jq 가 부재하거나 JSON 이 깨져도 `|| true` 로 빈 문자열로 흘려보냅니다.
+  LEDGER_CLOSED=false
+  if FIND_OUT=$(autopilot task find-by-pr "${PR_NUMBER}" --json 2>/dev/null); then
+    TASK_ID=$(printf '%s' "${FIND_OUT}" | jq -r '.id // empty' 2>/dev/null || true)
+    if [ -n "${TASK_ID}" ]; then
+      if autopilot task complete "${TASK_ID}" --pr "${PR_NUMBER}"; then
+        echo "[INFO] ledger: completed task ${TASK_ID} for PR #${PR_NUMBER}"
+        LEDGER_CLOSED=true
+      else
+        echo "[WARN] ledger: task complete failed for ${TASK_ID} (PR #${PR_NUMBER}) — continuing" >&2
+      fi
     else
-      echo "[WARN] ledger: task complete failed for ${TASK_ID} (PR #${PR_NUMBER}) — continuing" >&2
+      echo "[WARN] ledger: could not parse task id from find-by-pr output for PR #${PR_NUMBER} — skipping" >&2
     fi
   else
-    echo "[WARN] ledger: could not parse task id from find-by-pr output for PR #${PR_NUMBER} — skipping" >&2
+    # find-by-pr exit 1 = pre-ledger PR (소유한 task 없음). 정상 케이스이므로 INFO.
+    # 그 외 exit 코드(DB 오류, 바이너리 부재 등)도 동일하게 흡수합니다 — best-effort.
+    echo "[INFO] ledger: no task owns PR #${PR_NUMBER} (or ledger unavailable) — skipping complete" >&2
   fi
+
+  # ---------------------------------------------------------------------
+  # (2) 관련 이슈 자동 close
+  #     PR body 의 모든 `Closes #N` 패턴을 추출하여 명시적으로 close 합니다.
+  #     `--squash` 머지 시 GitHub auto-close 가 동작하지 않을 수 있으므로 fallback.
+  #     **머지 실패 경로에서는 절대 실행되지 않아야 합니다** (이슈 오close 방지 — #643).
+  # ---------------------------------------------------------------------
+  ISSUE_NUMBERS=$(gh pr view ${PR_NUMBER} --json body --jq '.body' | grep -oE 'Closes #[0-9]+' | grep -oE '[0-9]+')
+  for ISSUE_NUMBER in $ISSUE_NUMBERS; do
+    STATE=$(gh issue view "$ISSUE_NUMBER" --json state --jq '.state' 2>/dev/null || echo "")
+    if [ "$STATE" = "OPEN" ]; then
+      if ! gh issue close "$ISSUE_NUMBER" --comment "Closed by PR #${PR_NUMBER} merge (autopilot)" 2>/dev/null; then
+        echo "[WARN] gh issue close failed for #${ISSUE_NUMBER} (PR #${PR_NUMBER}) — manual close may be required" >&2
+      fi
+    fi
+  done
+
+  # ---------------------------------------------------------------------
+  # (3) 로컬 worktree 자동 정리
+  #     머지된 브랜치에 연결된 worktree 가 남아있으면 후속 브랜치 삭제가 실패합니다.
+  # ---------------------------------------------------------------------
+  HEAD_BRANCH=$(gh pr view ${PR_NUMBER} --json headRefName --jq '.headRefName')
+  autopilot worktree cleanup --branch "${HEAD_BRANCH}"
+
+  rm -f "${MERGE_STDERR}"
+  MERGE_STATUS="merged"
 else
-  # find-by-pr exit 1 = pre-ledger PR (소유한 task 없음). 정상 케이스이므로 INFO.
-  # 그 외 exit 코드(DB 오류, 바이너리 부재 등)도 동일하게 흡수합니다 — best-effort.
-  echo "[INFO] ledger: no task owns PR #${PR_NUMBER} (or ledger unavailable) — skipping complete" >&2
+  # === 머지 실패 경로 ===
+  # `gh pr merge` 가 비-zero 로 종료 (예: Base branch was modified, not mergeable,
+  # required reviews missing 등). ledger close / Closes #N / worktree cleanup 은 모두 스킵하고
+  # 호출자에게 merge_failed 로 보고한 뒤 종료합니다.
+  #
+  # 과거(#643)에는 이 경로에서도 후속 작업이 무조건 실행되어 머지에 실패한 PR 의
+  # 연결 이슈가 잘못 close 되거나 worktree 가 잘못 제거되는 버그가 있었습니다.
+  MERGE_FAILURE_REASON=$(cat "${MERGE_STDERR}" 2>/dev/null || echo "")
+  rm -f "${MERGE_STDERR}"
+  echo "[ERROR] merge failed for PR #${PR_NUMBER}: ${MERGE_FAILURE_REASON}" >&2
+  echo "[INFO] skipping ledger close / Closes #N / worktree cleanup — handing back to caller" >&2
+  MERGE_STATUS="merge_failed"
 fi
 ```
 
-**Failure isolation 원칙:**
+**머지 종료 코드 가드 (#643):** 위 `if gh pr merge ...; then ... else ... fi` 구조는 머지 실패 시 후속 작업이 무조건 실행되어 이슈가 잘못 close 되거나 worktree 가 잘못 제거되는 것을 방지합니다. 동일한 가드가 `commands/merge-prs.md` Step 4 (fast-path) 에도 적용되어 있습니다.
+
+**Failure isolation 원칙 (머지 성공 경로의 ledger close-the-loop):**
 
 | 케이스 | 동작 |
 |--------|------|
@@ -109,9 +156,11 @@ fi
 | `jq` 부재 또는 JSON 파싱 실패 | `\|\| true` 로 빈 id 처리 → WARN 로그 후 skip |
 | `task complete` 실패 (이미 done, not found 등) | WARN 로그 후 skip |
 
-> 이 단계의 어떤 실패도 PR 머지 상태(`"status": "merged"`)를 변경하지 않습니다.
+> 이 단계의 어떤 실패도 머지 성공 경로의 PR 머지 상태(`"status": "merged"`)를 변경하지 않습니다.
 
-### 5. 결과 보고
+### 4. 결과 보고
+
+머지 성공 시:
 
 ```json
 {
@@ -124,15 +173,32 @@ fi
 }
 ```
 
+머지 실패 시 (`gh pr merge` 가 비-zero exit):
+
+```json
+{
+  "pr_number": 50,
+  "status": "merge_failed",
+  "resolved_problems": ["conflict"],
+  "unresolved_problems": [],
+  "commits_added": 2,
+  "ledger_closed": false,
+  "failure_reason": "Pull Request is not mergeable: Base branch was modified"
+}
+```
+
 `ledger_closed`:
-- `true`: `task complete` 가 성공 (Wip → Done 전환됨)
-- `false`: PR 을 소유한 task 가 없거나 ledger 호출 실패 (머지 성공과 무관)
+- `true`: 머지 성공 + `task complete` 성공 (Wip → Done 전환됨)
+- `false`: 머지 실패 / PR 을 소유한 task 가 없음 / ledger 호출 실패 (`status` 와 무관)
+
+`failure_reason` 은 머지 실패 시에만 포함하며, `gh pr merge` 의 stderr 를 그대로 캡처한 값입니다.
 
 ## 에러 처리
 
 - 확신 없는 충돌: 해결하지 않고 보고 (`"status": "needs_human_review"`)
 - 권한 문제: skip + 보고
-- Ledger 호출 (Step 4) 실패: WARN/INFO 로그만 남기고 계속 진행 — 머지 결과를 절대 실패로 바꾸지 않음
+- `gh pr merge` 비-zero exit (Step 3): ledger close / `Closes #N` / worktree cleanup 을 모두 스킵하고 `"status": "merge_failed"` 로 호출자에게 반환 — 후처리는 호출 측 책임 (#643)
+- Ledger 호출 (머지 성공 경로 내부) 실패: WARN/INFO 로그만 남기고 계속 진행 — 머지 결과를 절대 실패로 바꾸지 않음
 
 ## 주의사항
 

--- a/plugins/github-autopilot/cli/Cargo.lock
+++ b/plugins/github-autopilot/cli/Cargo.lock
@@ -111,7 +111,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autopilot"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/plugins/github-autopilot/cli/src/cmd/mod.rs
+++ b/plugins/github-autopilot/cli/src/cmd/mod.rs
@@ -381,8 +381,8 @@ pub enum StatsCommands {
     /// Update statistics for a command
     Update {
         /// Command name. Canonical: build-issues, gap-watch, qa-boost,
-        /// ci-watch, pr-merger, merge-prs, work-ledger. Unknown but
-        /// well-formed names are accepted with a stderr warning.
+        /// ci-watch, merge-prs, work-ledger. Unknown but well-formed
+        /// names are accepted with a stderr warning.
         #[arg(long)]
         command: String,
         /// Number of issues processed this cycle

--- a/plugins/github-autopilot/cli/src/cmd/stats.rs
+++ b/plugins/github-autopilot/cli/src/cmd/stats.rs
@@ -20,7 +20,6 @@ pub const KNOWN_COMMANDS: &[&str] = &[
     "gap-watch",
     "qa-boost",
     "ci-watch",
-    "pr-merger",
     "merge-prs",
     "work-ledger",
 ];


### PR DESCRIPTION
## Summary

`epic/autopilot-stability` (PR #724) 머지 후 후속으로 식별된 작은 일관성 이슈들을 한 epic 안에서 마무리합니다.

- **#734** `fix(github-autopilot): guard pr-merger agent merge with exit-code check`
  `pr-merger` 에이전트 측에도 `gh pr merge` exit-code 가드 적용 (#643 후속). 머지 실패 시 ledger close / `Closes #N` / worktree cleanup 모두 스킵.
- **#735** `refactor(github-autopilot): drop pr-merger from stats KNOWN_COMMANDS`
  `cli/src/cmd/stats.rs` `KNOWN_COMMANDS` 에서 `pr-merger` 제거. agent 명세이며 stats update 를 emit 하지 않음.
- **#736** `refactor(github-autopilot): drop pr-merger from stats canonical doc`
  `cli/src/cmd/mod.rs` `Update.command` doc comment 에서 `pr-merger` 잔여 표기 정리. #735 와 일치.

## Acceptance

- [x] `pr-merger` agent 가 `gh pr merge` 실패 시 후처리(이슈 close 등) 를 진행하지 않음 — 명세 한 줄로 박제됨
- [x] `KNOWN_COMMANDS` 와 `--command` 인자 doc comment 가 일치 (canonical 6개)
- [x] `cargo fmt --check` / `cargo clippy -p github-autopilot --tests -- -D warnings` / `cargo test -p github-autopilot` 통과 (#735, #736)

## 관련 이슈

#643 (pr-merger 측 guard 적용)