### PR TITLE
refactor(github-autopilot): type Event.payload with EventPayload enum

### DIFF
--- a/plugins/github-autopilot/cli/src/cmd/events.rs
+++ b/plugins/github-autopilot/cli/src/cmd/events.rs
@@ -12,7 +12,7 @@ use clap::{Args, Subcommand};
 use serde::Serialize;
 
 use crate::cmd::output::write_json;
-use crate::domain::{Event, EventKind, TaskId};
+use crate::domain::{Event, EventKind, EventPayload, TaskId};
 use crate::ports::task_store::{EventFilter, EventLog};
 
 const PAYLOAD_PREVIEW_LIMIT: usize = 40;
@@ -126,12 +126,23 @@ fn render_table(events: &[Event], out: &mut dyn Write) -> Result<()> {
     Ok(())
 }
 
-fn payload_preview(value: &serde_json::Value) -> String {
-    let s = if value.is_null() {
-        "-".to_string()
+fn payload_preview(payload: &EventPayload) -> String {
+    // Convert via `serde_json::Value` so the table preview keeps its prior
+    // shape (compact JSON, "-" for empty objects). Round-tripping through
+    // Value also lets us strip the `kind` discriminator that the typed enum
+    // adds — it is redundant in the preview column since `KIND` is already
+    // shown to the left.
+    let value = serde_json::to_value(payload).unwrap_or(serde_json::Value::Null);
+    let preview_value = if let serde_json::Value::Object(mut map) = value {
+        map.remove("kind");
+        if map.is_empty() {
+            return "-".to_string();
+        }
+        serde_json::Value::Object(map)
     } else {
-        value.to_string()
+        value
     };
+    let s = preview_value.to_string();
     if s.chars().count() <= PAYLOAD_PREVIEW_LIMIT {
         return s;
     }
@@ -145,7 +156,7 @@ struct EventRecord<'a> {
     kind: &'static str,
     epic: Option<&'a str>,
     task: Option<&'a str>,
-    payload: &'a serde_json::Value,
+    payload: &'a EventPayload,
 }
 
 impl<'a> From<&'a Event> for EventRecord<'a> {

--- a/plugins/github-autopilot/cli/src/domain/event.rs
+++ b/plugins/github-autopilot/cli/src/domain/event.rs
@@ -8,8 +8,37 @@ pub struct Event {
     pub task_id: Option<TaskId>,
     pub epic_name: Option<String>,
     pub kind: EventKind,
-    pub payload: serde_json::Value,
+    pub payload: EventPayload,
     pub at: DateTime<Utc>,
+}
+
+impl Event {
+    /// Build an `Event` whose [`EventKind`] matches the inner [`EventPayload`]
+    /// variant. `debug_assert!` enforces the invariant in test/dev builds; in
+    /// release builds the caller-supplied `kind` is trusted (we deliberately
+    /// avoid panicking the daemon on a programming bug, since the same
+    /// information is recoverable from `payload.kind()`).
+    pub fn new(
+        kind: EventKind,
+        epic_name: Option<String>,
+        task_id: Option<TaskId>,
+        payload: EventPayload,
+        at: DateTime<Utc>,
+    ) -> Self {
+        debug_assert_eq!(
+            kind,
+            payload.kind(),
+            "Event::new: kind {kind:?} does not match payload variant {:?}",
+            payload.kind()
+        );
+        Self {
+            task_id,
+            epic_name,
+            kind,
+            payload,
+            at,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -85,5 +114,293 @@ impl EventKind {
             "task_released_stale" => EventKind::TaskReleasedStale,
             _ => return None,
         })
+    }
+}
+
+/// Typed counterpart of [`EventKind`]. Each variant carries the exact fields
+/// emitted by the corresponding store operation, so consumers no longer have
+/// to memorize untyped JSON keys.
+///
+/// Serializes with an internally tagged representation
+/// (`{ "kind": "<snake_case>", ...fields }`). Variant ↔ [`EventKind`] mapping
+/// is enforced by [`EventPayload::kind`] and asserted in [`Event::new`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum EventPayload {
+    EpicStarted,
+    EpicCompleted,
+    EpicAbandoned,
+    /// Emitted both for `insert_epic_with_tasks` (only `source` populated) and
+    /// `upsert_watch_task` (both `source` and `fingerprint` populated).
+    TaskInserted {
+        source: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        fingerprint: Option<String>,
+    },
+    TaskClaimed {
+        attempts: u32,
+    },
+    /// Reserved — no emit site yet. Kept so [`EventKind`] ↔ [`EventPayload`]
+    /// stays 1:1.
+    TaskStarted,
+    TaskCompleted {
+        pr_number: u64,
+    },
+    TaskFailed {
+        #[serde(rename = "final")]
+        is_final: bool,
+        attempts: u32,
+    },
+    /// Emitted from two paths: `mark_task_failed` (max-attempts → escalated)
+    /// carries `attempts`; `escalate_task` (record GitHub issue number)
+    /// carries `issue`. Both fields are optional so either path can be
+    /// represented losslessly.
+    TaskEscalated {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        attempts: Option<u32>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        issue: Option<u64>,
+    },
+    TaskBlocked {
+        reason: String,
+        parent: String,
+    },
+    TaskUnblocked,
+    /// Reconciliation events come in two shapes — per-orphan-branch and a
+    /// summary line at the end. Modelled as separate sub-variants via an
+    /// internal `event` discriminator so each shape is unambiguous.
+    Reconciled(ReconciledPayload),
+    /// Reserved — no emit site yet.
+    ClaimLost,
+    /// Reserved — no emit site yet.
+    MigratedFromIssue,
+    /// Reserved — no emit site yet.
+    EscalationResolved,
+    WatchDuplicate {
+        fingerprint: String,
+    },
+    TaskForceStatus {
+        from: String,
+        to: String,
+        reason: String,
+    },
+    TaskReleasedStale {
+        prev_attempts: u32,
+    },
+}
+
+/// Sub-variants of [`EventPayload::Reconciled`]. Reconciliation emits one
+/// event per orphan branch plus a final summary; both shapes are recorded
+/// distinctly so tooling can filter / count without inspecting payload keys.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "event", rename_all = "snake_case")]
+pub enum ReconciledPayload {
+    OrphanBranch { orphan_branch: String },
+    Summary { tasks: u64 },
+}
+
+impl EventPayload {
+    /// Returns the [`EventKind`] this payload corresponds to. Pairs with
+    /// [`Event::new`] to guarantee `Event.kind == Event.payload.kind()`.
+    pub fn kind(&self) -> EventKind {
+        match self {
+            EventPayload::EpicStarted => EventKind::EpicStarted,
+            EventPayload::EpicCompleted => EventKind::EpicCompleted,
+            EventPayload::EpicAbandoned => EventKind::EpicAbandoned,
+            EventPayload::TaskInserted { .. } => EventKind::TaskInserted,
+            EventPayload::TaskClaimed { .. } => EventKind::TaskClaimed,
+            EventPayload::TaskStarted => EventKind::TaskStarted,
+            EventPayload::TaskCompleted { .. } => EventKind::TaskCompleted,
+            EventPayload::TaskFailed { .. } => EventKind::TaskFailed,
+            EventPayload::TaskEscalated { .. } => EventKind::TaskEscalated,
+            EventPayload::TaskBlocked { .. } => EventKind::TaskBlocked,
+            EventPayload::TaskUnblocked => EventKind::TaskUnblocked,
+            EventPayload::Reconciled(_) => EventKind::Reconciled,
+            EventPayload::ClaimLost => EventKind::ClaimLost,
+            EventPayload::MigratedFromIssue => EventKind::MigratedFromIssue,
+            EventPayload::EscalationResolved => EventKind::EscalationResolved,
+            EventPayload::WatchDuplicate { .. } => EventKind::WatchDuplicate,
+            EventPayload::TaskForceStatus { .. } => EventKind::TaskForceStatus,
+            EventPayload::TaskReleasedStale { .. } => EventKind::TaskReleasedStale,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn at() -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc)
+    }
+
+    fn roundtrip(payload: EventPayload) -> EventPayload {
+        let s = serde_json::to_string(&payload).expect("serialize");
+        serde_json::from_str(&s).expect("deserialize")
+    }
+
+    #[test]
+    fn payload_kind_matches_for_every_variant() {
+        let cases: Vec<(EventPayload, EventKind)> = vec![
+            (EventPayload::EpicStarted, EventKind::EpicStarted),
+            (EventPayload::EpicCompleted, EventKind::EpicCompleted),
+            (EventPayload::EpicAbandoned, EventKind::EpicAbandoned),
+            (
+                EventPayload::TaskInserted {
+                    source: "spec".into(),
+                    fingerprint: None,
+                },
+                EventKind::TaskInserted,
+            ),
+            (
+                EventPayload::TaskClaimed { attempts: 1 },
+                EventKind::TaskClaimed,
+            ),
+            (EventPayload::TaskStarted, EventKind::TaskStarted),
+            (
+                EventPayload::TaskCompleted { pr_number: 42 },
+                EventKind::TaskCompleted,
+            ),
+            (
+                EventPayload::TaskFailed {
+                    is_final: false,
+                    attempts: 1,
+                },
+                EventKind::TaskFailed,
+            ),
+            (
+                EventPayload::TaskEscalated {
+                    attempts: Some(3),
+                    issue: None,
+                },
+                EventKind::TaskEscalated,
+            ),
+            (
+                EventPayload::TaskBlocked {
+                    reason: "parent_escalated".into(),
+                    parent: "abc".into(),
+                },
+                EventKind::TaskBlocked,
+            ),
+            (EventPayload::TaskUnblocked, EventKind::TaskUnblocked),
+            (
+                EventPayload::Reconciled(ReconciledPayload::Summary { tasks: 3 }),
+                EventKind::Reconciled,
+            ),
+            (EventPayload::ClaimLost, EventKind::ClaimLost),
+            (
+                EventPayload::MigratedFromIssue,
+                EventKind::MigratedFromIssue,
+            ),
+            (
+                EventPayload::EscalationResolved,
+                EventKind::EscalationResolved,
+            ),
+            (
+                EventPayload::WatchDuplicate {
+                    fingerprint: "fp".into(),
+                },
+                EventKind::WatchDuplicate,
+            ),
+            (
+                EventPayload::TaskForceStatus {
+                    from: "wip".into(),
+                    to: "ready".into(),
+                    reason: "manual".into(),
+                },
+                EventKind::TaskForceStatus,
+            ),
+            (
+                EventPayload::TaskReleasedStale { prev_attempts: 2 },
+                EventKind::TaskReleasedStale,
+            ),
+        ];
+        for (payload, expected_kind) in cases {
+            assert_eq!(
+                payload.kind(),
+                expected_kind,
+                "kind() mismatch for {payload:?}"
+            );
+            // Round-trip preserves the variant.
+            let restored = roundtrip(payload.clone());
+            assert_eq!(restored, payload, "round-trip mismatch for {payload:?}");
+        }
+    }
+
+    #[test]
+    fn task_inserted_serializes_with_kind_tag() {
+        let p = EventPayload::TaskInserted {
+            source: "spec".into(),
+            fingerprint: Some("fp1".into()),
+        };
+        let v = serde_json::to_value(&p).unwrap();
+        assert_eq!(v["kind"], "task_inserted");
+        assert_eq!(v["source"], "spec");
+        assert_eq!(v["fingerprint"], "fp1");
+    }
+
+    #[test]
+    fn task_inserted_omits_fingerprint_when_none() {
+        let p = EventPayload::TaskInserted {
+            source: "spec".into(),
+            fingerprint: None,
+        };
+        let v = serde_json::to_value(&p).unwrap();
+        assert_eq!(v["kind"], "task_inserted");
+        assert!(
+            v.get("fingerprint").is_none(),
+            "fingerprint key must be omitted when None, got {v}"
+        );
+    }
+
+    #[test]
+    fn reconciled_orphan_branch_distinct_from_summary() {
+        let orphan = EventPayload::Reconciled(ReconciledPayload::OrphanBranch {
+            orphan_branch: "feat/x".into(),
+        });
+        let summary = EventPayload::Reconciled(ReconciledPayload::Summary { tasks: 5 });
+        let v_orphan = serde_json::to_value(&orphan).unwrap();
+        let v_summary = serde_json::to_value(&summary).unwrap();
+        assert_eq!(v_orphan["kind"], "reconciled");
+        assert_eq!(v_orphan["event"], "orphan_branch");
+        assert_eq!(v_orphan["orphan_branch"], "feat/x");
+        assert_eq!(v_summary["kind"], "reconciled");
+        assert_eq!(v_summary["event"], "summary");
+        assert_eq!(v_summary["tasks"], 5);
+    }
+
+    #[test]
+    fn event_new_propagates_fields() {
+        let payload = EventPayload::TaskClaimed { attempts: 1 };
+        let event = Event::new(
+            EventKind::TaskClaimed,
+            Some("e1".into()),
+            Some(TaskId::from_raw("aaaaaaaaaaaa")),
+            payload.clone(),
+            at(),
+        );
+        assert_eq!(event.kind, EventKind::TaskClaimed);
+        assert_eq!(event.payload, payload);
+        assert_eq!(event.epic_name.as_deref(), Some("e1"));
+        assert_eq!(
+            event.task_id.as_ref().map(TaskId::as_str),
+            Some("aaaaaaaaaaaa")
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "kind")]
+    fn event_new_panics_on_kind_payload_mismatch_in_debug() {
+        // Only meaningful in debug builds; release skips the assert and the
+        // event is still constructed. This test guards the dev-time check.
+        let _ = Event::new(
+            EventKind::TaskCompleted,
+            None,
+            None,
+            EventPayload::TaskUnblocked,
+            at(),
+        );
     }
 }

--- a/plugins/github-autopilot/cli/src/domain/mod.rs
+++ b/plugins/github-autopilot/cli/src/domain/mod.rs
@@ -8,6 +8,6 @@ pub mod task_id;
 pub use deps::{CycleError, TaskGraph};
 pub use epic::{Epic, EpicStatus};
 pub use error::{DomainError, UserInputError};
-pub use event::{Event, EventKind};
+pub use event::{Event, EventKind, EventPayload, ReconciledPayload};
 pub use task::{Task, TaskFailureOutcome, TaskSource, TaskStatus};
 pub use task_id::{TaskId, TaskIdParseError};

--- a/plugins/github-autopilot/cli/src/store/memory.rs
+++ b/plugins/github-autopilot/cli/src/store/memory.rs
@@ -5,8 +5,8 @@ use std::sync::Mutex;
 use chrono::{DateTime, Utc};
 
 use crate::domain::{
-    DomainError, Epic, EpicStatus, Event, EventKind, Task, TaskFailureOutcome, TaskGraph, TaskId,
-    TaskStatus,
+    DomainError, Epic, EpicStatus, Event, EventKind, EventPayload, ReconciledPayload, Task,
+    TaskFailureOutcome, TaskGraph, TaskId, TaskStatus,
 };
 use crate::ports::task_store::{
     EpicPlan, EpicRepo, EventFilter, EventLog, NewWatchTask, ReconciliationPlan, RemotePrState,
@@ -70,9 +70,15 @@ impl InMemoryTaskStore {
         kind: EventKind,
         epic: Option<String>,
         task: Option<TaskId>,
-        payload: serde_json::Value,
+        payload: EventPayload,
         at: DateTime<Utc>,
     ) -> Event {
+        debug_assert_eq!(
+            kind,
+            payload.kind(),
+            "make_event: kind {kind:?} does not match payload variant {:?}",
+            payload.kind()
+        );
         Event {
             task_id: task,
             epic_name: epic,
@@ -121,13 +127,12 @@ impl EpicRepo for InMemoryTaskStore {
             EpicStatus::Completed => EventKind::EpicCompleted,
             EpicStatus::Abandoned => EventKind::EpicAbandoned,
         };
-        let event = InMemoryTaskStore::make_event(
-            kind,
-            Some(name.to_string()),
-            None,
-            serde_json::json!({}),
-            at,
-        );
+        let payload = match status {
+            EpicStatus::Active => EventPayload::EpicStarted,
+            EpicStatus::Completed => EventPayload::EpicCompleted,
+            EpicStatus::Abandoned => EventPayload::EpicAbandoned,
+        };
+        let event = InMemoryTaskStore::make_event(kind, Some(name.to_string()), None, payload, at);
         InMemoryTaskStore::push_event(&mut s, event);
         Ok(())
     }
@@ -238,7 +243,7 @@ impl TaskRepo for InMemoryTaskStore {
                 EventKind::EpicStarted,
                 Some(epic.name.clone()),
                 None,
-                serde_json::json!({}),
+                EventPayload::EpicStarted,
                 now,
             ),
         );
@@ -249,7 +254,10 @@ impl TaskRepo for InMemoryTaskStore {
                     EventKind::TaskInserted,
                     Some(epic.name.clone()),
                     Some(nt.id.clone()),
-                    serde_json::json!({"source": nt.source.as_str()}),
+                    EventPayload::TaskInserted {
+                        source: nt.source.as_str().to_string(),
+                        fingerprint: None,
+                    },
                     now,
                 ),
             );
@@ -304,7 +312,9 @@ impl TaskRepo for InMemoryTaskStore {
                     EventKind::WatchDuplicate,
                     Some(task.epic_name.clone()),
                     Some(existing.id.clone()),
-                    serde_json::json!({"fingerprint": task.fingerprint}),
+                    EventPayload::WatchDuplicate {
+                        fingerprint: task.fingerprint.clone(),
+                    },
                     now,
                 ),
             );
