### PR TITLE
fix(github-autopilot): drop pr-merger agent reference to commands layer

### DIFF
--- a/plugins/github-autopilot/agents/pr-merger.md
+++ b/plugins/github-autopilot/agents/pr-merger.md
@@ -144,7 +144,7 @@ else
 fi
 ```
 
-**머지 종료 코드 가드 (#643):** 위 `if gh pr merge ...; then ... else ... fi` 구조는 머지 실패 시 후속 작업이 무조건 실행되어 이슈가 잘못 close 되거나 worktree 가 잘못 제거되는 것을 방지합니다. 동일한 가드가 `commands/merge-prs.md` Step 4 (fast-path) 에도 적용되어 있습니다.
+**머지 종료 코드 가드 (#643):** 위 `if gh pr merge ...; then ... else ... fi` 구조는 머지 실패 시 후속 작업이 무조건 실행되어 이슈가 잘못 close 되거나 worktree 가 잘못 제거되는 것을 방지합니다.
 
 **Failure isolation 원칙 (머지 성공 경로의 ledger close-the-loop):**
 


### PR DESCRIPTION
## Summary

PR #739 (rollup) 의 `validate` workflow 가 다음 메시지로 실패했습니다:

```
✗ ./plugins/github-autopilot/agents/pr-merger.md
    Type: layer-dependency
    → line 142: agent references command layer (commands/merge-prs) — violates command → agent direction
```

`tools/validate/internal/architecture/dependency.go` 의 layer 방향 규칙은 `command → agent → skill` (downward only) 만 허용합니다. PR #734 머지 종료 코드 가드 추가 시 `pr-merger.md` 의 설명 줄에 들어간 `commands/merge-prs.md` 직접 참조가 이 규칙을 위반하고 있어, validator regex `(?:\./?)?commands/[a-z][a-z0-9-]+` 에 catch 됩니다.

## 수정 방식

- 단일 파일 변경: `plugins/github-autopilot/agents/pr-merger.md`
- "동일한 가드가 `commands/merge-prs.md` Step 4 (fast-path) 에도 적용되어 있습니다." 한 문장 제거
- 가드 의도 (#643 후속 작업 차단) 자체는 첫 문장에 그대로 유지
- 다른 agent 명세 본문 / 다른 파일은 손대지 않음

## Test plan

- [x] `git grep -n 'commands/' plugins/github-autopilot/agents/pr-merger.md` → 0 matches (exit 1)
- [ ] CI 의 `validate` workflow 가 layer-dependency 위반 없이 통과