### PR TITLE
refactor(github-autopilot): unify release-stale json output to Task array

### DIFF
--- a/plugins/github-autopilot/cli/src/cmd/task.rs
+++ b/plugins/github-autopilot/cli/src/cmd/task.rs
@@ -368,14 +368,14 @@ impl<'a> TaskService<'a> {
             .release_stale(cutoff, now)
             .with_context(|| format!("releasing stale Wip tasks older than {before_seconds}s"))?;
         if json {
-            let ids: Vec<&str> = recovered.iter().map(|i| i.as_str()).collect();
-            write_json(out, &ids)?;
-        } else if recovered.is_empty() {
+            return write_json(out, &recovered).map(|()| 0);
+        }
+        if recovered.is_empty() {
             writeln!(out, "released 0 stale tasks")?;
         } else {
             writeln!(out, "released {} stale tasks:", recovered.len())?;
-            for id in &recovered {
-                writeln!(out, "  {}", id.as_str())?;
+            for t in &recovered {
+                writeln!(out, "  {}", t.id.as_str())?;
             }
         }
         Ok(0)

--- a/plugins/github-autopilot/cli/src/ports/task_store.rs
+++ b/plugins/github-autopilot/cli/src/ports/task_store.rs
@@ -156,13 +156,16 @@ pub trait TaskRepo: Send + Sync {
     /// `release_claim`). Used by the cron supervisor to reap orphaned claims
     /// after worker crashes / ctrl-C / worktree destruction so the task can
     /// reach another worker. Each recovered task gets a `TaskReleasedStale`
-    /// event for audit. Returns the ids of recovered tasks (empty when no
-    /// stale Wip exists — idempotent).
+    /// event for audit. Returns the recovered tasks — each `Task` reflects
+    /// the post-release state (`status = Ready`, `attempts` decremented,
+    /// `updated_at = now`), matching the `Vec<Task>` shape produced by
+    /// `list_stale` so callers can use a single parser. Empty result is
+    /// normal (idempotent).
     ///
     /// Per `CLAUDE.md` "책임 경계", the **decision** of when to bulk-recover
     /// vs review per-task is the agent's call (see `list_stale`); this CLI
     /// path remains as an emergency operator primitive.
-    fn release_stale(&self, before: DateTime<Utc>, now: DateTime<Utc>) -> Result<Vec<TaskId>>;
+    fn release_stale(&self, before: DateTime<Utc>, now: DateTime<Utc>) -> Result<Vec<Task>>;
 
     /// Read-only observation of Wip tasks whose `updated_at` is older than
     /// `before`. Returns the same set of tasks that `release_stale` would

--- a/plugins/github-autopilot/cli/src/store/memory.rs
+++ b/plugins/github-autopilot/cli/src/store/memory.rs
@@ -596,7 +596,7 @@ impl TaskRepo for InMemoryTaskStore {
         Ok(stale)
     }
 
-    fn release_stale(&self, before: DateTime<Utc>, now: DateTime<Utc>) -> Result<Vec<TaskId>> {
+    fn release_stale(&self, before: DateTime<Utc>, now: DateTime<Utc>) -> Result<Vec<Task>> {
         let mut s = self.state.lock().expect("poisoned");
         let stale: Vec<(TaskId, String, u32)> = s
             .tasks
@@ -607,11 +607,17 @@ impl TaskRepo for InMemoryTaskStore {
 
         let mut recovered = Vec::with_capacity(stale.len());
         for (id, epic_name, prev_attempts) in stale {
-            if let Some(task) = s.tasks.get_mut(&id) {
+            // Apply the release transition then snapshot the post-release
+            // Task so the returned vec matches `list_stale`'s shape (each
+            // Task carries Ready status + decremented attempts).
+            let snapshot = if let Some(task) = s.tasks.get_mut(&id) {
                 task.status = TaskStatus::Ready;
                 task.attempts = task.attempts.saturating_sub(1);
                 task.updated_at = now;
-            }
+                Some(task.clone())
+            } else {
+                None
+            };
             let event = InMemoryTaskStore::make_event(
                 EventKind::TaskReleasedStale,
                 Some(epic_name),
@@ -620,7 +626,9 @@ impl TaskRepo for InMemoryTaskStore {
                 now,
             );
             InMemoryTaskStore::push_event(&mut s, event);
-            recovered.push(id);
+            if let Some(task) = snapshot {
+                recovered.push(task);
+            }
         }
         Ok(recovered)
     }

--- a/plugins/github-autopilot/cli/src/store/sqlite.rs
+++ b/plugins/github-autopilot/cli/src/store/sqlite.rs
@@ -915,7 +915,7 @@ impl TaskRepo for SqliteTaskStore {
         rows.map_err(backend)
     }
 
-    fn release_stale(&self, before: DateTime<Utc>, now: DateTime<Utc>) -> Result<Vec<TaskId>> {
+    fn release_stale(&self, before: DateTime<Utc>, now: DateTime<Utc>) -> Result<Vec<Task>> {
         let mut conn = self.conn.lock().expect("poisoned");
         let tx = conn.transaction().map_err(backend)?;
 
@@ -961,7 +961,19 @@ impl TaskRepo for SqliteTaskStore {
                 now,
             )
             .map_err(backend)?;
-            recovered.push(task_id);
+            // Re-read the post-update row so the returned `Task` reflects
+            // the Ready/decremented state (matches `list_stale`'s shape).
+            let task = tx
+                .query_row(
+                    "SELECT id, epic_name, source, fingerprint, title, body, status, attempts,
+                            branch, pr_number, escalated_issue, created_at, updated_at
+                       FROM tasks
+                      WHERE id=?",
+                    params![id],
+                    task_from_row,
+                )
+                .map_err(backend)?;
+            recovered.push(task);
         }
 
         tx.commit().map_err(backend)?;

--- a/plugins/github-autopilot/cli/tests/cli_e2e.rs
+++ b/plugins/github-autopilot/cli/tests/cli_e2e.rs
@@ -946,13 +946,14 @@ fn json_schema_task_list_stale() {
 
 #[test]
 fn json_schema_task_release_stale() {
-    // Lock: `task release-stale --json` -> JSON **array of task id
-    // strings**, NOT an array of Task objects. This is the one place the
-    // CLI emits a "thin" id list rather than full Task records, so we
-    // pin both shape and element type.
+    // Lock: `task release-stale --json` -> JSON **array of Task objects**,
+    // matching `task list-stale --json` so agents can use a single parser.
+    // Each element reflects the post-release state (status=ready, attempts
+    // decremented from the claim).
     let ws = Workspace::new();
     let task_id = "abc123def456";
-    seed_epic_with_task(&ws, "demo", task_id, "release-stale demo");
+    let title = "release-stale demo";
+    seed_epic_with_task(&ws, "demo", task_id, title);
     ws.cmd()
         .args(["task", "claim", "--epic", "demo"])
         .assert()
@@ -965,14 +966,19 @@ fn json_schema_task_release_stale() {
     );
     assert!(
         json.is_array(),
-        "release-stale --json must emit an array of ids"
+        "release-stale --json must emit an array of Task objects"
     );
-    let ids = json.as_array().unwrap();
-    assert_eq!(ids.len(), 1, "one task should be released");
-    let id = ids[0]
-        .as_str()
-        .expect("release-stale --json elements must be strings");
-    assert_eq!(id, task_id);
+    let tasks = json.as_array().unwrap();
+    assert_eq!(tasks.len(), 1, "one task should be released");
+    assert_task_shape(&tasks[0], task_id, "demo", title);
+    assert_eq!(
+        tasks[0]["status"], "ready",
+        "released task must be Ready (post-release state)"
+    );
+    assert_eq!(
+        tasks[0]["attempts"], 0,
+        "released task must have decremented attempts"
+    );
 }
 
 #[test]

--- a/plugins/github-autopilot/cli/tests/store_conformance.rs
+++ b/plugins/github-autopilot/cli/tests/store_conformance.rs
@@ -260,9 +260,28 @@ fn body_release_stale_recovers_old_wip_tasks(store: Arc<dyn TaskStore>) {
     let recovered = store
         .release_stale(t0() + Duration::minutes(5), t0() + Duration::minutes(11))
         .unwrap();
-    let mut ids: Vec<String> = recovered.iter().map(|i| i.as_str().to_string()).collect();
+    // The returned Vec<Task> must reflect post-release state — Ready with
+    // attempts decremented — so callers can use a single parser shared with
+    // `list_stale` (Vec<Task>).
+    let mut ids: Vec<String> = recovered
+        .iter()
+        .map(|t| t.id.as_str().to_string())
+        .collect();
     ids.sort();
     assert_eq!(ids, vec!["A".to_string(), "B".to_string()]);
+    for t in &recovered {
+        assert_eq!(
+            t.status,
+            TaskStatus::Ready,
+            "released task must be Ready: {:?}",
+            t
+        );
+        assert_eq!(
+            t.attempts, 0,
+            "released task must have decremented attempts: {:?}",
+            t
+        );
+    }
 
     let by_id = |id: &str| store.get_task(&TaskId::from_raw(id)).unwrap().unwrap();
     assert_eq!(by_id("A").status, TaskStatus::Ready);

--- a/plugins/github-autopilot/cli/tests/task_tests.rs
+++ b/plugins/github-autopilot/cli/tests/task_tests.rs
@@ -697,7 +697,10 @@ fn release_stale_with_no_stale_tasks_exits_0_and_reports_zero() {
 }
 
 #[test]
-fn release_stale_json_emits_array_of_recovered_ids() {
+fn release_stale_json_emits_array_of_recovered_tasks() {
+    // `release-stale --json` mirrors `list-stale --json` shape — both emit
+    // `[Task]` so agents can share a single parser. Each element reflects
+    // the post-release state (status=ready, attempts decremented).
     let (store, clock) = fixture();
     let svc = TaskService::new(store.as_ref(), &clock);
     seed_via_add(&svc, "aaaaaaaaaaaa", "0x1");
@@ -706,7 +709,12 @@ fn release_stale_json_emits_array_of_recovered_ids() {
     let (code, out) = capture(|w| svc.release_stale(3_600, true, w));
     assert_eq!(code, 0);
     let v: serde_json::Value = serde_json::from_str(out.trim()).unwrap();
-    assert_eq!(v, serde_json::json!(["aaaaaaaaaaaa"]));
+    let arr = v.as_array().expect("release-stale --json must be array");
+    assert_eq!(arr.len(), 1);
+    let t = &arr[0];
+    assert_eq!(t["id"], "aaaaaaaaaaaa");
+    assert_eq!(t["status"], "ready");
+    assert_eq!(t["attempts"], 0);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- `task release-stale --json` now emits `[Task]` (full Task objects), matching `task list-stale --json`. Previously it emitted `[String]` (id-only).
- Each returned Task reflects the post-release state: `status = ready`, `attempts` decremented, `updated_at = now`. Same trip through both stores (sqlite/memory) is in a single transaction/lock so the snapshot is consistent with the state transition.
- Human-readable output is unchanged in spirit (still lists ids), only the count line phrasing kept the same.

## Why

Agents calling both `list-stale` and `release-stale` had to maintain two parsers for what is conceptually the same set of stale tasks at the same cutoff. Unifying to `[Task]` lets a single parser cover both paths.

## Breaking change

Yes. `--json` shape changes from `["id1", "id2"]` to `[{ id, epic_name, status, attempts, ... }, ...]`. No external consumers; agent callers updated together.

## Implementation

- `TaskRepo::release_stale` returns `Result<Vec<Task>>` (was `Vec<TaskId>`); docstring updated to spell out post-release semantics.
- `store/sqlite.rs`: re-reads each updated row inside the same transaction via `task_from_row`.
- `store/memory.rs`: clones the task after applying the Ready/decrement transition.
- `cmd/task.rs::release_stale`: routes Task array to `write_json` for `--json`; iterates Task objects to print ids in human mode.
- Tests updated:
  - `tests/store_conformance.rs::body_release_stale_recovers_old_wip_tasks` — asserts each returned Task has `status = Ready`, `attempts = 0`.
  - `tests/task_tests.rs::release_stale_json_emits_array_of_recovered_tasks` — pins `[Task]` shape with id/status/attempts.
  - `tests/cli_e2e.rs::json_schema_task_release_stale` — uses `assert_task_shape` (same helper as `list-stale`/`get`/`claim`) to lock the canonical Task field set.

## Acceptance

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --tests -- -D warnings` clean
- [x] `cargo test` all green (release-stale store conformance + task_tests + cli_e2e all updated)
- [x] `release-stale --json` shape matches `list-stale --json` (`[Task]`)
- [x] Returned Tasks reflect post-release state (Ready, attempts decremented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)