@@ -338,7 +348,10 @@ impl TaskRepo for InMemoryTaskStore {
                 EventKind::TaskInserted,
                 Some(task.epic_name.clone()),
                 Some(id.clone()),
-                serde_json::json!({"source": task.source.as_str(), "fingerprint": task.fingerprint}),
+                EventPayload::TaskInserted {
+                    source: task.source.as_str().to_string(),
+                    fingerprint: Some(task.fingerprint.clone()),
+                },
                 now,
             ),
         );
@@ -381,7 +394,9 @@ impl TaskRepo for InMemoryTaskStore {
                 EventKind::TaskClaimed,
                 Some(epic.to_string()),
                 Some(snapshot.id.clone()),
-                serde_json::json!({"attempts": snapshot.attempts}),
+                EventPayload::TaskClaimed {
+                    attempts: snapshot.attempts,
+                },
                 now,
             ),
         );
@@ -415,7 +430,7 @@ impl TaskRepo for InMemoryTaskStore {
                 EventKind::TaskCompleted,
                 Some(epic_name.clone()),
                 Some(id.clone()),
-                serde_json::json!({"pr_number": pr_number}),
+                EventPayload::TaskCompleted { pr_number },
                 now,
             ),
         );
@@ -444,7 +459,7 @@ impl TaskRepo for InMemoryTaskStore {
                         EventKind::TaskUnblocked,
                         Some(epic_name.clone()),
                         Some(dep_task_id),
-                        serde_json::json!({}),
+                        EventPayload::TaskUnblocked,
                         now,
                     ),
                 );
