### PR TITLE
refactor(github-autopilot): cli-ux tail (release-stale shape, log/env_logger, typed event payload)

### DIFF
--- a/plugins/github-autopilot/cli/Cargo.lock
+++ b/plugins/github-autopilot/cli/Cargo.lock
@@ -117,7 +117,9 @@ dependencies = [
  "assert_cmd",
  "chrono",
  "clap",
+ "env_logger",
  "hex",
+ "log",
  "predicates",
  "rusqlite",
  "serde",
@@ -276,6 +278,29 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "env_filter"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
 ]
 
 [[package]]
@@ -480,6 +505,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jiff"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -570,6 +619,21 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "predicates"

--- a/plugins/github-autopilot/cli/Cargo.toml
+++ b/plugins/github-autopilot/cli/Cargo.toml
@@ -15,7 +15,9 @@ path = "src/main.rs"
 anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
+env_logger = "0.11"
 hex = "0.4"
+log = "0.4"
 rusqlite = { version = "0.32", features = ["bundled", "chrono"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/plugins/github-autopilot/cli/src/cmd/events.rs
+++ b/plugins/github-autopilot/cli/src/cmd/events.rs
@@ -12,7 +12,7 @@ use clap::{Args, Subcommand};
 use serde::Serialize;
 
 use crate::cmd::output::write_json;
-use crate::domain::{Event, EventKind, TaskId};
+use crate::domain::{Event, EventKind, EventPayload, TaskId};
 use crate::ports::task_store::{EventFilter, EventLog};
 
 const PAYLOAD_PREVIEW_LIMIT: usize = 40;
@@ -126,12 +126,23 @@ fn render_table(events: &[Event], out: &mut dyn Write) -> Result<()> {
     Ok(())
 }
 
-fn payload_preview(value: &serde_json::Value) -> String {
-    let s = if value.is_null() {
-        "-".to_string()
+fn payload_preview(payload: &EventPayload) -> String {
+    // Convert via `serde_json::Value` so the table preview keeps its prior
+    // shape (compact JSON, "-" for empty objects). Round-tripping through
+    // Value also lets us strip the `kind` discriminator that the typed enum
+    // adds — it is redundant in the preview column since `KIND` is already
+    // shown to the left.
+    let value = serde_json::to_value(payload).unwrap_or(serde_json::Value::Null);
+    let preview_value = if let serde_json::Value::Object(mut map) = value {
+        map.remove("kind");
+        if map.is_empty() {
+            return "-".to_string();
+        }
+        serde_json::Value::Object(map)
     } else {
-        value.to_string()
+        value
     };
+    let s = preview_value.to_string();
     if s.chars().count() <= PAYLOAD_PREVIEW_LIMIT {
         return s;
     }
@@ -145,7 +156,7 @@ struct EventRecord<'a> {
     kind: &'static str,
     epic: Option<&'a str>,
     task: Option<&'a str>,
-    payload: &'a serde_json::Value,
+    payload: &'a EventPayload,
 }
 
 impl<'a> From<&'a Event> for EventRecord<'a> {

--- a/plugins/github-autopilot/cli/src/cmd/stats.rs
+++ b/plugins/github-autopilot/cli/src/cmd/stats.rs
@@ -75,8 +75,8 @@ impl StatsService {
     ) -> Result<i32> {
         validate_loop_name(command)?;
         if !KNOWN_COMMANDS.contains(&command) {
-            eprintln!(
-                "warning: --command {command:?} is not in the canonical list ({}). Recording anyway.",
+            log::warn!(
+                "--command {command:?} is not in the canonical list ({}). Recording anyway.",
                 KNOWN_COMMANDS.join(", ")
             );
         }

--- a/plugins/github-autopilot/cli/src/cmd/task.rs
+++ b/plugins/github-autopilot/cli/src/cmd/task.rs
@@ -368,14 +368,14 @@ impl<'a> TaskService<'a> {
             .release_stale(cutoff, now)
             .with_context(|| format!("releasing stale Wip tasks older than {before_seconds}s"))?;
         if json {
-            let ids: Vec<&str> = recovered.iter().map(|i| i.as_str()).collect();
-            write_json(out, &ids)?;
-        } else if recovered.is_empty() {
+            return write_json(out, &recovered).map(|()| 0);
+        }
+        if recovered.is_empty() {
             writeln!(out, "released 0 stale tasks")?;
         } else {
             writeln!(out, "released {} stale tasks:", recovered.len())?;
-            for id in &recovered {
-                writeln!(out, "  {}", id.as_str())?;
+            for t in &recovered {
+                writeln!(out, "  {}", t.id.as_str())?;
             }
         }
         Ok(0)

--- a/plugins/github-autopilot/cli/src/cmd/watch/mod.rs
+++ b/plugins/github-autopilot/cli/src/cmd/watch/mod.rs
@@ -228,7 +228,7 @@ impl WatchService {
         let stale_threshold_secs = match parse_duration_seconds(&args.stale_threshold) {
             Ok(s) => s,
             Err(e) => {
-                eprintln!("invalid --stale-threshold: {e}");
+                log::error!("invalid --stale-threshold: {e}");
                 return Err(2);
             }
         };
@@ -328,7 +328,7 @@ impl WatchService {
                 // catches up. Clamp at the read boundary, warn once, and
                 // let the next periodic save persist the corrected cursor.
                 if let Some(future) = ts.state.ledger.clamp_future_cursor(now) {
-                    eprintln!(
+                    log::warn!(
                         "watch.json clock skew detected: last_event_at={future} > now={now}; \
                          clamping. Likely cause: NTP correction or watch.json copied across hosts."
                     );

--- a/plugins/github-autopilot/cli/src/domain/event.rs
+++ b/plugins/github-autopilot/cli/src/domain/event.rs
@@ -8,8 +8,37 @@ pub struct Event {
     pub task_id: Option<TaskId>,
     pub epic_name: Option<String>,
     pub kind: EventKind,
-    pub payload: serde_json::Value,
+    pub payload: EventPayload,
     pub at: DateTime<Utc>,
+}
+
+impl Event {
+    /// Build an `Event` whose [`EventKind`] matches the inner [`EventPayload`]
+    /// variant. `debug_assert!` enforces the invariant in test/dev builds; in
+    /// release builds the caller-supplied `kind` is trusted (we deliberately
+    /// avoid panicking the daemon on a programming bug, since the same
+    /// information is recoverable from `payload.kind()`).
+    pub fn new(
+        kind: EventKind,
+        epic_name: Option<String>,
+        task_id: Option<TaskId>,
+        payload: EventPayload,
+        at: DateTime<Utc>,
+    ) -> Self {
+        debug_assert_eq!(
+            kind,
+            payload.kind(),
+            "Event::new: kind {kind:?} does not match payload variant {:?}",
+            payload.kind()
+        );
+        Self {
+            task_id,
+            epic_name,
+            kind,
+            payload,
+            at,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -85,5 +114,293 @@ impl EventKind {
             "task_released_stale" => EventKind::TaskReleasedStale,
             _ => return None,
         })
+    }
+}
+
+/// Typed counterpart of [`EventKind`]. Each variant carries the exact fields
+/// emitted by the corresponding store operation, so consumers no longer have
+/// to memorize untyped JSON keys.
+///
+/// Serializes with an internally tagged representation
+/// (`{ "kind": "<snake_case>", ...fields }`). Variant ↔ [`EventKind`] mapping
+/// is enforced by [`EventPayload::kind`] and asserted in [`Event::new`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum EventPayload {
+    EpicStarted,
+    EpicCompleted,
+    EpicAbandoned,
+    /// Emitted both for `insert_epic_with_tasks` (only `source` populated) and
+    /// `upsert_watch_task` (both `source` and `fingerprint` populated).
+    TaskInserted {
+        source: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        fingerprint: Option<String>,
+    },
+    TaskClaimed {
+        attempts: u32,
+    },
+    /// Reserved — no emit site yet. Kept so [`EventKind`] ↔ [`EventPayload`]
+    /// stays 1:1.
+    TaskStarted,
+    TaskCompleted {
+        pr_number: u64,
+    },
+    TaskFailed {
+        #[serde(rename = "final")]
+        is_final: bool,
+        attempts: u32,
+    },
+    /// Emitted from two paths: `mark_task_failed` (max-attempts → escalated)
+    /// carries `attempts`; `escalate_task` (record GitHub issue number)
+    /// carries `issue`. Both fields are optional so either path can be
+    /// represented losslessly.
+    TaskEscalated {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        attempts: Option<u32>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        issue: Option<u64>,
+    },
+    TaskBlocked {
+        reason: String,
+        parent: String,
+    },
+    TaskUnblocked,
+    /// Reconciliation events come in two shapes — per-orphan-branch and a
+    /// summary line at the end. Modelled as separate sub-variants via an
+    /// internal `event` discriminator so each shape is unambiguous.
+    Reconciled(ReconciledPayload),
+    /// Reserved — no emit site yet.
+    ClaimLost,
+    /// Reserved — no emit site yet.
+    MigratedFromIssue,
+    /// Reserved — no emit site yet.
+    EscalationResolved,
+    WatchDuplicate {
+        fingerprint: String,
+    },
+    TaskForceStatus {
+        from: String,
+        to: String,
+        reason: String,
+    },
+    TaskReleasedStale {
+        prev_attempts: u32,
+    },
+}
+
+/// Sub-variants of [`EventPayload::Reconciled`]. Reconciliation emits one
+/// event per orphan branch plus a final summary; both shapes are recorded
+/// distinctly so tooling can filter / count without inspecting payload keys.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "event", rename_all = "snake_case")]
+pub enum ReconciledPayload {
+    OrphanBranch { orphan_branch: String },
+    Summary { tasks: u64 },
+}
+
+impl EventPayload {
+    /// Returns the [`EventKind`] this payload corresponds to. Pairs with
+    /// [`Event::new`] to guarantee `Event.kind == Event.payload.kind()`.
+    pub fn kind(&self) -> EventKind {
+        match self {
+            EventPayload::EpicStarted => EventKind::EpicStarted,
+            EventPayload::EpicCompleted => EventKind::EpicCompleted,
+            EventPayload::EpicAbandoned => EventKind::EpicAbandoned,
+            EventPayload::TaskInserted { .. } => EventKind::TaskInserted,
+            EventPayload::TaskClaimed { .. } => EventKind::TaskClaimed,
+            EventPayload::TaskStarted => EventKind::TaskStarted,
+            EventPayload::TaskCompleted { .. } => EventKind::TaskCompleted,
+            EventPayload::TaskFailed { .. } => EventKind::TaskFailed,
+            EventPayload::TaskEscalated { .. } => EventKind::TaskEscalated,
+            EventPayload::TaskBlocked { .. } => EventKind::TaskBlocked,
+            EventPayload::TaskUnblocked => EventKind::TaskUnblocked,
+            EventPayload::Reconciled(_) => EventKind::Reconciled,
+            EventPayload::ClaimLost => EventKind::ClaimLost,
+            EventPayload::MigratedFromIssue => EventKind::MigratedFromIssue,
+            EventPayload::EscalationResolved => EventKind::EscalationResolved,
+            EventPayload::WatchDuplicate { .. } => EventKind::WatchDuplicate,
+            EventPayload::TaskForceStatus { .. } => EventKind::TaskForceStatus,
+            EventPayload::TaskReleasedStale { .. } => EventKind::TaskReleasedStale,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn at() -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc)
+    }
+
+    fn roundtrip(payload: EventPayload) -> EventPayload {
+        let s = serde_json::to_string(&payload).expect("serialize");
+        serde_json::from_str(&s).expect("deserialize")
+    }
+
+    #[test]
+    fn payload_kind_matches_for_every_variant() {
+        let cases: Vec<(EventPayload, EventKind)> = vec![
+            (EventPayload::EpicStarted, EventKind::EpicStarted),
+            (EventPayload::EpicCompleted, EventKind::EpicCompleted),
+            (EventPayload::EpicAbandoned, EventKind::EpicAbandoned),
+            (
+                EventPayload::TaskInserted {
+                    source: "spec".into(),
+                    fingerprint: None,
+                },
+                EventKind::TaskInserted,
+            ),
+            (
+                EventPayload::TaskClaimed { attempts: 1 },
+                EventKind::TaskClaimed,
+            ),
+            (EventPayload::TaskStarted, EventKind::TaskStarted),
+            (
+                EventPayload::TaskCompleted { pr_number: 42 },
+                EventKind::TaskCompleted,
+            ),
+            (
+                EventPayload::TaskFailed {
+                    is_final: false,
+                    attempts: 1,
+                },
+                EventKind::TaskFailed,
+            ),
+            (
+                EventPayload::TaskEscalated {
+                    attempts: Some(3),
+                    issue: None,
+                },
+                EventKind::TaskEscalated,
+            ),
+            (
+                EventPayload::TaskBlocked {
+                    reason: "parent_escalated".into(),
+                    parent: "abc".into(),
+                },
+                EventKind::TaskBlocked,
+            ),
+            (EventPayload::TaskUnblocked, EventKind::TaskUnblocked),
+            (
+                EventPayload::Reconciled(ReconciledPayload::Summary { tasks: 3 }),
+                EventKind::Reconciled,
+            ),
+            (EventPayload::ClaimLost, EventKind::ClaimLost),
+            (
+                EventPayload::MigratedFromIssue,
+                EventKind::MigratedFromIssue,
+            ),
+            (
+                EventPayload::EscalationResolved,
+                EventKind::EscalationResolved,
+            ),
+            (
+                EventPayload::WatchDuplicate {
+                    fingerprint: "fp".into(),
+                },
+                EventKind::WatchDuplicate,
+            ),
+            (
+                EventPayload::TaskForceStatus {
+                    from: "wip".into(),
+                    to: "ready".into(),
+                    reason: "manual".into(),
+                },
+                EventKind::TaskForceStatus,
+            ),
+            (
+                EventPayload::TaskReleasedStale { prev_attempts: 2 },
+                EventKind::TaskReleasedStale,
+            ),
+        ];
+        for (payload, expected_kind) in cases {
+            assert_eq!(
+                payload.kind(),
+                expected_kind,
+                "kind() mismatch for {payload:?}"
+            );
+            // Round-trip preserves the variant.
+            let restored = roundtrip(payload.clone());
+            assert_eq!(restored, payload, "round-trip mismatch for {payload:?}");
+        }
+    }
+
+    #[test]
+    fn task_inserted_serializes_with_kind_tag() {
+        let p = EventPayload::TaskInserted {
+            source: "spec".into(),
+            fingerprint: Some("fp1".into()),
+        };
+        let v = serde_json::to_value(&p).unwrap();
+        assert_eq!(v["kind"], "task_inserted");
+        assert_eq!(v["source"], "spec");
+        assert_eq!(v["fingerprint"], "fp1");
+    }
+
+    #[test]
+    fn task_inserted_omits_fingerprint_when_none() {
+        let p = EventPayload::TaskInserted {
+            source: "spec".into(),
+            fingerprint: None,
+        };
+        let v = serde_json::to_value(&p).unwrap();
+        assert_eq!(v["kind"], "task_inserted");
+        assert!(
+            v.get("fingerprint").is_none(),
+            "fingerprint key must be omitted when None, got {v}"
+        );
+    }
+
+    #[test]
+    fn reconciled_orphan_branch_distinct_from_summary() {
+        let orphan = EventPayload::Reconciled(ReconciledPayload::OrphanBranch {
+            orphan_branch: "feat/x".into(),
+        });
+        let summary = EventPayload::Reconciled(ReconciledPayload::Summary { tasks: 5 });
+        let v_orphan = serde_json::to_value(&orphan).unwrap();
+        let v_summary = serde_json::to_value(&summary).unwrap();
+        assert_eq!(v_orphan["kind"], "reconciled");
+        assert_eq!(v_orphan["event"], "orphan_branch");
+        assert_eq!(v_orphan["orphan_branch"], "feat/x");
+        assert_eq!(v_summary["kind"], "reconciled");
+        assert_eq!(v_summary["event"], "summary");
+        assert_eq!(v_summary["tasks"], 5);
+    }
+
+    #[test]
+    fn event_new_propagates_fields() {
+        let payload = EventPayload::TaskClaimed { attempts: 1 };
+        let event = Event::new(
+            EventKind::TaskClaimed,
+            Some("e1".into()),
+            Some(TaskId::from_raw("aaaaaaaaaaaa")),
+            payload.clone(),
+            at(),
+        );
+        assert_eq!(event.kind, EventKind::TaskClaimed);
+        assert_eq!(event.payload, payload);
+        assert_eq!(event.epic_name.as_deref(), Some("e1"));
+        assert_eq!(
+            event.task_id.as_ref().map(TaskId::as_str),
+            Some("aaaaaaaaaaaa")
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "kind")]
+    fn event_new_panics_on_kind_payload_mismatch_in_debug() {
+        // Only meaningful in debug builds; release skips the assert and the
+        // event is still constructed. This test guards the dev-time check.
+        let _ = Event::new(
+            EventKind::TaskCompleted,
+            None,
+            None,
+            EventPayload::TaskUnblocked,
+            at(),
+        );
     }
 }

--- a/plugins/github-autopilot/cli/src/domain/mod.rs
+++ b/plugins/github-autopilot/cli/src/domain/mod.rs
@@ -8,6 +8,6 @@ pub mod task_id;
 pub use deps::{CycleError, TaskGraph};
 pub use epic::{Epic, EpicStatus};
 pub use error::{DomainError, UserInputError};
-pub use event::{Event, EventKind};
+pub use event::{Event, EventKind, EventPayload, ReconciledPayload};
 pub use task::{Task, TaskFailureOutcome, TaskSource, TaskStatus};
 pub use task_id::{TaskId, TaskIdParseError};

--- a/plugins/github-autopilot/cli/src/main.rs
+++ b/plugins/github-autopilot/cli/src/main.rs
@@ -12,11 +12,13 @@ use std::io::stdout;
 use std::path::{Path, PathBuf};
 
 fn main() {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
     let cli = Cli::parse();
     let config = match load_config(cli.config.as_deref()) {
         Ok(c) => c,
         Err(e) => {
-            eprintln!("{e:#}");
+            log::error!("{e:#}");
             std::process::exit(2);
         }
     };
@@ -208,7 +210,7 @@ fn main() {
                 } => match resolve_before_seconds(before.as_deref(), before_seconds) {
                     Ok(secs) => svc.list_stale(secs, json, &mut out),
                     Err(msg) => {
-                        eprintln!("{msg}");
+                        log::error!("{msg}");
                         std::process::exit(2);
                     }
                 },
@@ -228,7 +230,7 @@ fn main() {
                         match resolve_before_seconds(before.as_deref(), before_seconds) {
                             Ok(secs) => svc.release_stale(secs, json, &mut out),
                             Err(msg) => {
-                                eprintln!("{msg}");
+                                log::error!("{msg}");
                                 std::process::exit(2);
                             }
                         }
@@ -299,7 +301,7 @@ fn main() {
     match result {
         Ok(code) => std::process::exit(code),
         Err(e) => {
-            eprintln!("{e:#}");
+            log::error!("{e:#}");
             std::process::exit(exit_code_for(&e));
         }
     }
@@ -370,7 +372,7 @@ fn open_store(config: &Config) -> SqliteTaskStore {
     match SqliteTaskStore::open(&db_path) {
         Ok(s) => s,
         Err(e) => {
-            eprintln!("failed to open task store at {}: {e}", db_path.display());
+            log::error!("failed to open task store at {}: {e}", db_path.display());
             std::process::exit(2);
         }
     }

--- a/plugins/github-autopilot/cli/src/ports/task_store.rs
+++ b/plugins/github-autopilot/cli/src/ports/task_store.rs
@@ -156,13 +156,16 @@ pub trait TaskRepo: Send + Sync {
     /// `release_claim`). Used by the cron supervisor to reap orphaned claims
     /// after worker crashes / ctrl-C / worktree destruction so the task can
     /// reach another worker. Each recovered task gets a `TaskReleasedStale`
-    /// event for audit. Returns the ids of recovered tasks (empty when no
-    /// stale Wip exists — idempotent).
+    /// event for audit. Returns the recovered tasks — each `Task` reflects
+    /// the post-release state (`status = Ready`, `attempts` decremented,
+    /// `updated_at = now`), matching the `Vec<Task>` shape produced by
+    /// `list_stale` so callers can use a single parser. Empty result is
+    /// normal (idempotent).
     ///
     /// Per `CLAUDE.md` "책임 경계", the **decision** of when to bulk-recover
     /// vs review per-task is the agent's call (see `list_stale`); this CLI
     /// path remains as an emergency operator primitive.
-    fn release_stale(&self, before: DateTime<Utc>, now: DateTime<Utc>) -> Result<Vec<TaskId>>;
+    fn release_stale(&self, before: DateTime<Utc>, now: DateTime<Utc>) -> Result<Vec<Task>>;
 
     /// Read-only observation of Wip tasks whose `updated_at` is older than
     /// `before`. Returns the same set of tasks that `release_stale` would

--- a/plugins/github-autopilot/cli/src/store/memory.rs
+++ b/plugins/github-autopilot/cli/src/store/memory.rs
@@ -596,7 +596,7 @@ impl TaskRepo for InMemoryTaskStore {
         Ok(stale)
     }
 
-    fn release_stale(&self, before: DateTime<Utc>, now: DateTime<Utc>) -> Result<Vec<TaskId>> {
+    fn release_stale(&self, before: DateTime<Utc>, now: DateTime<Utc>) -> Result<Vec<Task>> {
         let mut s = self.state.lock().expect("poisoned");
         let stale: Vec<(TaskId, String, u32)> = s
             .tasks
@@ -607,11 +607,17 @@ impl TaskRepo for InMemoryTaskStore {
 
         let mut recovered = Vec::with_capacity(stale.len());
         for (id, epic_name, prev_attempts) in stale {
-            if let Some(task) = s.tasks.get_mut(&id) {
+            // Apply the release transition then snapshot the post-release
+            // Task so the returned vec matches `list_stale`'s shape (each
+            // Task carries Ready status + decremented attempts).
+            let snapshot = if let Some(task) = s.tasks.get_mut(&id) {
                 task.status = TaskStatus::Ready;
                 task.attempts = task.attempts.saturating_sub(1);
                 task.updated_at = now;
-            }
+                Some(task.clone())
+            } else {
+                None
+            };
             let event = InMemoryTaskStore::make_event(
                 EventKind::TaskReleasedStale,
                 Some(epic_name),
@@ -620,7 +626,9 @@ impl TaskRepo for InMemoryTaskStore {
                 now,
             );
             InMemoryTaskStore::push_event(&mut s, event);
-            recovered.push(id);
+            if let Some(task) = snapshot {
+                recovered.push(task);
+            }
         }
         Ok(recovered)
     }

--- a/plugins/github-autopilot/cli/src/store/memory.rs
+++ b/plugins/github-autopilot/cli/src/store/memory.rs
@@ -5,8 +5,8 @@ use std::sync::Mutex;
 use chrono::{DateTime, Utc};
 
 use crate::domain::{
-    DomainError, Epic, EpicStatus, Event, EventKind, Task, TaskFailureOutcome, TaskGraph, TaskId,
-    TaskStatus,
+    DomainError, Epic, EpicStatus, Event, EventKind, EventPayload, ReconciledPayload, Task,
+    TaskFailureOutcome, TaskGraph, TaskId, TaskStatus,
 };
 use crate::ports::task_store::{
     EpicPlan, EpicRepo, EventFilter, EventLog, NewWatchTask, ReconciliationPlan, RemotePrState,
@@ -70,9 +70,15 @@ impl InMemoryTaskStore {
         kind: EventKind,
         epic: Option<String>,
         task: Option<TaskId>,
-        payload: serde_json::Value,
+        payload: EventPayload,
         at: DateTime<Utc>,
     ) -> Event {
+        debug_assert_eq!(
+            kind,
+            payload.kind(),
+            "make_event: kind {kind:?} does not match payload variant {:?}",
+            payload.kind()
+        );
         Event {
             task_id: task,
             epic_name: epic,
@@ -121,13 +127,12 @@ impl EpicRepo for InMemoryTaskStore {
             EpicStatus::Completed => EventKind::EpicCompleted,
             EpicStatus::Abandoned => EventKind::EpicAbandoned,
         };
-        let event = InMemoryTaskStore::make_event(
-            kind,
-            Some(name.to_string()),
-            None,
-            serde_json::json!({}),
-            at,
-        );
+        let payload = match status {
+            EpicStatus::Active => EventPayload::EpicStarted,
+            EpicStatus::Completed => EventPayload::EpicCompleted,
+            EpicStatus::Abandoned => EventPayload::EpicAbandoned,
+        };
+        let event = InMemoryTaskStore::make_event(kind, Some(name.to_string()), None, payload, at);
         InMemoryTaskStore::push_event(&mut s, event);
         Ok(())
     }
@@ -238,7 +243,7 @@ impl TaskRepo for InMemoryTaskStore {
                 EventKind::EpicStarted,
                 Some(epic.name.clone()),
                 None,
-                serde_json::json!({}),
+                EventPayload::EpicStarted,
                 now,
             ),
         );
@@ -249,7 +254,10 @@ impl TaskRepo for InMemoryTaskStore {
                     EventKind::TaskInserted,
                     Some(epic.name.clone()),
                     Some(nt.id.clone()),
-                    serde_json::json!({"source": nt.source.as_str()}),
+                    EventPayload::TaskInserted {
+                        source: nt.source.as_str().to_string(),
+                        fingerprint: None,
+                    },
                     now,
                 ),
             );
@@ -304,7 +312,9 @@ impl TaskRepo for InMemoryTaskStore {
                     EventKind::WatchDuplicate,
                     Some(task.epic_name.clone()),
                     Some(existing.id.clone()),
-                    serde_json::json!({"fingerprint": task.fingerprint}),
+                    EventPayload::WatchDuplicate {
+                        fingerprint: task.fingerprint.clone(),
+                    },
                     now,
                 ),
             );
@@ -338,7 +348,10 @@ impl TaskRepo for InMemoryTaskStore {
                 EventKind::TaskInserted,
                 Some(task.epic_name.clone()),
                 Some(id.clone()),
-                serde_json::json!({"source": task.source.as_str(), "fingerprint": task.fingerprint}),
+                EventPayload::TaskInserted {
+                    source: task.source.as_str().to_string(),
+                    fingerprint: Some(task.fingerprint.clone()),
+                },
                 now,
             ),
         );
@@ -381,7 +394,9 @@ impl TaskRepo for InMemoryTaskStore {
                 EventKind::TaskClaimed,
                 Some(epic.to_string()),
                 Some(snapshot.id.clone()),
-                serde_json::json!({"attempts": snapshot.attempts}),
+                EventPayload::TaskClaimed {
+                    attempts: snapshot.attempts,
+                },
                 now,
             ),
         );
@@ -415,7 +430,7 @@ impl TaskRepo for InMemoryTaskStore {
                 EventKind::TaskCompleted,
                 Some(epic_name.clone()),
                 Some(id.clone()),
-                serde_json::json!({"pr_number": pr_number}),
+                EventPayload::TaskCompleted { pr_number },
                 now,
             ),
         );
@@ -444,7 +459,7 @@ impl TaskRepo for InMemoryTaskStore {
                         EventKind::TaskUnblocked,
                         Some(epic_name.clone()),
                         Some(dep_task_id),
-                        serde_json::json!({}),
+                        EventPayload::TaskUnblocked,
                         now,
                     ),
                 );
@@ -484,7 +499,10 @@ impl TaskRepo for InMemoryTaskStore {
                     EventKind::TaskFailed,
                     Some(epic_name.clone()),
                     Some(id.clone()),
-                    serde_json::json!({"final": true, "attempts": attempts}),
+                    EventPayload::TaskFailed {
+                        is_final: true,
+                        attempts,
+                    },
                     now,
                 ),
             );
@@ -494,7 +512,10 @@ impl TaskRepo for InMemoryTaskStore {
                     EventKind::TaskEscalated,
                     Some(epic_name.clone()),
                     Some(id.clone()),
-                    serde_json::json!({"attempts": attempts}),
+                    EventPayload::TaskEscalated {
+                        attempts: Some(attempts),
+                        issue: None,
+                    },
                     now,
                 ),
             );
@@ -516,7 +537,10 @@ impl TaskRepo for InMemoryTaskStore {
                             EventKind::TaskBlocked,
                             Some(epic_name.clone()),
                             Some(dep_id),
-                            serde_json::json!({"reason": "parent_escalated", "parent": id.as_str()}),
+                            EventPayload::TaskBlocked {
+                                reason: "parent_escalated".to_string(),
+                                parent: id.as_str().to_string(),
+                            },
                             now,
                         ),
                     );
@@ -532,7 +556,10 @@ impl TaskRepo for InMemoryTaskStore {
                     EventKind::TaskFailed,
                     Some(epic_name),
                     Some(id.clone()),
-                    serde_json::json!({"final": false, "attempts": attempts}),
+                    EventPayload::TaskFailed {
+                        is_final: false,
+                        attempts,
+                    },
                     now,
                 ),
             );
@@ -555,7 +582,10 @@ impl TaskRepo for InMemoryTaskStore {
                 EventKind::TaskEscalated,
                 Some(epic_name),
                 Some(id.clone()),
-                serde_json::json!({"issue": issue_number}),
+                EventPayload::TaskEscalated {
+                    attempts: None,
+                    issue: Some(issue_number),
+                },
                 now,
             ),
         );
@@ -622,7 +652,7 @@ impl TaskRepo for InMemoryTaskStore {
                 EventKind::TaskReleasedStale,
                 Some(epic_name),
                 Some(id.clone()),
-                serde_json::json!({"prev_attempts": prev_attempts}),
+                EventPayload::TaskReleasedStale { prev_attempts },
                 now,
             );
             InMemoryTaskStore::push_event(&mut s, event);
@@ -655,11 +685,11 @@ impl TaskRepo for InMemoryTaskStore {
             EventKind::TaskForceStatus,
             Some(epic_name),
             Some(id.clone()),
-            serde_json::json!({
-                "from": prev.as_str(),
-                "to": target.as_str(),
-                "reason": reason,
-            }),
+            EventPayload::TaskForceStatus {
+                from: prev.as_str().to_string(),
+                to: target.as_str().to_string(),
+                reason: reason.to_string(),
+            },
             now,
         );
         InMemoryTaskStore::push_event(&mut s, event);
@@ -786,7 +816,9 @@ impl TaskRepo for InMemoryTaskStore {
                     EventKind::Reconciled,
                     Some(epic_name.clone()),
                     None,
-                    serde_json::json!({"orphan_branch": branch}),
+                    EventPayload::Reconciled(ReconciledPayload::OrphanBranch {
+                        orphan_branch: branch.clone(),
+                    }),
                     now,
                 ),
             );
@@ -798,7 +830,9 @@ impl TaskRepo for InMemoryTaskStore {
                 EventKind::Reconciled,
                 Some(epic_name.clone()),
                 None,
-                serde_json::json!({"tasks": plan.tasks.len()}),
+                EventPayload::Reconciled(ReconciledPayload::Summary {
+                    tasks: plan.tasks.len() as u64,
+                }),
                 now,
             ),
         );

--- a/plugins/github-autopilot/cli/src/store/sqlite.rs
+++ b/plugins/github-autopilot/cli/src/store/sqlite.rs
@@ -915,7 +915,7 @@ impl TaskRepo for SqliteTaskStore {
         rows.map_err(backend)
     }
 
-    fn release_stale(&self, before: DateTime<Utc>, now: DateTime<Utc>) -> Result<Vec<TaskId>> {
+    fn release_stale(&self, before: DateTime<Utc>, now: DateTime<Utc>) -> Result<Vec<Task>> {
         let mut conn = self.conn.lock().expect("poisoned");
         let tx = conn.transaction().map_err(backend)?;
 
@@ -961,7 +961,19 @@ impl TaskRepo for SqliteTaskStore {
                 now,
             )
             .map_err(backend)?;
-            recovered.push(task_id);
+            // Re-read the post-update row so the returned `Task` reflects
+            // the Ready/decremented state (matches `list_stale`'s shape).
+            let task = tx
+                .query_row(
+                    "SELECT id, epic_name, source, fingerprint, title, body, status, attempts,
+                            branch, pr_number, escalated_issue, created_at, updated_at
+                       FROM tasks
+                      WHERE id=?",
+                    params![id],
+                    task_from_row,
+                )
+                .map_err(backend)?;
+            recovered.push(task);
         }
 
         tx.commit().map_err(backend)?;

--- a/plugins/github-autopilot/cli/src/store/sqlite.rs
+++ b/plugins/github-autopilot/cli/src/store/sqlite.rs
@@ -11,8 +11,8 @@ use chrono::{DateTime, Utc};
 use rusqlite::{params, Connection, OptionalExtension, Row};
 
 use crate::domain::{
-    DomainError, Epic, EpicStatus, Event, EventKind, Task, TaskFailureOutcome, TaskGraph, TaskId,
-    TaskSource, TaskStatus,
+    DomainError, Epic, EpicStatus, Event, EventKind, EventPayload, ReconciledPayload, Task,
+    TaskFailureOutcome, TaskGraph, TaskId, TaskSource, TaskStatus,
 };
 use crate::ports::task_store::{
     EpicPlan, EpicRepo, EventFilter, EventLog, NewWatchTask, ReconciliationPlan, Result,
@@ -153,6 +153,7 @@ fn task_from_row(row: &Row<'_>) -> rusqlite::Result<Task> {
 }
 
 fn event_from_row(row: &Row<'_>) -> rusqlite::Result<Event> {
+    let row_id: i64 = row.get("id").unwrap_or(0);
     let kind_str: String = row.get("kind")?;
     let kind = EventKind::parse(&kind_str).ok_or_else(|| {
         rusqlite::Error::FromSqlConversionFailure(
@@ -162,8 +163,17 @@ fn event_from_row(row: &Row<'_>) -> rusqlite::Result<Event> {
         )
     })?;
     let payload_str: String = row.get("payload")?;
-    let payload: serde_json::Value =
-        serde_json::from_str(&payload_str).unwrap_or(serde_json::Value::Object(Default::default()));
+    let payload: EventPayload = serde_json::from_str(&payload_str).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(
+            0,
+            rusqlite::types::Type::Text,
+            format!(
+                "failed to deserialize event payload at row {row_id}: {e}; \
+                 if upgrading from older schema, reset the ledger DB"
+            )
+            .into(),
+        )
+    })?;
     let task_id: Option<String> = row.get("task_id")?;
     Ok(Event {
         task_id: task_id.map(TaskId::from_raw),
@@ -180,16 +190,28 @@ impl SqliteTaskStore {
         kind: EventKind,
         epic: Option<&str>,
         task: Option<&TaskId>,
-        payload: &serde_json::Value,
+        payload: &EventPayload,
         at: DateTime<Utc>,
     ) -> rusqlite::Result<()> {
+        debug_assert_eq!(
+            kind,
+            payload.kind(),
+            "append_event_with: kind {kind:?} does not match payload variant {:?}",
+            payload.kind()
+        );
+        let payload_json = serde_json::to_string(payload).map_err(|e| {
+            rusqlite::Error::ToSqlConversionFailure(Box::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("failed to serialize event payload: {e}"),
+            )))
+        })?;
         conn.execute(
             "INSERT INTO events(epic_name, task_id, kind, payload, at) VALUES (?, ?, ?, ?, ?)",
             params![
                 epic,
                 task.map(|t| t.as_str().to_string()),
                 kind.as_str(),
-                payload.to_string(),
+                payload_json,
                 at,
             ],
         )?;
@@ -280,15 +302,13 @@ impl EpicRepo for SqliteTaskStore {
             EpicStatus::Completed => EventKind::EpicCompleted,
             EpicStatus::Abandoned => EventKind::EpicAbandoned,
         };
-        SqliteTaskStore::append_event_with(
-            &conn,
-            kind,
-            Some(name),
-            None,
-            &serde_json::json!({}),
-            at,
-        )
-        .map_err(backend)?;
+        let payload = match status {
+            EpicStatus::Active => EventPayload::EpicStarted,
+            EpicStatus::Completed => EventPayload::EpicCompleted,
+            EpicStatus::Abandoned => EventPayload::EpicAbandoned,
+        };
+        SqliteTaskStore::append_event_with(&conn, kind, Some(name), None, &payload, at)
+            .map_err(backend)?;
         Ok(())
     }
 
@@ -409,7 +429,7 @@ impl TaskRepo for SqliteTaskStore {
             EventKind::EpicStarted,
             Some(&plan.epic.name),
             None,
-            &serde_json::json!({}),
+            &EventPayload::EpicStarted,
             now,
         )
         .map_err(backend)?;
@@ -419,7 +439,10 @@ impl TaskRepo for SqliteTaskStore {
                 EventKind::TaskInserted,
                 Some(&plan.epic.name),
                 Some(&nt.id),
-                &serde_json::json!({"source": nt.source.as_str()}),
+                &EventPayload::TaskInserted {
+                    source: nt.source.as_str().to_string(),
+                    fingerprint: None,
+                },
                 now,
             )
             .map_err(backend)?;
@@ -515,7 +538,9 @@ impl TaskRepo for SqliteTaskStore {
                 EventKind::WatchDuplicate,
                 Some(&task.epic_name),
                 Some(&TaskId::from_raw(existing_id.clone())),
-                &serde_json::json!({"fingerprint": task.fingerprint}),
+                &EventPayload::WatchDuplicate {
+                    fingerprint: task.fingerprint.clone(),
+                },
                 now,
             )
             .map_err(backend)?;
@@ -548,7 +573,10 @@ impl TaskRepo for SqliteTaskStore {
             EventKind::TaskInserted,
             Some(&task.epic_name),
             Some(&task.id),
-            &serde_json::json!({"source": task.source.as_str(), "fingerprint": task.fingerprint}),
+            &EventPayload::TaskInserted {
+                source: task.source.as_str().to_string(),
+                fingerprint: Some(task.fingerprint.clone()),
+            },
             now,
         )
         .map_err(backend)?;
@@ -609,7 +637,9 @@ impl TaskRepo for SqliteTaskStore {
             EventKind::TaskClaimed,
             Some(epic),
             Some(&task.id),
-            &serde_json::json!({"attempts": task.attempts}),
+            &EventPayload::TaskClaimed {
+                attempts: task.attempts,
+            },
             now,
         )
         .map_err(backend)?;
@@ -675,7 +705,7 @@ impl TaskRepo for SqliteTaskStore {
             EventKind::TaskCompleted,
             Some(&epic_name),
             Some(id),
-            &serde_json::json!({"pr_number": pr_number}),
+            &EventPayload::TaskCompleted { pr_number },
             now,
         )
         .map_err(backend)?;
@@ -716,7 +746,7 @@ impl TaskRepo for SqliteTaskStore {
                 EventKind::TaskUnblocked,
                 Some(&epic_name),
                 Some(&TaskId::from_raw(nid.clone())),
-                &serde_json::json!({}),
+                &EventPayload::TaskUnblocked,
                 now,
             )
             .map_err(backend)?;
@@ -767,7 +797,10 @@ impl TaskRepo for SqliteTaskStore {
                 EventKind::TaskFailed,
                 Some(&epic_name),
                 Some(id),
-                &serde_json::json!({"final": true, "attempts": attempts}),
+                &EventPayload::TaskFailed {
+                    is_final: true,
+                    attempts,
+                },
                 now,
             )
             .map_err(backend)?;
@@ -776,7 +809,10 @@ impl TaskRepo for SqliteTaskStore {
                 EventKind::TaskEscalated,
                 Some(&epic_name),
                 Some(id),
-                &serde_json::json!({"attempts": attempts}),
+                &EventPayload::TaskEscalated {
+                    attempts: Some(attempts),
+                    issue: None,
+                },
                 now,
             )
             .map_err(backend)?;
@@ -808,7 +844,10 @@ impl TaskRepo for SqliteTaskStore {
                         EventKind::TaskBlocked,
                         Some(&epic_name),
                         Some(&TaskId::from_raw(dep_id.clone())),
-                        &serde_json::json!({"reason":"parent_escalated","parent": id.as_str()}),
+                        &EventPayload::TaskBlocked {
+                            reason: "parent_escalated".to_string(),
+                            parent: id.as_str().to_string(),
+                        },
                         now,
                     )
                     .map_err(backend)?;
@@ -828,7 +867,10 @@ impl TaskRepo for SqliteTaskStore {
                 EventKind::TaskFailed,
                 Some(&epic_name),
                 Some(id),
-                &serde_json::json!({"final": false, "attempts": attempts}),
+                &EventPayload::TaskFailed {
+                    is_final: false,
+                    attempts,
+                },
                 now,
             )
             .map_err(backend)?;
@@ -860,7 +902,10 @@ impl TaskRepo for SqliteTaskStore {
             EventKind::TaskEscalated,
             Some(&epic_name),
             Some(id),
-            &serde_json::json!({"issue": issue_number}),
+            &EventPayload::TaskEscalated {
+                attempts: None,
+                issue: Some(issue_number),
+            },
             now,
         )
         .map_err(backend)?;
@@ -957,7 +1002,7 @@ impl TaskRepo for SqliteTaskStore {
                 EventKind::TaskReleasedStale,
                 Some(&epic_name),
                 Some(&task_id),
-                &serde_json::json!({"prev_attempts": prev_attempts}),
+                &EventPayload::TaskReleasedStale { prev_attempts },
                 now,
             )
             .map_err(backend)?;
@@ -1011,11 +1056,11 @@ impl TaskRepo for SqliteTaskStore {
             EventKind::TaskForceStatus,
             Some(&epic_name),
             Some(id),
-            &serde_json::json!({
-                "from": prev.as_str(),
-                "to": target.as_str(),
-                "reason": reason,
-            }),
+            &EventPayload::TaskForceStatus {
+                from: prev.as_str().to_string(),
+                to: target.as_str().to_string(),
+                reason: reason.to_string(),
+            },
             now,
         )
         .map_err(backend)?;
@@ -1224,7 +1269,9 @@ impl TaskRepo for SqliteTaskStore {
                 EventKind::Reconciled,
                 Some(&plan.epic.name),
                 None,
-                &serde_json::json!({"orphan_branch": branch}),
+                &EventPayload::Reconciled(ReconciledPayload::OrphanBranch {
+                    orphan_branch: branch.clone(),
+                }),
                 now,
             )
             .map_err(backend)?;
@@ -1234,7 +1281,9 @@ impl TaskRepo for SqliteTaskStore {
             EventKind::Reconciled,
             Some(&plan.epic.name),
             None,
-            &serde_json::json!({"tasks": plan.tasks.len()}),
+            &EventPayload::Reconciled(ReconciledPayload::Summary {
+                tasks: plan.tasks.len() as u64,
+            }),
             now,
         )
         .map_err(backend)?;
@@ -1320,7 +1369,7 @@ impl EventLog for SqliteTaskStore {
     fn list_events(&self, filter: EventFilter) -> Result<Vec<Event>> {
         let conn = self.conn.lock().expect("poisoned");
         let mut sql =
-            String::from("SELECT epic_name, task_id, kind, payload, at FROM events WHERE 1=1");
+            String::from("SELECT id, epic_name, task_id, kind, payload, at FROM events WHERE 1=1");
         let mut binds: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
         if let Some(epic) = &filter.epic {
             sql.push_str(" AND epic_name=?");

--- a/plugins/github-autopilot/cli/tests/cli_e2e.rs
+++ b/plugins/github-autopilot/cli/tests/cli_e2e.rs
@@ -946,13 +946,14 @@ fn json_schema_task_list_stale() {
 
 #[test]
 fn json_schema_task_release_stale() {
-    // Lock: `task release-stale --json` -> JSON **array of task id
-    // strings**, NOT an array of Task objects. This is the one place the
-    // CLI emits a "thin" id list rather than full Task records, so we
-    // pin both shape and element type.
+    // Lock: `task release-stale --json` -> JSON **array of Task objects**,
+    // matching `task list-stale --json` so agents can use a single parser.
+    // Each element reflects the post-release state (status=ready, attempts
+    // decremented from the claim).
     let ws = Workspace::new();
     let task_id = "abc123def456";
-    seed_epic_with_task(&ws, "demo", task_id, "release-stale demo");
+    let title = "release-stale demo";
+    seed_epic_with_task(&ws, "demo", task_id, title);
     ws.cmd()
         .args(["task", "claim", "--epic", "demo"])
         .assert()
@@ -965,14 +966,19 @@ fn json_schema_task_release_stale() {
     );
     assert!(
         json.is_array(),
-        "release-stale --json must emit an array of ids"
+        "release-stale --json must emit an array of Task objects"
     );
-    let ids = json.as_array().unwrap();
-    assert_eq!(ids.len(), 1, "one task should be released");
-    let id = ids[0]
-        .as_str()
-        .expect("release-stale --json elements must be strings");
-    assert_eq!(id, task_id);
+    let tasks = json.as_array().unwrap();
+    assert_eq!(tasks.len(), 1, "one task should be released");
+    assert_task_shape(&tasks[0], task_id, "demo", title);
+    assert_eq!(
+        tasks[0]["status"], "ready",
+        "released task must be Ready (post-release state)"
+    );
+    assert_eq!(
+        tasks[0]["attempts"], 0,
+        "released task must have decremented attempts"
+    );
 }
 
 #[test]

--- a/plugins/github-autopilot/cli/tests/events_tests.rs
+++ b/plugins/github-autopilot/cli/tests/events_tests.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use autopilot::cmd::events::{EventsService, ListArgs};
-use autopilot::domain::{Event, EventKind, TaskId};
+use autopilot::domain::{Event, EventKind, EventPayload, TaskId};
 use autopilot::ports::task_store::TaskStore;
 use autopilot::store::InMemoryTaskStore;
 use chrono::{DateTime, TimeZone, Utc};
@@ -12,40 +12,78 @@ fn base_time() -> DateTime<Utc> {
     Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap()
 }
 
+type EventSeed<'a> = (
+    Option<&'a str>,
+    Option<&'a str>,
+    EventKind,
+    EventPayload,
+    i64,
+);
+
 fn fixture_with_events() -> Arc<dyn TaskStore> {
     let store: Arc<dyn TaskStore> = Arc::new(InMemoryTaskStore::new());
     let t0 = base_time();
-    // (epic, task, kind, +seconds)
-    let seeds: &[(Option<&str>, Option<&str>, EventKind, i64)] = &[
-        (Some("e1"), None, EventKind::EpicStarted, 0),
+    // (epic, task, kind, payload, +seconds)
+    let seeds: Vec<EventSeed> = vec![
+        (
+            Some("e1"),
+            None,
+            EventKind::EpicStarted,
+            EventPayload::EpicStarted,
+            0,
+        ),
         (
             Some("e1"),
             Some("aaaaaaaaaaaa"),
             EventKind::TaskInserted,
+            EventPayload::TaskInserted {
+                source: "spec".into(),
+                fingerprint: None,
+            },
             10,
         ),
-        (Some("e1"), Some("aaaaaaaaaaaa"), EventKind::TaskClaimed, 20),
+        (
+            Some("e1"),
+            Some("aaaaaaaaaaaa"),
+            EventKind::TaskClaimed,
+            EventPayload::TaskClaimed { attempts: 1 },
+            20,
+        ),
         (
             Some("e1"),
             Some("bbbbbbbbbbbb"),
             EventKind::TaskInserted,
+            EventPayload::TaskInserted {
+                source: "spec".into(),
+                fingerprint: None,
+            },
             30,
         ),
-        (Some("e2"), None, EventKind::EpicStarted, 40),
+        (
+            Some("e2"),
+            None,
+            EventKind::EpicStarted,
+            EventPayload::EpicStarted,
+            40,
+        ),
         (
             Some("e2"),
             Some("cccccccccccc"),
             EventKind::TaskInserted,
+            EventPayload::TaskInserted {
+                source: "spec".into(),
+                fingerprint: None,
+            },
             50,
         ),
     ];
-    for (epic, task, kind, sec) in seeds {
+    for (epic, task, kind, payload, sec) in seeds {
         let event = Event {
             task_id: task.map(TaskId::from_raw),
             epic_name: epic.map(|s| s.to_string()),
-            kind: *kind,
-            payload: serde_json::Value::Null,
-            at: t0 + chrono::Duration::seconds(*sec),
+            kind,
+            payload,
+            at: t0 + chrono::Duration::seconds(sec),
         };
         store.append_event(&event).unwrap();
     }

--- a/plugins/github-autopilot/cli/tests/store_conformance.rs
+++ b/plugins/github-autopilot/cli/tests/store_conformance.rs
@@ -260,9 +260,28 @@ fn body_release_stale_recovers_old_wip_tasks(store: Arc<dyn TaskStore>) {
     let recovered = store
         .release_stale(t0() + Duration::minutes(5), t0() + Duration::minutes(11))
         .unwrap();
-    let mut ids: Vec<String> = recovered.iter().map(|i| i.as_str().to_string()).collect();
+    // The returned Vec<Task> must reflect post-release state — Ready with
+    // attempts decremented — so callers can use a single parser shared with
+    // `list_stale` (Vec<Task>).
+    let mut ids: Vec<String> = recovered
+        .iter()
+        .map(|t| t.id.as_str().to_string())
+        .collect();
     ids.sort();
     assert_eq!(ids, vec!["A".to_string(), "B".to_string()]);
+    for t in &recovered {
+        assert_eq!(
+            t.status,
+            TaskStatus::Ready,
+            "released task must be Ready: {:?}",
+            t
+        );
+        assert_eq!(
+            t.attempts, 0,
+            "released task must have decremented attempts: {:?}",
+            t
+        );
+    }
 
     let by_id = |id: &str| store.get_task(&TaskId::from_raw(id)).unwrap().unwrap();
     assert_eq!(by_id("A").status, TaskStatus::Ready);

--- a/plugins/github-autopilot/cli/tests/store_conformance.rs
+++ b/plugins/github-autopilot/cli/tests/store_conformance.rs
@@ -793,8 +793,13 @@ fn body_force_status_records_event_with_reason(store: Arc<dyn TaskStore>) {
         })
         .unwrap();
     assert_eq!(evs.len(), 1);
-    assert_eq!(evs[0].payload["reason"], "rollback for repro");
-    assert_eq!(evs[0].payload["to"], "pending");
+    match &evs[0].payload {
+        autopilot::domain::EventPayload::TaskForceStatus { reason, to, .. } => {
+            assert_eq!(reason, "rollback for repro");
+            assert_eq!(to, "pending");
+        }
+        other => panic!("expected TaskForceStatus payload, got {other:?}"),
+    }
 }
 
 fn body_suppression_blocks_until_window_expires(store: Arc<dyn TaskStore>) {

--- a/plugins/github-autopilot/cli/tests/task_tests.rs
+++ b/plugins/github-autopilot/cli/tests/task_tests.rs
@@ -697,7 +697,10 @@ fn release_stale_with_no_stale_tasks_exits_0_and_reports_zero() {
 }
 
 #[test]
-fn release_stale_json_emits_array_of_recovered_ids() {
+fn release_stale_json_emits_array_of_recovered_tasks() {
+    // `release-stale --json` mirrors `list-stale --json` shape — both emit
+    // `[Task]` so agents can share a single parser. Each element reflects
+    // the post-release state (status=ready, attempts decremented).
     let (store, clock) = fixture();
     let svc = TaskService::new(store.as_ref(), &clock);
     seed_via_add(&svc, "aaaaaaaaaaaa", "0x1");
@@ -706,7 +709,12 @@ fn release_stale_json_emits_array_of_recovered_ids() {
     let (code, out) = capture(|w| svc.release_stale(3_600, true, w));
     assert_eq!(code, 0);
     let v: serde_json::Value = serde_json::from_str(out.trim()).unwrap();
-    assert_eq!(v, serde_json::json!(["aaaaaaaaaaaa"]));
+    let arr = v.as_array().expect("release-stale --json must be array");
+    assert_eq!(arr.len(), 1);
+    let t = &arr[0];
+    assert_eq!(t["id"], "aaaaaaaaaaaa");
+    assert_eq!(t["status"], "ready");
+    assert_eq!(t["attempts"], 0);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

cli-ux 시리즈에서 메모로만 남았던 follow-up 항목들을 한 epic 안에서 마무리합니다.

- **#741** `refactor(github-autopilot): unify release-stale json output to Task array`
  `release-stale --json` 의 출력 형태를 `[TaskId]` → `[Task]` 로 변경, `list-stale --json` 과 일관성 확보. release_stale 트레이트 시그니처도 `Vec<TaskId>` → `Vec<Task>`. (breaking, 외부 소비자 없음)
- **#742** `feat(github-autopilot): adopt log + env_logger for diagnostic output`
  `log` + `env_logger` crate 도입. 14곳의 `eprintln!` 중 진단 성격 (warn/error) 8곳을 `log::warn!` / `log::error!` 로 마이그레이션. 사용자 UX 출력 (worktree.rs 등 6곳) 은 그대로 유지. `RUST_LOG=debug` 같은 환경 변수로 verbosity 제어 가능.
- **#743** `refactor(github-autopilot): type Event.payload with EventPayload enum`
  `Event.payload` 를 untyped `serde_json::Value` 에서 `EventKind` 와 1:1 매핑된 `EventPayload` enum 으로 마이그레이션. emit / consume 시점에 컴파일러가 일관성 강제.

## Breaking 정책

- `release-stale --json` 출력 shape 변경 (외부 소비자 없음 — 내부 agent 호출만)
- `Event.payload` 직렬화 형태 변경 — 기존 `events` 테이블 row 와 호환 안 될 수 있음. 마이그레이션 SQL 미작성 — 사용자가 ledger DB reset 권장 (사용자 본인 DB 한정 사용).

## Acceptance

- [x] `cargo fmt --check` / `cargo clippy --tests -- -D warnings` / `cargo test` 전체 통과 (#741, #742, #743)
- [x] `release-stale --json` 출력이 list-stale 과 동일한 Task array
- [x] `RUST_LOG=info` 등 환경 변수로 진단 출력 제어
- [x] `EventPayload::kind()` ↔ `EventKind` 일관성 검증 단위 테스트

## 관련 이슈 / 메모

- PR #707 follow-up (release-stale shape, events.payload typing)
- #714 메모 (eprintln → tracing/log 도입)