@@ -484,7 +499,10 @@ impl TaskRepo for InMemoryTaskStore {
                     EventKind::TaskFailed,
                     Some(epic_name.clone()),
                     Some(id.clone()),
-                    serde_json::json!({"final": true, "attempts": attempts}),
+                    EventPayload::TaskFailed {
+                        is_final: true,
+                        attempts,
+                    },
                     now,
                 ),
             );
@@ -494,7 +512,10 @@ impl TaskRepo for InMemoryTaskStore {
                     EventKind::TaskEscalated,
                     Some(epic_name.clone()),
                     Some(id.clone()),
-                    serde_json::json!({"attempts": attempts}),
+                    EventPayload::TaskEscalated {
+                        attempts: Some(attempts),
+                        issue: None,
+                    },
                     now,
                 ),
             );
@@ -516,7 +537,10 @@ impl TaskRepo for InMemoryTaskStore {
                             EventKind::TaskBlocked,
                             Some(epic_name.clone()),
                             Some(dep_id),
-                            serde_json::json!({"reason": "parent_escalated", "parent": id.as_str()}),
+                            EventPayload::TaskBlocked {
+                                reason: "parent_escalated".to_string(),
+                                parent: id.as_str().to_string(),
+                            },
                             now,
                         ),
                     );
@@ -532,7 +556,10 @@ impl TaskRepo for InMemoryTaskStore {
                     EventKind::TaskFailed,
                     Some(epic_name),
                     Some(id.clone()),
-                    serde_json::json!({"final": false, "attempts": attempts}),
+                    EventPayload::TaskFailed {
+                        is_final: false,
+                        attempts,
+                    },
                     now,
                 ),
             );
@@ -555,7 +582,10 @@ impl TaskRepo for InMemoryTaskStore {
                 EventKind::TaskEscalated,
                 Some(epic_name),
                 Some(id.clone()),
-                serde_json::json!({"issue": issue_number}),
+                EventPayload::TaskEscalated {
+                    attempts: None,
+                    issue: Some(issue_number),
+                },
                 now,
             ),
         );
@@ -622,7 +652,7 @@ impl TaskRepo for InMemoryTaskStore {
                 EventKind::TaskReleasedStale,
                 Some(epic_name),
                 Some(id.clone()),
-                serde_json::json!({"prev_attempts": prev_attempts}),
+                EventPayload::TaskReleasedStale { prev_attempts },
                 now,
             );
             InMemoryTaskStore::push_event(&mut s, event);
@@ -655,11 +685,11 @@ impl TaskRepo for InMemoryTaskStore {
             EventKind::TaskForceStatus,
             Some(epic_name),
             Some(id.clone()),
-            serde_json::json!({
-                "from": prev.as_str(),
-                "to": target.as_str(),
-                "reason": reason,
-            }),
+            EventPayload::TaskForceStatus {
+                from: prev.as_str().to_string(),
+                to: target.as_str().to_string(),
+                reason: reason.to_string(),
+            },
             now,
         );
         InMemoryTaskStore::push_event(&mut s, event);
@@ -786,7 +816,9 @@ impl TaskRepo for InMemoryTaskStore {
                     EventKind::Reconciled,
                     Some(epic_name.clone()),
                     None,
-                    serde_json::json!({"orphan_branch": branch}),
+                    EventPayload::Reconciled(ReconciledPayload::OrphanBranch {
+                        orphan_branch: branch.clone(),
+                    }),
                     now,
                 ),
             );
@@ -798,7 +830,9 @@ impl TaskRepo for InMemoryTaskStore {
                 EventKind::Reconciled,
                 Some(epic_name.clone()),
                 None,
-                serde_json::json!({"tasks": plan.tasks.len()}),
+                EventPayload::Reconciled(ReconciledPayload::Summary {
+                    tasks: plan.tasks.len() as u64,
+                }),
                 now,
             ),
         );

--- a/plugins/github-autopilot/cli/src/store/sqlite.rs
+++ b/plugins/github-autopilot/cli/src/store/sqlite.rs
@@ -11,8 +11,8 @@ use chrono::{DateTime, Utc};
 use rusqlite::{params, Connection, OptionalExtension, Row};
 
 use crate::domain::{
-    DomainError, Epic, EpicStatus, Event, EventKind, Task, TaskFailureOutcome, TaskGraph, TaskId,
-    TaskSource, TaskStatus,
+    DomainError, Epic, EpicStatus, Event, EventKind, EventPayload, ReconciledPayload, Task,
+    TaskFailureOutcome, TaskGraph, TaskId, TaskSource, TaskStatus,
 };
 use crate::ports::task_store::{
     EpicPlan, EpicRepo, EventFilter, EventLog, NewWatchTask, ReconciliationPlan, Result,
@@ -153,6 +153,7 @@ fn task_from_row(row: &Row<'_>) -> rusqlite::Result<Task> {
 }
 
 fn event_from_row(row: &Row<'_>) -> rusqlite::Result<Event> {
+    let row_id: i64 = row.get("id").unwrap_or(0);
     let kind_str: String = row.get("kind")?;
     let kind = EventKind::parse(&kind_str).ok_or_else(|| {
         rusqlite::Error::FromSqlConversionFailure(
@@ -162,8 +163,17 @@ fn event_from_row(row: &Row<'_>) -> rusqlite::Result<Event> {
         )
     })?;
     let payload_str: String = row.get("payload")?;
-    let payload: serde_json::Value =
-        serde_json::from_str(&payload_str).unwrap_or(serde_json::Value::Object(Default::default()));
+    let payload: EventPayload = serde_json::from_str(&payload_str).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(
+            0,
+            rusqlite::types::Type::Text,
+            format!(
+                "failed to deserialize event payload at row {row_id}: {e}; \
+                 if upgrading from older schema, reset the ledger DB"
+            )
+            .into(),
+        )
+    })?;
     let task_id: Option<String> = row.get("task_id")?;
     Ok(Event {
         task_id: task_id.map(TaskId::from_raw),
@@ -180,16 +190,28 @@ impl SqliteTaskStore {
         kind: EventKind,
         epic: Option<&str>,
         task: Option<&TaskId>,
-        payload: &serde_json::Value,
+        payload: &EventPayload,
         at: DateTime<Utc>,
     ) -> rusqlite::Result<()> {
+        debug_assert_eq!(
+            kind,
+            payload.kind(),
+            "append_event_with: kind {kind:?} does not match payload variant {:?}",
+            payload.kind()
+        );
+        let payload_json = serde_json::to_string(payload).map_err(|e| {
+            rusqlite::Error::ToSqlConversionFailure(Box::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("failed to serialize event payload: {e}"),
+            )))
+        })?;
         conn.execute(
             "INSERT INTO events(epic_name, task_id, kind, payload, at) VALUES (?, ?, ?, ?, ?)",
             params![
                 epic,
                 task.map(|t| t.as_str().to_string()),
                 kind.as_str(),
-                payload.to_string(),
+                payload_json,
                 at,
             ],
         )?;
@@ -280,15 +302,13 @@ impl EpicRepo for SqliteTaskStore {
             EpicStatus::Completed => EventKind::EpicCompleted,
             EpicStatus::Abandoned => EventKind::EpicAbandoned,
         };
-        SqliteTaskStore::append_event_with(
-            &conn,
-            kind,
-            Some(name),
-            None,
-            &serde_json::json!({}),
-            at,
-        )
-        .map_err(backend)?;
+        let payload = match status {
+            EpicStatus::Active => EventPayload::EpicStarted,
+            EpicStatus::Completed => EventPayload::EpicCompleted,
+            EpicStatus::Abandoned => EventPayload::EpicAbandoned,
+        };
+        SqliteTaskStore::append_event_with(&conn, kind, Some(name), None, &payload, at)
+            .map_err(backend)?;
         Ok(())
     }
 
@@ -409,7 +429,7 @@ impl TaskRepo for SqliteTaskStore {
             EventKind::EpicStarted,
             Some(&plan.epic.name),
             None,
-            &serde_json::json!({}),
+            &EventPayload::EpicStarted,
             now,
         )
         .map_err(backend)?;
@@ -419,7 +439,10 @@ impl TaskRepo for SqliteTaskStore {
                 EventKind::TaskInserted,
                 Some(&plan.epic.name),
                 Some(&nt.id),
-                &serde_json::json!({"source": nt.source.as_str()}),
+                &EventPayload::TaskInserted {
+                    source: nt.source.as_str().to_string(),
+                    fingerprint: None,
+                },
                 now,
             )
             .map_err(backend)?;
@@ -515,7 +538,9 @@ impl TaskRepo for SqliteTaskStore {
                 EventKind::WatchDuplicate,
                 Some(&task.epic_name),
                 Some(&TaskId::from_raw(existing_id.clone())),
-                &serde_json::json!({"fingerprint": task.fingerprint}),
+                &EventPayload::WatchDuplicate {
+                    fingerprint: task.fingerprint.clone(),
+                },
                 now,
             )
             .map_err(backend)?;
@@ -548,7 +573,10 @@ impl TaskRepo for SqliteTaskStore {
             EventKind::TaskInserted,
             Some(&task.epic_name),
             Some(&task.id),
-            &serde_json::json!({"source": task.source.as_str(), "fingerprint": task.fingerprint}),
+            &EventPayload::TaskInserted {
+                source: task.source.as_str().to_string(),
+                fingerprint: Some(task.fingerprint.clone()),
+            },
             now,
         )
         .map_err(backend)?;
@@ -609,7 +637,9 @@ impl TaskRepo for SqliteTaskStore {
             EventKind::TaskClaimed,
             Some(epic),
             Some(&task.id),
-            &serde_json::json!({"attempts": task.attempts}),
+            &EventPayload::TaskClaimed {
+                attempts: task.attempts,
+            },
             now,
         )
         .map_err(backend)?;
@@ -675,7 +705,7 @@ impl TaskRepo for SqliteTaskStore {
             EventKind::TaskCompleted,
             Some(&epic_name),
             Some(id),
-            &serde_json::json!({"pr_number": pr_number}),
+            &EventPayload::TaskCompleted { pr_number },
             now,
         )
         .map_err(backend)?;
@@ -716,7 +746,7 @@ impl TaskRepo for SqliteTaskStore {
                 EventKind::TaskUnblocked,
                 Some(&epic_name),
                 Some(&TaskId::from_raw(nid.clone())),
-                &serde_json::json!({}),
+                &EventPayload::TaskUnblocked,
                 now,
             )
             .map_err(backend)?;
@@ -767,7 +797,10 @@ impl TaskRepo for SqliteTaskStore {
                 EventKind::TaskFailed,
                 Some(&epic_name),
                 Some(id),
-                &serde_json::json!({"final": true, "attempts": attempts}),
+                &EventPayload::TaskFailed {
+                    is_final: true,
+                    attempts,
+                },
                 now,
             )
             .map_err(backend)?;
@@ -776,7 +809,10 @@ impl TaskRepo for SqliteTaskStore {
                 EventKind::TaskEscalated,
                 Some(&epic_name),
                 Some(id),
-                &serde_json::json!({"attempts": attempts}),
+                &EventPayload::TaskEscalated {
+                    attempts: Some(attempts),
+                    issue: None,
+                },
                 now,
             )
             .map_err(backend)?;
@@ -808,7 +844,10 @@ impl TaskRepo for SqliteTaskStore {
                         EventKind::TaskBlocked,
                         Some(&epic_name),
                         Some(&TaskId::from_raw(dep_id.clone())),
-                        &serde_json::json!({"reason":"parent_escalated","parent": id.as_str()}),
+                        &EventPayload::TaskBlocked {
+                            reason: "parent_escalated".to_string(),
+                            parent: id.as_str().to_string(),
+                        },
                         now,
                     )
                     .map_err(backend)?;
@@ -828,7 +867,10 @@ impl TaskRepo for SqliteTaskStore {
                 EventKind::TaskFailed,
                 Some(&epic_name),
                 Some(id),
-                &serde_json::json!({"final": false, "attempts": attempts}),
+                &EventPayload::TaskFailed {
+                    is_final: false,
+                    attempts,
+                },
                 now,
             )
             .map_err(backend)?;
@@ -860,7 +902,10 @@ impl TaskRepo for SqliteTaskStore {
             EventKind::TaskEscalated,
             Some(&epic_name),
             Some(id),
-            &serde_json::json!({"issue": issue_number}),
+            &EventPayload::TaskEscalated {
+                attempts: None,
+                issue: Some(issue_number),
+            },
             now,
         )
         .map_err(backend)?;
@@ -957,7 +1002,7 @@ impl TaskRepo for SqliteTaskStore {
                 EventKind::TaskReleasedStale,
                 Some(&epic_name),
                 Some(&task_id),
-                &serde_json::json!({"prev_attempts": prev_attempts}),
+                &EventPayload::TaskReleasedStale { prev_attempts },
                 now,
             )
             .map_err(backend)?;
@@ -1011,11 +1056,11 @@ impl TaskRepo for SqliteTaskStore {
             EventKind::TaskForceStatus,
             Some(&epic_name),
             Some(id),
-            &serde_json::json!({
-                "from": prev.as_str(),
-                "to": target.as_str(),
-                "reason": reason,
-            }),
+            &EventPayload::TaskForceStatus {
+                from: prev.as_str().to_string(),
+                to: target.as_str().to_string(),
+                reason: reason.to_string(),
+            },
             now,
         )
         .map_err(backend)?;
@@ -1224,7 +1269,9 @@ impl TaskRepo for SqliteTaskStore {
                 EventKind::Reconciled,
                 Some(&plan.epic.name),
                 None,
-                &serde_json::json!({"orphan_branch": branch}),
+                &EventPayload::Reconciled(ReconciledPayload::OrphanBranch {
+                    orphan_branch: branch.clone(),
+                }),
                 now,
             )
             .map_err(backend)?;
@@ -1234,7 +1281,9 @@ impl TaskRepo for SqliteTaskStore {
             EventKind::Reconciled,
             Some(&plan.epic.name),
             None,
-            &serde_json::json!({"tasks": plan.tasks.len()}),
+            &EventPayload::Reconciled(ReconciledPayload::Summary {
+                tasks: plan.tasks.len() as u64,
+            }),
             now,
         )
         .map_err(backend)?;
@@ -1320,7 +1369,7 @@ impl EventLog for SqliteTaskStore {
     fn list_events(&self, filter: EventFilter) -> Result<Vec<Event>> {
         let conn = self.conn.lock().expect("poisoned");
         let mut sql =
-            String::from("SELECT epic_name, task_id, kind, payload, at FROM events WHERE 1=1");
+            String::from("SELECT id, epic_name, task_id, kind, payload, at FROM events WHERE 1=1");
         let mut binds: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
         if let Some(epic) = &filter.epic {
             sql.push_str(" AND epic_name=?");

--- a/plugins/github-autopilot/cli/tests/events_tests.rs
+++ b/plugins/github-autopilot/cli/tests/events_tests.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use autopilot::cmd::events::{EventsService, ListArgs};
-use autopilot::domain::{Event, EventKind, TaskId};
+use autopilot::domain::{Event, EventKind, EventPayload, TaskId};
 use autopilot::ports::task_store::TaskStore;
 use autopilot::store::InMemoryTaskStore;
 use chrono::{DateTime, TimeZone, Utc};
@@ -16,36 +16,66 @@ fn fixture_with_events() -> Arc<dyn TaskStore> {
     let store: Arc<dyn TaskStore> = Arc::new(InMemoryTaskStore::new());
     let t0 = base_time();
     // (epic, task, kind, +seconds)
-    let seeds: &[(Option<&str>, Option<&str>, EventKind, i64)] = &[
-        (Some("e1"), None, EventKind::EpicStarted, 0),
+    let seeds: Vec<(Option<&str>, Option<&str>, EventKind, EventPayload, i64)> = vec![
+        (
+            Some("e1"),
+            None,
+            EventKind::EpicStarted,
+            EventPayload::EpicStarted,
+            0,
+        ),
         (
             Some("e1"),
             Some("aaaaaaaaaaaa"),
             EventKind::TaskInserted,
+            EventPayload::TaskInserted {
+                source: "spec".into(),
+                fingerprint: None,
+            },
             10,
         ),
-        (Some("e1"), Some("aaaaaaaaaaaa"), EventKind::TaskClaimed, 20),
+        (
+            Some("e1"),
+            Some("aaaaaaaaaaaa"),
+            EventKind::TaskClaimed,
+            EventPayload::TaskClaimed { attempts: 1 },
+            20,
+        ),
         (
             Some("e1"),
             Some("bbbbbbbbbbbb"),
             EventKind::TaskInserted,
+            EventPayload::TaskInserted {
+                source: "spec".into(),
+                fingerprint: None,
+            },
             30,
         ),
-        (Some("e2"), None, EventKind::EpicStarted, 40),
+        (
+            Some("e2"),
+            None,
+            EventKind::EpicStarted,
+            EventPayload::EpicStarted,
+            40,
+        ),
         (
             Some("e2"),
             Some("cccccccccccc"),
             EventKind::TaskInserted,
+            EventPayload::TaskInserted {
+                source: "spec".into(),
+                fingerprint: None,
+            },
             50,
         ),
     ];
-    for (epic, task, kind, sec) in seeds {
+    for (epic, task, kind, payload, sec) in seeds {
         let event = Event {
             task_id: task.map(TaskId::from_raw),
             epic_name: epic.map(|s| s.to_string()),
-            kind: *kind,
-            payload: serde_json::Value::Null,
-            at: t0 + chrono::Duration::seconds(*sec),
+            kind,
+            payload,
+            at: t0 + chrono::Duration::seconds(sec),
         };
         store.append_event(&event).unwrap();
     }

--- a/plugins/github-autopilot/cli/tests/events_tests.rs
+++ b/plugins/github-autopilot/cli/tests/events_tests.rs
@@ -12,11 +12,19 @@ fn base_time() -> DateTime<Utc> {
     Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap()
 }
 
+type EventSeed<'a> = (
+    Option<&'a str>,
+    Option<&'a str>,
+    EventKind,
+    EventPayload,
+    i64,
+);
+
 fn fixture_with_events() -> Arc<dyn TaskStore> {
     let store: Arc<dyn TaskStore> = Arc::new(InMemoryTaskStore::new());
     let t0 = base_time();
-    // (epic, task, kind, +seconds)
-    let seeds: Vec<(Option<&str>, Option<&str>, EventKind, EventPayload, i64)> = vec![
+    // (epic, task, kind, payload, +seconds)
+    let seeds: Vec<EventSeed> = vec![
         (
             Some("e1"),
             None,

--- a/plugins/github-autopilot/cli/tests/store_conformance.rs
+++ b/plugins/github-autopilot/cli/tests/store_conformance.rs
@@ -793,8 +793,13 @@ fn body_force_status_records_event_with_reason(store: Arc<dyn TaskStore>) {
         })
         .unwrap();
     assert_eq!(evs.len(), 1);
-    assert_eq!(evs[0].payload["reason"], "rollback for repro");
-    assert_eq!(evs[0].payload["to"], "pending");
+    match &evs[0].payload {
+        autopilot::domain::EventPayload::TaskForceStatus { reason, to, .. } => {
+            assert_eq!(reason, "rollback for repro");
+            assert_eq!(to, "pending");
+        }
+        other => panic!("expected TaskForceStatus payload, got {other:?}"),
+    }
 }
 
 fn body_suppression_blocks_until_window_expires(store: Arc<dyn TaskStore>) {


### PR DESCRIPTION
## Summary

`Event.payload` 를 untyped `serde_json::Value` 에서 `EventKind` 와 1:1 매핑된 `EventPayload` enum 으로 마이그레이션.

## Design (옵션 1, incremental)

`Event` struct 자체는 유지하고 `payload` 필드 타입만 변경. `EventKind` enum 은 그대로 두고 `EventPayload::kind()` helper 로 일관성 검증.

## Breaking 정책

- 외부 소비자 없음 (사용자 본인만 사용). breaking 허용.
- 기존 `events` 테이블 row 의 payload JSON 은 새 typed enum 직렬화 형태와 호환 안 될 수 있음.
- 마이그레이션 SQL 작성 안 함 — DB read 실패 시 사용자가 직접 ledger reset 권장.

## Acceptance

- [x] `cargo build --tests` — pass
- [x] `cargo test -p github-autopilot` — 모든 테스트 pass
- [ ] `cargo clippy --tests -- -D warnings` — `tests/events_tests.rs:19` type_complexity 한 건 follow-up 으로 fix 예정 (별도 commit)
- [x] `cargo fmt --check` — pass

## 후속

clippy type_complexity fix commit 이 같은 PR 에 추가 push 됨.