### PR TITLE
feat(github-autopilot): add 'check stagnation' subcommand

### DIFF
--- a/plugins/github-autopilot/cli/src/cmd/check/mod.rs
+++ b/plugins/github-autopilot/cli/src/cmd/check/mod.rs
@@ -10,7 +10,6 @@ use crate::fs::FsOps;
 use crate::git::GitOps;
 
 use analysis::{AnalysisContext, DiffAnalysis};
-use stagnation::classify_pattern;
 use state::{
     append_output_entry, read_state, state_dir, state_file_path, validate_loop_name, write_state,
     OutputEntry, STATE_EXT,
@@ -21,7 +20,12 @@ pub const EXIT_NO_CHANGES: i32 = 0;
 pub const EXIT_SPEC_CHANGED: i32 = 1;
 pub const EXIT_CODE_CHANGED: i32 = 2;
 pub const EXIT_FIRST_RUN: i32 = 3;
-pub const EXIT_STAGNATION: i32 = 4;
+/// Stagnation detected (3 ≤ N < 5 similar ledger tasks). Re-exported from
+/// the `stagnation` module so existing call sites keep working after the
+/// ledger-native rewrite.
+pub const EXIT_STAGNATION: i32 = stagnation::EXIT_STAGNATION;
+/// Auto-escalate threshold reached (N ≥ 5 similar ledger tasks).
+pub const EXIT_ESCALATE: i32 = stagnation::EXIT_ESCALATE;
 
 #[derive(Serialize)]
 struct DiffResult {
@@ -227,9 +231,15 @@ impl CheckService {
     }
 
     /// Pipeline health report across all loops.
+    ///
+    /// Per the C10 ledger-stagnation redesign
+    /// (`plans/ledger-stagnation-redesign.md`), simhash-based pattern
+    /// classification has moved out of the loop-state pipeline and into
+    /// `autopilot check stagnation` (ledger-native). `health` is now a
+    /// pure overview: it reports the last seen HEAD and history length per
+    /// loop and always marks the pipeline as `healthy` — operators should
+    /// run `check stagnation --task <id>` for the per-task assessment.
     pub fn health(&self) -> Result<i32> {
-        use crate::cmd::simhash;
-
         let dir = state_dir(self.git.as_ref())?;
         let files = match self.fs.list_files(&dir, STATE_EXT) {
             Ok(f) => f,
@@ -245,7 +255,6 @@ impl CheckService {
         }
 
         let mut loops = Vec::new();
-        let mut any_stagnation = false;
 
         for file in &files {
             let name = file
@@ -254,41 +263,16 @@ impl CheckService {
                 .unwrap_or_default();
 
             if let Ok(loop_state) = read_state(self.fs.as_ref(), file) {
-                let history = &loop_state.output_history;
-                let pattern = if history.len() >= 2 {
-                    let latest = &history[history.len() - 1];
-                    simhash::parse_simhash(&latest.simhash).and_then(|latest_hash| {
-                        classify_pattern(
-                            history,
-                            latest_hash,
-                            stagnation::DEFAULT_SIMILARITY_THRESHOLD,
-                        )
-                    })
-                } else {
-                    None
-                };
-
-                if pattern.is_some() {
-                    any_stagnation = true;
-                }
-
                 loops.push(serde_json::json!({
                     "name": name,
                     "hash": &loop_state.hash[..7.min(loop_state.hash.len())],
                     "timestamp": loop_state.timestamp,
-                    "history_len": history.len(),
-                    "pattern_type": pattern,
-                    "recommended_persona": pattern.map(|p| p.recommended_persona()),
+                    "history_len": loop_state.output_history.len(),
                 }));
             }
         }
 
-        let overall = if any_stagnation {
-            "degraded"
-        } else {
-            "healthy"
-        };
-        let out = serde_json::json!({ "loops": loops, "overall": overall });
+        let out = serde_json::json!({ "loops": loops, "overall": "healthy" });
         println!("{out}");
         Ok(0)
     }

--- a/plugins/github-autopilot/cli/src/cmd/check/stagnation.rs
+++ b/plugins/github-autopilot/cli/src/cmd/check/stagnation.rs
@@ -1,501 +1,373 @@
-use anyhow::Result;
+//! Ledger-native stagnation detection (`autopilot check stagnation`).
+//!
+//! Per `plans/ledger-stagnation-redesign.md`, the GitHub-issue-body
+//! fingerprint flow is retired and stagnation is now grouped over ledger
+//! tasks via a hybrid (simhash hamming distance OR path Jaccard) similarity
+//! query. The CLI is a deterministic primitive: same input → same output,
+//! threshold decisions live in the calling Skill (CLAUDE.md "책임 경계").
+//!
+//! The service:
+//! 1. Fetches the current task by id.
+//! 2. Asks the [`TaskStore`] for similar tasks via
+//!    [`TaskRepo::list_similar_tasks`] (hybrid OR; set is the union).
+//! 3. Counts the candidates `N` and bands the result:
+//!    - `N < n_threshold` → `status="ok"`, exit 0.
+//!    - `n_threshold ≤ N < n_escalate` → `status="stagnation"`, exit 4.
+//!    - `N ≥ n_escalate` → `status="escalate"`, exit 5.
+//! 4. Emits the spec §3.10 JSON to `out` so hooks / Skills can read it
+//!    directly without touching SQLite.
+//!
+//! `recommended_persona` follows the same rotation as
+//! `cmd::issue::filter_comments` (`PERSONAS` array) so a human reading
+//! both surfaces sees a consistent "next persona" suggestion.
+
+use std::io::Write;
+
+use anyhow::{Context, Result};
 use serde::Serialize;
 
-use super::analysis::{AnalysisContext, AnalysisOutcome, DiffAnalysis};
-use super::EXIT_STAGNATION;
-use crate::cmd::check::state::OutputEntry;
-use crate::cmd::simhash;
+use crate::cmd::output::write_json;
+use crate::domain::event::{EventKind, EventPayload};
+use crate::domain::simhash::{hamming_distance, jaccard_similarity};
+use crate::domain::{Task, TaskId, TaskStatus};
+use crate::ports::task_store::{EventFilter, TaskStore};
 
-/// Default minimum number of history entries to attempt pattern detection.
-const DEFAULT_MIN_HISTORY_LEN: usize = 2;
+/// Exit code: `n_threshold ≤ N < n_escalate` similar tasks detected. Hook
+/// converts this into a redirect prompt without auto-escalating.
+pub const EXIT_STAGNATION: i32 = 4;
 
-/// Default hamming distance threshold: entries within this distance are considered "similar".
-pub const DEFAULT_SIMILARITY_THRESHOLD: u32 = 5;
+/// Exit code: `N ≥ n_escalate` similar tasks detected. Hook should call
+/// `autopilot task escalate` automatically.
+pub const EXIT_ESCALATE: i32 = 5;
 
-/// Default number of similar entries needed to flag stagnation.
-const DEFAULT_STAGNATION_COUNT: usize = 2;
+/// Persona rotation order. Mirrors `cmd::issue::PERSONAS` so the same
+/// `consecutive_failures → persona` mapping appears in both filter-comments
+/// and ledger stagnation outputs.
+pub const PERSONAS: &[&str] = &[
+    "hacker",
+    "researcher",
+    "simplifier",
+    "architect",
+    "contrarian",
+];
 
-/// Classified stagnation pattern types (priority order).
-#[derive(Serialize, Clone, Copy, Debug, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum PatternType {
-    /// Same hash repeating (distance ≤ 3 for all pairs)
-    Spinning,
-    /// A↔B alternating pattern (even/odd entries cluster separately)
-    Oscillation,
-    /// All entries similar but no improvement trend
-    NoDrift,
-    /// Distances gradually decreasing but still within threshold
-    DiminishingReturns,
+/// Configuration for [`StagnationService::check`]. Every field is required
+/// — the CLI surface fills defaults via clap (`max-distance=3`,
+/// `min-jaccard=0.5`, `n-threshold=3`, `n-escalate=5`).
+#[derive(Debug, Clone, Copy)]
+pub struct StagnationConfig {
+    /// Hamming distance upper bound (inclusive) for the simhash dimension.
+    /// Spec §3.4 default `T = 3`.
+    pub max_distance: u32,
+    /// Jaccard ratio lower bound (inclusive) for the path-set dimension.
+    /// Spec §3.4 default `J = 0.5`.
+    pub min_jaccard: f64,
+    /// `N`: candidate count that flips status from `ok` to `stagnation`.
+    /// Default 3.
+    pub n_threshold: u32,
+    /// `N_esc`: candidate count that flips status to `escalate`. Default 5.
+    /// Must satisfy `n_escalate >= n_threshold`; not asserted because clap
+    /// already accepts both as user input — invalid combinations are
+    /// surfaced to the operator via the band logic (escalate dominates).
+    pub n_escalate: u32,
 }
 
-impl PatternType {
-    /// Deterministic persona recommendation per pattern.
-    pub fn recommended_persona(self) -> &'static str {
-        match self {
-            PatternType::Spinning => "hacker",
-            PatternType::Oscillation => "architect",
-            PatternType::NoDrift => "researcher",
-            PatternType::DiminishingReturns => "simplifier",
-        }
-    }
-}
-
-/// Detects stagnation patterns by comparing simhash history in LoopState.
-///
-/// If recent output hashes show repeated similar patterns, overrides
-/// the exit code to EXIT_STAGNATION and includes candidate details.
-///
-/// Thresholds are configurable for tuning with real gap report data (#578).
-pub struct StagnationAnalysis {
-    pub similarity_threshold: u32,
-    pub stagnation_count: usize,
-    pub min_history_len: usize,
-}
-
-impl Default for StagnationAnalysis {
+impl Default for StagnationConfig {
     fn default() -> Self {
         Self {
-            similarity_threshold: DEFAULT_SIMILARITY_THRESHOLD,
-            stagnation_count: DEFAULT_STAGNATION_COUNT,
-            min_history_len: DEFAULT_MIN_HISTORY_LEN,
+            max_distance: 3,
+            min_jaccard: 0.5,
+            n_threshold: 3,
+            n_escalate: 5,
         }
     }
 }
 
-/// Classify the stagnation pattern from a history of simhashes.
-/// Returns None if no stagnation pattern is detected.
-///
-/// Priority: Spinning > Oscillation > NoDrift > DiminishingReturns
-pub fn classify_pattern(
-    history: &[OutputEntry],
-    latest_hash: u64,
-    threshold: u32,
-) -> Option<PatternType> {
-    let distances: Vec<u32> = history[..history.len() - 1]
-        .iter()
-        .filter_map(|e| simhash::parse_simhash(&e.simhash))
-        .map(|h| simhash::hamming_distance(latest_hash, h))
-        .collect();
-
-    if distances.is_empty() {
-        return None;
-    }
-
-    // Spinning: all distances very small (≤ 3)
-    let spinning_threshold = 3.min(threshold);
-    if distances.len() >= 2 && distances.iter().all(|&d| d <= spinning_threshold) {
-        return Some(PatternType::Spinning);
-    }
-
-    // Oscillation: parse full hash sequence, check even/odd clustering
-    if distances.len() >= 3 {
-        let hashes: Vec<u64> = history
-            .iter()
-            .filter_map(|e| simhash::parse_simhash(&e.simhash))
-            .collect();
-        if hashes.len() >= 4 {
-            let even_similar = (0..hashes.len() - 2)
-                .filter(|&i| simhash::hamming_distance(hashes[i], hashes[i + 2]) <= threshold)
-                .count();
-            let odd_different = (0..hashes.len() - 1)
-                .filter(|&i| simhash::hamming_distance(hashes[i], hashes[i + 1]) > threshold)
-                .count();
-            // At least 2 even-skip matches and most adjacent pairs are different
-            if even_similar >= 2 && odd_different >= hashes.len() / 2 {
-                return Some(PatternType::Oscillation);
-            }
-        }
-    }
-
-    // NoDrift: all within threshold, no clear improvement trend
-    if distances.len() >= 2 && distances.iter().all(|&d| d <= threshold) {
-        // Check if NOT diminishing (no clear downward trend)
-        let is_diminishing = distances.windows(2).all(|w| w[1] <= w[0]);
-        if !is_diminishing || distances.first() == distances.last() {
-            return Some(PatternType::NoDrift);
-        }
-    }
-
-    // DiminishingReturns: distances are decreasing and all within threshold
-    if distances.len() >= 2 && distances.iter().all(|&d| d <= threshold) {
-        let is_diminishing = distances.windows(2).all(|w| w[1] <= w[0]);
-        if is_diminishing && distances.first() != distances.last() {
-            return Some(PatternType::DiminishingReturns);
-        }
-    }
-
-    None
+/// Stagnation status banding. Drives both the CLI exit code and the JSON
+/// `status` field.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum StagnationStatus {
+    Ok,
+    Stagnation,
+    Escalate,
 }
 
-fn no_stagnation() -> AnalysisOutcome {
-    AnalysisOutcome {
-        exit_override: None,
-        extra_fields: serde_json::json!({}),
+impl StagnationStatus {
+    pub fn exit_code(self) -> i32 {
+        match self {
+            StagnationStatus::Ok => 0,
+            StagnationStatus::Stagnation => EXIT_STAGNATION,
+            StagnationStatus::Escalate => EXIT_ESCALATE,
+        }
     }
 }
 
-impl DiffAnalysis for StagnationAnalysis {
-    fn analyze(&self, ctx: &AnalysisContext) -> Result<AnalysisOutcome> {
-        let history = &ctx.state.output_history;
+/// Outcome label for a single similar task. Mirrors spec §3.10
+/// (`failed | completed | wip | ...`). Derived from the live `TaskStatus`,
+/// not from event history — the events log is consulted only to extract
+/// `failure_reason`.
+fn outcome_label(status: TaskStatus) -> &'static str {
+    match status {
+        TaskStatus::Done => "completed",
+        TaskStatus::Escalated => "failed",
+        TaskStatus::Wip => "wip",
+        TaskStatus::Ready => "ready",
+        TaskStatus::Pending => "pending",
+        TaskStatus::Blocked => "blocked",
+    }
+}
 
-        if history.len() < self.min_history_len {
-            return Ok(no_stagnation());
-        }
+/// Reads the most recent `TaskFailed` event payload for a task and returns
+/// a short human-readable reason string. The current `EventPayload::TaskFailed`
+/// only carries `is_final` and `attempts` — there is no free-form `reason`
+/// field today, so we synthesize one. Callers should treat `None` as
+/// "task hasn't failed yet".
+fn derive_failure_reason(store: &dyn TaskStore, task_id: &TaskId) -> Option<String> {
+    let events = store
+        .list_events(EventFilter {
+            task: Some(task_id.clone()),
+            kinds: vec![EventKind::TaskFailed],
+            ..Default::default()
+        })
+        .ok()?;
+    let last = events.last()?;
+    if let EventPayload::TaskFailed { is_final, attempts } = &last.payload {
+        let phase = if *is_final { "final" } else { "retry" };
+        Some(format!("{phase} after {attempts} attempts"))
+    } else {
+        None
+    }
+}
 
-        let latest = &history[history.len() - 1];
-        let latest_hash = match simhash::parse_simhash(&latest.simhash) {
-            Some(h) => h,
-            None => return Ok(no_stagnation()),
+/// Service that orchestrates ledger-based stagnation detection. Holds only
+/// references — the caller decides the lifetime of the store. Mirrors the
+/// shape of [`crate::cmd::task::TaskService`] so wiring in `main.rs` is
+/// uniform.
+pub struct StagnationService<'a> {
+    store: &'a dyn TaskStore,
+}
+
+impl<'a> StagnationService<'a> {
+    pub fn new(store: &'a dyn TaskStore) -> Self {
+        Self { store }
+    }
+
+    /// Runs the full check pipeline for `task_id` and writes the spec §3.10
+    /// JSON to `out`. Returns the exit code (0 / 4 / 5) for `main.rs` to
+    /// propagate to the OS.
+    ///
+    /// Errors:
+    /// - `task_id` not found → wraps a `TaskStoreError::NotFound` for the
+    ///   `main.rs` mapper, which exits 2 by default.
+    /// - missing `simhash` and `affected_paths` on the current task → still
+    ///   runs the query (treated as `simhash = 0`, `paths = []`); typically
+    ///   yields zero candidates → `status="ok"` exit 0.
+    pub fn check(
+        &self,
+        task_id: &TaskId,
+        config: &StagnationConfig,
+        out: &mut dyn Write,
+    ) -> Result<i32> {
+        let current = self
+            .store
+            .get_task(task_id)
+            .with_context(|| format!("loading task '{task_id}'"))?
+            .ok_or_else(|| anyhow::anyhow!("task '{task_id}' not found"))?;
+
+        let cur_simhash = current.simhash.unwrap_or(0);
+        let cur_paths: Vec<String> = current.affected_paths.clone().unwrap_or_default();
+
+        let similar = self
+            .store
+            .list_similar_tasks(
+                &current.id,
+                cur_simhash,
+                config.max_distance,
+                &cur_paths,
+                config.min_jaccard,
+            )
+            .with_context(|| format!("listing similar tasks for '{task_id}'"))?;
+
+        let n = similar.len() as u32;
+        let status = if n >= config.n_escalate {
+            StagnationStatus::Escalate
+        } else if n >= config.n_threshold {
+            StagnationStatus::Stagnation
+        } else {
+            StagnationStatus::Ok
         };
 
-        let mut candidates = Vec::new();
-        for entry in &history[..history.len() - 1] {
-            if let Some(h) = simhash::parse_simhash(&entry.simhash) {
-                let distance = simhash::hamming_distance(latest_hash, h);
-                candidates.push(serde_json::json!({
-                    "simhash": simhash::format_simhash(h),
-                    "distance": distance,
-                    "category": entry.category,
-                    "timestamp": entry.timestamp,
-                }));
-            }
+        let report = build_report(self.store, &current, &similar, status);
+        write_json(out, &report)?;
+        Ok(status.exit_code())
+    }
+}
+
+// ── JSON report shaping ────────────────────────────────────────────────
+
+#[derive(Debug, Serialize)]
+struct CurrentTaskJson {
+    id: String,
+    simhash: Option<String>,
+    affected_paths: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct SimilarityJson {
+    simhash_distance: Option<u32>,
+    jaccard: f64,
+    shared_paths: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct SimilarTaskJson {
+    id: String,
+    title: String,
+    similarity: SimilarityJson,
+    outcome: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    failure_reason: Option<String>,
+    completed_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug, Serialize)]
+struct PatternJson {
+    shared_paths: Vec<String>,
+    common_failure_categories: Vec<String>,
+    consecutive_failures: u32,
+}
+
+#[derive(Debug, Serialize)]
+struct StagnationReport {
+    status: StagnationStatus,
+    current_task: CurrentTaskJson,
+    similar_tasks: Vec<SimilarTaskJson>,
+    pattern: PatternJson,
+    recommended_persona: Option<&'static str>,
+}
+
+fn build_report(
+    store: &dyn TaskStore,
+    current: &Task,
+    similar: &[Task],
+    status: StagnationStatus,
+) -> StagnationReport {
+    let cur_paths_owned: Vec<String> = current.affected_paths.clone().unwrap_or_default();
+
+    let mut similar_json: Vec<SimilarTaskJson> = Vec::with_capacity(similar.len());
+    let mut failures_among_similar: u32 = 0;
+    for t in similar {
+        let simhash_distance = match (current.simhash, t.simhash) {
+            (Some(a), Some(b)) => Some(hamming_distance(a, b)),
+            _ => None,
+        };
+        let other_paths = t.affected_paths.clone().unwrap_or_default();
+        let jaccard = jaccard_similarity(&cur_paths_owned, &other_paths);
+        let shared_paths: Vec<String> = match &t.affected_paths {
+            Some(p) => p
+                .iter()
+                .filter(|x| cur_paths_owned.iter().any(|c| c == *x))
+                .cloned()
+                .collect(),
+            None => Vec::new(),
+        };
+        if matches!(t.status, TaskStatus::Escalated) {
+            failures_among_similar += 1;
         }
+        let failure_reason = derive_failure_reason(store, &t.id);
+        similar_json.push(SimilarTaskJson {
+            id: t.id.as_str().to_string(),
+            title: t.title.clone(),
+            similarity: SimilarityJson {
+                simhash_distance,
+                jaccard,
+                shared_paths,
+            },
+            outcome: outcome_label(t.status),
+            failure_reason,
+            completed_at: t.updated_at,
+        });
+    }
 
-        candidates.sort_by_key(|c| c["distance"].as_u64().unwrap_or(64));
-
-        let similar_count = candidates
+    // Pattern.shared_paths = paths present in EVERY similar task AND in
+    // the current task. Determined intersectionally; degrades gracefully
+    // when no candidate has a path set (in which case `all` over an empty
+    // iter is vacuously true — guard explicitly).
+    let any_candidate_has_paths = similar
+        .iter()
+        .any(|t| t.affected_paths.as_ref().is_some_and(|p| !p.is_empty()));
+    let pattern_shared: Vec<String> = if !cur_paths_owned.is_empty() && any_candidate_has_paths {
+        cur_paths_owned
             .iter()
-            .filter(|c| c["distance"].as_u64().unwrap_or(64) <= self.similarity_threshold as u64)
-            .count();
-
-        if similar_count >= self.stagnation_count {
-            let pattern = classify_pattern(history, latest_hash, self.similarity_threshold);
-            let persona = pattern.map(|p| p.recommended_persona());
-
-            Ok(AnalysisOutcome {
-                exit_override: Some(EXIT_STAGNATION),
-                extra_fields: serde_json::json!({
-                    "stagnation": {
-                        "detected": true,
-                        "pattern_type": pattern,
-                        "recommended_persona": persona,
-                        "current_simhash": simhash::format_simhash(latest_hash),
-                        "similar_count": similar_count,
-                        "candidates": candidates,
-                    }
-                }),
+            .filter(|p| {
+                similar
+                    .iter()
+                    .filter_map(|t| t.affected_paths.as_ref())
+                    .all(|sp| sp.iter().any(|s| s == *p))
             })
-        } else {
-            Ok(no_stagnation())
+            .cloned()
+            .collect()
+    } else {
+        Vec::new()
+    };
+
+    // The persona table is keyed by `consecutive` per `cmd::issue.rs:553`:
+    // 2 → PERSONAS[0], 3 → PERSONAS[1], capped at the last entry. We use
+    // the count of similar tasks (which already excludes the current one)
+    // plus 1 for the current attempt, mirroring the "consecutive failures
+    // including this one" semantic.
+    let _ = failures_among_similar; // reserved for future
+    let recommended_persona = match status {
+        StagnationStatus::Ok => None,
+        _ => {
+            let consecutive = (similar.len() as u32 + 1).max(2);
+            let idx = (consecutive as usize - 2).min(PERSONAS.len() - 1);
+            Some(PERSONAS[idx])
         }
+    };
+
+    StagnationReport {
+        status,
+        current_task: CurrentTaskJson {
+            id: current.id.as_str().to_string(),
+            simhash: current.simhash.map(|h| format!("0x{h:016x}")),
+            affected_paths: cur_paths_owned,
+        },
+        similar_tasks: similar_json,
+        pattern: PatternJson {
+            shared_paths: pattern_shared,
+            common_failure_categories: Vec::new(),
+            consecutive_failures: similar.len() as u32,
+        },
+        recommended_persona,
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cmd::check::state::{LoopState, OutputCategory, OutputEntry};
 
-    fn make_ctx(history: Vec<OutputEntry>) -> (Vec<String>, LoopState) {
-        let state = LoopState {
-            hash: "abc1234".to_string(),
-            timestamp: "2026-01-01T00:00:00Z".to_string(),
-            output_history: history,
-            ..Default::default()
-        };
-        (vec!["src/lib.rs".to_string()], state)
+    #[test]
+    fn outcome_label_maps_terminal_states() {
+        assert_eq!(outcome_label(TaskStatus::Done), "completed");
+        assert_eq!(outcome_label(TaskStatus::Escalated), "failed");
+        assert_eq!(outcome_label(TaskStatus::Wip), "wip");
     }
 
     #[test]
-    fn no_stagnation_with_empty_history() {
-        let (files, state) = make_ctx(vec![]);
-        let ctx = AnalysisContext {
-            loop_name: "gap-watch",
-            changed_files: &files,
-            spec_files: &[],
-            code_files: &files,
-            state: &state,
-        };
-        let result = StagnationAnalysis::default().analyze(&ctx).unwrap();
-        assert!(result.exit_override.is_none());
+    fn config_defaults_match_spec() {
+        let c = StagnationConfig::default();
+        assert_eq!(c.max_distance, 3);
+        assert!((c.min_jaccard - 0.5).abs() < 1e-9);
+        assert_eq!(c.n_threshold, 3);
+        assert_eq!(c.n_escalate, 5);
     }
 
     #[test]
-    fn no_stagnation_with_different_hashes() {
-        let (files, state) = make_ctx(vec![
-            OutputEntry {
-                simhash: "0x0000000000000001".to_string(),
-                category: OutputCategory::GapAnalysis,
-                timestamp: "2026-01-01T00:00:00Z".to_string(),
-            },
-            OutputEntry {
-                simhash: "0xFFFFFFFFFFFFFFFF".to_string(),
-                category: OutputCategory::GapAnalysis,
-                timestamp: "2026-01-02T00:00:00Z".to_string(),
-            },
-        ]);
-        let ctx = AnalysisContext {
-            loop_name: "gap-watch",
-            changed_files: &files,
-            spec_files: &[],
-            code_files: &files,
-            state: &state,
-        };
-        let result = StagnationAnalysis::default().analyze(&ctx).unwrap();
-        assert!(result.exit_override.is_none());
-    }
-
-    #[test]
-    fn detects_stagnation_with_similar_hashes() {
-        let base: u64 = 0xA3F2B81C4D5E6F1B;
-        let similar = base ^ 0x01; // 1 bit different
-        let (files, state) = make_ctx(vec![
-            OutputEntry {
-                simhash: simhash::format_simhash(base),
-                category: OutputCategory::GapAnalysis,
-                timestamp: "2026-01-01T00:00:00Z".to_string(),
-            },
-            OutputEntry {
-                simhash: simhash::format_simhash(similar),
-                category: OutputCategory::GapAnalysis,
-                timestamp: "2026-01-02T00:00:00Z".to_string(),
-            },
-            OutputEntry {
-                simhash: simhash::format_simhash(base),
-                category: OutputCategory::GapAnalysis,
-                timestamp: "2026-01-03T00:00:00Z".to_string(),
-            },
-        ]);
-        let ctx = AnalysisContext {
-            loop_name: "gap-watch",
-            changed_files: &files,
-            spec_files: &[],
-            code_files: &files,
-            state: &state,
-        };
-        let result = StagnationAnalysis::default().analyze(&ctx).unwrap();
-        assert_eq!(result.exit_override, Some(EXIT_STAGNATION));
-        assert!(result.extra_fields["stagnation"]["detected"]
-            .as_bool()
-            .unwrap());
-    }
-
-    #[test]
-    fn stricter_threshold_detects_more() {
-        let base: u64 = 0xA3F2B81C4D5E6F1B;
-        let slightly_different = base ^ 0x07; // 3 bits different
-        let (files, state) = make_ctx(vec![
-            OutputEntry {
-                simhash: simhash::format_simhash(base),
-                category: OutputCategory::GapAnalysis,
-                timestamp: "2026-01-01T00:00:00Z".to_string(),
-            },
-            OutputEntry {
-                simhash: simhash::format_simhash(slightly_different),
-                category: OutputCategory::GapAnalysis,
-                timestamp: "2026-01-02T00:00:00Z".to_string(),
-            },
-            OutputEntry {
-                simhash: simhash::format_simhash(base),
-                category: OutputCategory::GapAnalysis,
-                timestamp: "2026-01-03T00:00:00Z".to_string(),
-            },
-        ]);
-        let ctx = AnalysisContext {
-            loop_name: "gap-watch",
-            changed_files: &files,
-            spec_files: &[],
-            code_files: &files,
-            state: &state,
-        };
-
-        // Default threshold=5 detects (3 bits < 5)
-        let result = StagnationAnalysis::default().analyze(&ctx).unwrap();
-        assert_eq!(result.exit_override, Some(EXIT_STAGNATION));
-
-        // Tight threshold=2 does NOT detect (3 bits > 2)
-        let tight = StagnationAnalysis {
-            similarity_threshold: 2,
-            ..Default::default()
-        };
-        let result = tight.analyze(&ctx).unwrap();
-        assert!(result.exit_override.is_none());
-    }
-
-    #[test]
-    fn higher_stagnation_count_requires_more_matches() {
-        let base: u64 = 0xA3F2B81C4D5E6F1B;
-        let (files, state) = make_ctx(vec![
-            OutputEntry {
-                simhash: simhash::format_simhash(base),
-                category: OutputCategory::GapAnalysis,
-                timestamp: "2026-01-01T00:00:00Z".to_string(),
-            },
-            OutputEntry {
-                simhash: simhash::format_simhash(base ^ 0x01),
-                category: OutputCategory::GapAnalysis,
-                timestamp: "2026-01-02T00:00:00Z".to_string(),
-            },
-            OutputEntry {
-                simhash: simhash::format_simhash(base),
-                category: OutputCategory::GapAnalysis,
-                timestamp: "2026-01-03T00:00:00Z".to_string(),
-            },
-        ]);
-        let ctx = AnalysisContext {
-            loop_name: "gap-watch",
-            changed_files: &files,
-            spec_files: &[],
-            code_files: &files,
-            state: &state,
-        };
-
-        // Default count=2 detects (2 similar entries)
-        let result = StagnationAnalysis::default().analyze(&ctx).unwrap();
-        assert_eq!(result.exit_override, Some(EXIT_STAGNATION));
-
-        // Require count=5 → not enough matches
-        let high_count = StagnationAnalysis {
-            stagnation_count: 5,
-            ..Default::default()
-        };
-        let result = high_count.analyze(&ctx).unwrap();
-        assert!(result.exit_override.is_none());
-    }
-
-    #[test]
-    fn min_history_len_gates_detection() {
-        let base: u64 = 0xA3F2B81C4D5E6F1B;
-        // 3 entries: latest compares against 2 previous, both similar → stagnation
-        let (files, state) = make_ctx(vec![
-            OutputEntry {
-                simhash: simhash::format_simhash(base),
-                category: OutputCategory::GapAnalysis,
-                timestamp: "2026-01-01T00:00:00Z".to_string(),
-            },
-            OutputEntry {
-                simhash: simhash::format_simhash(base ^ 0x01),
-                category: OutputCategory::GapAnalysis,
-                timestamp: "2026-01-02T00:00:00Z".to_string(),
-            },
-            OutputEntry {
-                simhash: simhash::format_simhash(base),
-                category: OutputCategory::GapAnalysis,
-                timestamp: "2026-01-03T00:00:00Z".to_string(),
-            },
-        ]);
-        let ctx = AnalysisContext {
-            loop_name: "gap-watch",
-            changed_files: &files,
-            spec_files: &[],
-            code_files: &files,
-            state: &state,
-        };
-
-        // Default min_history=2, 3 entries → detection proceeds
-        let result = StagnationAnalysis::default().analyze(&ctx).unwrap();
-        assert_eq!(result.exit_override, Some(EXIT_STAGNATION));
-
-        // Require min_history=5 → not enough history, skips detection
-        let high_min = StagnationAnalysis {
-            min_history_len: 5,
-            ..Default::default()
-        };
-        let result = high_min.analyze(&ctx).unwrap();
-        assert!(result.exit_override.is_none());
-    }
-
-    fn entry(hash: u64) -> OutputEntry {
-        OutputEntry {
-            simhash: simhash::format_simhash(hash),
-            category: OutputCategory::GapAnalysis,
-            timestamp: "2026-01-01T00:00:00Z".to_string(),
-        }
-    }
-
-    #[test]
-    fn classifies_spinning_pattern() {
-        let base: u64 = 0xA3F2B81C4D5E6F1B;
-        let history = vec![
-            entry(base),
-            entry(base ^ 0x01),
-            entry(base),
-            entry(base ^ 0x01),
-        ];
-        let pattern = classify_pattern(&history, base ^ 0x01, 5);
-        assert_eq!(pattern, Some(PatternType::Spinning));
-        assert_eq!(PatternType::Spinning.recommended_persona(), "hacker");
-    }
-
-    #[test]
-    fn classifies_oscillation_pattern() {
-        let a: u64 = 0xA3F2B81C4D5E6F1B;
-        let b: u64 = 0x1234567890ABCDEF; // very different from a
-                                         // A, B, A, B → even indices similar, odd pairs different
-        let history = vec![entry(a), entry(b), entry(a), entry(b)];
-        let pattern = classify_pattern(&history, b, 5);
-        assert_eq!(pattern, Some(PatternType::Oscillation));
-        assert_eq!(PatternType::Oscillation.recommended_persona(), "architect");
-    }
-
-    #[test]
-    fn classifies_no_drift_pattern() {
-        let base: u64 = 0xA3F2B81C4D5E6F1B;
-        // All within threshold but not spinning (distance > 3 but ≤ 5)
-        let history = vec![
-            entry(base ^ 0x0F), // 4 bits from latest
-            entry(base ^ 0x17), // ~4 bits from latest
-            entry(base ^ 0x0F), // 4 bits from latest
-            entry(base),        // latest
-        ];
-        let pattern = classify_pattern(&history, base, 5);
-        assert_eq!(pattern, Some(PatternType::NoDrift));
-        assert_eq!(PatternType::NoDrift.recommended_persona(), "researcher");
-    }
-
-    #[test]
-    fn classifies_diminishing_returns() {
-        let base: u64 = 0xA3F2B81C4D5E6F1B;
-        // Distances decreasing: 5, 3, 1
-        let history = vec![
-            entry(base ^ 0x1F), // 5 bits
-            entry(base ^ 0x07), // 3 bits
-            entry(base ^ 0x01), // 1 bit
-            entry(base),        // latest
-        ];
-        let pattern = classify_pattern(&history, base, 5);
-        assert_eq!(pattern, Some(PatternType::DiminishingReturns));
-        assert_eq!(
-            PatternType::DiminishingReturns.recommended_persona(),
-            "simplifier"
-        );
-    }
-
-    #[test]
-    fn no_pattern_when_insufficient_history() {
-        let base: u64 = 0xA3F2B81C4D5E6F1B;
-        let history = vec![entry(base)];
-        let pattern = classify_pattern(&history, base, 5);
-        assert_eq!(pattern, None);
-    }
-
-    #[test]
-    fn stagnation_output_includes_pattern_and_persona() {
-        let base: u64 = 0xA3F2B81C4D5E6F1B;
-        let (files, state) = make_ctx(vec![entry(base), entry(base ^ 0x01), entry(base)]);
-        let ctx = AnalysisContext {
-            loop_name: "gap-watch",
-            changed_files: &files,
-            spec_files: &[],
-            code_files: &files,
-            state: &state,
-        };
-        let result = StagnationAnalysis::default().analyze(&ctx).unwrap();
-        assert_eq!(result.exit_override, Some(EXIT_STAGNATION));
-
-        let stag = &result.extra_fields["stagnation"];
-        assert!(stag["pattern_type"].is_string());
-        assert!(stag["recommended_persona"].is_string());
+    fn status_exit_codes() {
+        assert_eq!(StagnationStatus::Ok.exit_code(), 0);
+        assert_eq!(StagnationStatus::Stagnation.exit_code(), 4);
+        assert_eq!(StagnationStatus::Escalate.exit_code(), 5);
     }
 }

--- a/plugins/github-autopilot/cli/src/cmd/mod.rs
+++ b/plugins/github-autopilot/cli/src/cmd/mod.rs
@@ -278,6 +278,36 @@ pub enum CheckCommands {
         /// Loop name to reset. If omitted, resets all loops.
         loop_name: Option<String>,
     },
+    /// Detect ledger-based stagnation for a single task and emit the
+    /// hybrid (simhash distance OR path Jaccard) similarity report.
+    ///
+    /// Exit codes:
+    ///   0 — ok (no stagnation pattern)
+    ///   4 — stagnation detected (n_threshold ≤ N < n_escalate)
+    ///   5 — escalate required (N ≥ n_escalate)
+    Stagnation(CheckStagnationArgs),
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct CheckStagnationArgs {
+    /// Task id whose stagnation status is being assessed.
+    #[arg(long)]
+    pub task: String,
+    /// Max simhash hamming distance (inclusive). Spec §3.4 default `T = 3`.
+    #[arg(long, default_value_t = 3)]
+    pub max_distance: u32,
+    /// Min Jaccard similarity for the affected-paths dimension (inclusive).
+    /// Spec §3.4 default `J = 0.5`.
+    #[arg(long, default_value_t = 0.5)]
+    pub min_jaccard: f64,
+    /// `N`: similar-task count that flips status from `ok` to `stagnation`.
+    /// Spec §3.4 default 3.
+    #[arg(long, default_value_t = 3)]
+    pub n_threshold: u32,
+    /// `N_esc`: similar-task count that flips status to `escalate`. Spec
+    /// §3.4 default 5.
+    #[arg(long, default_value_t = 5)]
+    pub n_escalate: u32,
 }
 
 #[derive(Args)]

--- a/plugins/github-autopilot/cli/src/main.rs
+++ b/plugins/github-autopilot/cli/src/main.rs
@@ -88,30 +88,52 @@ fn main() {
         }
         Commands::Check { command } => {
             use cmd::check::spec_code::SpecCodeAnalysis;
-            use cmd::check::stagnation::StagnationAnalysis;
+            use cmd::check::stagnation::{StagnationConfig, StagnationService};
             use cmd::check::CheckService;
+            use cmd::CheckStagnationArgs;
 
-            let svc = CheckService::new(
-                git::real(),
-                fs::real(),
-                vec![
-                    Box::new(SpecCodeAnalysis),
-                    Box::new(StagnationAnalysis::default()),
-                ],
-            );
             match command {
-                CheckCommands::Diff {
-                    loop_name,
-                    spec_paths,
-                } => svc.diff(&loop_name, &spec_paths),
-                CheckCommands::Mark {
-                    loop_name,
-                    output_hash,
-                    status,
-                } => svc.mark(&loop_name, output_hash.as_deref(), status.as_ref()),
-                CheckCommands::Status => svc.status(),
-                CheckCommands::Health => svc.health(),
-                CheckCommands::Reset { loop_name } => svc.reset(loop_name.as_deref()),
+                CheckCommands::Stagnation(CheckStagnationArgs {
+                    task,
+                    max_distance,
+                    min_jaccard,
+                    n_threshold,
+                    n_escalate,
+                }) => {
+                    let store = open_store(&config);
+                    let svc = StagnationService::new(&store);
+                    let task_id = autopilot::domain::TaskId::from_raw(task);
+                    let cfg = StagnationConfig {
+                        max_distance,
+                        min_jaccard,
+                        n_threshold,
+                        n_escalate,
+                    };
+                    let mut out = stdout();
+                    svc.check(&task_id, &cfg, &mut out)
+                }
+                other => {
+                    let svc = CheckService::new(
+                        git::real(),
+                        fs::real(),
+                        vec![Box::new(SpecCodeAnalysis)],
+                    );
+                    match other {
+                        CheckCommands::Diff {
+                            loop_name,
+                            spec_paths,
+                        } => svc.diff(&loop_name, &spec_paths),
+                        CheckCommands::Mark {
+                            loop_name,
+                            output_hash,
+                            status,
+                        } => svc.mark(&loop_name, output_hash.as_deref(), status.as_ref()),
+                        CheckCommands::Status => svc.status(),
+                        CheckCommands::Health => svc.health(),
+                        CheckCommands::Reset { loop_name } => svc.reset(loop_name.as_deref()),
+                        CheckCommands::Stagnation(_) => unreachable!("handled above"),
+                    }
+                }
             }
         }
         Commands::Watch(args) => {

--- a/plugins/github-autopilot/cli/src/ports/task_store.rs
+++ b/plugins/github-autopilot/cli/src/ports/task_store.rs
@@ -199,6 +199,29 @@ pub trait TaskRepo: Send + Sync {
     fn apply_reconciliation(&self, plan: ReconciliationPlan, now: DateTime<Utc>) -> Result<()>;
 
     fn list_deps(&self, task_id: &TaskId) -> Result<Vec<TaskId>>;
+
+    /// Returns tasks whose simhash signature is within `max_distance` hamming
+    /// bits of `simhash` **OR** whose `affected_paths` Jaccard similarity
+    /// with `paths` is at least `min_jaccard`. The candidate set is the
+    /// union of both dimensions per `plans/ledger-stagnation-redesign.md`
+    /// §3.3 (hybrid OR).
+    ///
+    /// `exclude` is the task being inspected — it must not appear in the
+    /// returned list (a task is not similar to itself for the purpose of
+    /// stagnation grouping). Tasks whose `simhash` is `None` and whose
+    /// `affected_paths` is `None` (rows that pre-date the V3 schema) are
+    /// silently skipped because neither dimension can match.
+    ///
+    /// Order is implementation-defined; callers should not rely on it.
+    /// Implementations should keep this method side-effect free.
+    fn list_similar_tasks(
+        &self,
+        exclude: &TaskId,
+        simhash: u64,
+        max_distance: u32,
+        paths: &[String],
+        min_jaccard: f64,
+    ) -> Result<Vec<Task>>;
 }
 
 pub trait EventLog: Send + Sync {

--- a/plugins/github-autopilot/cli/src/store/memory.rs
+++ b/plugins/github-autopilot/cli/src/store/memory.rs
@@ -850,6 +850,42 @@ impl TaskRepo for InMemoryTaskStore {
         let s = self.state.lock().expect("poisoned");
         Ok(InMemoryTaskStore::deps_of(&s, task_id))
     }
+
+    fn list_similar_tasks(
+        &self,
+        exclude: &TaskId,
+        simhash: u64,
+        max_distance: u32,
+        paths: &[String],
+        min_jaccard: f64,
+    ) -> Result<Vec<Task>> {
+        use crate::domain::simhash::{hamming_distance, jaccard_similarity};
+        let s = self.state.lock().expect("poisoned");
+        let mut out: Vec<Task> = s
+            .tasks
+            .values()
+            .filter(|t| &t.id != exclude)
+            .filter(|t| {
+                let simhash_match = t
+                    .simhash
+                    .map(|h| hamming_distance(h, simhash) <= max_distance)
+                    .unwrap_or(false);
+                let jaccard_match = match &t.affected_paths {
+                    Some(p) => jaccard_similarity(p, paths) >= min_jaccard,
+                    None => false,
+                };
+                simhash_match || jaccard_match
+            })
+            .cloned()
+            .collect();
+        // Stable order so JSON output is deterministic — tests rely on it.
+        out.sort_by(|a, b| {
+            a.created_at
+                .cmp(&b.created_at)
+                .then_with(|| a.id.as_str().cmp(b.id.as_str()))
+        });
+        Ok(out)
+    }
 }
 
 fn remote_to_status(r: &crate::ports::task_store::RemoteTaskState, s: &State) -> TaskStatus {

--- a/plugins/github-autopilot/cli/src/store/sqlite.rs
+++ b/plugins/github-autopilot/cli/src/store/sqlite.rs
@@ -1345,6 +1345,53 @@ impl TaskRepo for SqliteTaskStore {
             .map_err(backend)?;
         Ok(rows)
     }
+
+    fn list_similar_tasks(
+        &self,
+        exclude: &TaskId,
+        simhash: u64,
+        max_distance: u32,
+        paths: &[String],
+        min_jaccard: f64,
+    ) -> Result<Vec<Task>> {
+        use crate::domain::simhash::{hamming_distance, jaccard_similarity};
+        let conn = self.conn.lock().expect("poisoned");
+        // Pull every task that has at least one similarity dimension
+        // populated (rows pre-V3 are skipped by the WHERE clause). Filter
+        // distance / Jaccard in-process — set sizes are small and the
+        // domain primitives keep the rule in one place.
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, epic_name, source, fingerprint, title, body, status, attempts,
+                        branch, pr_number, escalated_issue, simhash, affected_paths,
+                        created_at, updated_at
+                   FROM tasks
+                  WHERE id != ?
+                    AND (simhash IS NOT NULL OR affected_paths IS NOT NULL)
+                  ORDER BY created_at, id",
+            )
+            .map_err(backend)?;
+        let candidates = stmt
+            .query_map(params![exclude.as_str()], task_from_row)
+            .map_err(backend)?
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(backend)?;
+        let out = candidates
+            .into_iter()
+            .filter(|t: &Task| {
+                let simhash_match = t
+                    .simhash
+                    .map(|h| hamming_distance(h, simhash) <= max_distance)
+                    .unwrap_or(false);
+                let jaccard_match = match &t.affected_paths {
+                    Some(p) => jaccard_similarity(p, paths) >= min_jaccard,
+                    None => false,
+                };
+                simhash_match || jaccard_match
+            })
+            .collect();
+        Ok(out)
+    }
 }
 
 impl SuppressionRepo for SqliteTaskStore {

--- a/plugins/github-autopilot/cli/tests/check_stagnation_tests.rs
+++ b/plugins/github-autopilot/cli/tests/check_stagnation_tests.rs
@@ -1,0 +1,336 @@
+//! E2E scenario tests for `autopilot check stagnation`.
+//!
+//! Each scenario:
+//! 1. Seeds an in-memory store with one or more tasks (simhash + paths
+//!    crafted to land on a specific stagnation band).
+//! 2. Calls [`StagnationService::check`] for the "current" task id.
+//! 3. Parses the JSON written to a buffer and asserts on `status`,
+//!    `similar_tasks` count, exit code, and `recommended_persona`.
+//!
+//! Per `.claude/rules/rust-cli.md`, the tests stay on the public API
+//! (service constructor + JSON output) so internal refactors don't break
+//! them. `InMemoryTaskStore` provides scenario isolation; the same
+//! conformance suite verifies sqlite parity.
+
+use std::sync::Arc;
+
+use autopilot::cmd::check::stagnation::{StagnationConfig, StagnationService};
+use autopilot::domain::{TaskId, TaskSource};
+use autopilot::ports::task_store::{NewWatchTask, TaskStore};
+use autopilot::store::InMemoryTaskStore;
+use chrono::{DateTime, TimeZone, Utc};
+use serde_json::Value;
+
+const EPIC: &str = "epic-a";
+
+fn t0() -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 5, 1, 12, 0, 0).unwrap()
+}
+
+fn seed_task(
+    store: &dyn TaskStore,
+    id: &str,
+    title: &str,
+    simhash: Option<u64>,
+    paths: Option<Vec<String>>,
+    fingerprint: &str,
+    at: DateTime<Utc>,
+) {
+    let nt = NewWatchTask {
+        id: TaskId::from_raw(id),
+        epic_name: EPIC.to_string(),
+        source: TaskSource::Human,
+        fingerprint: fingerprint.to_string(),
+        title: title.to_string(),
+        body: None,
+        simhash,
+        affected_paths: paths,
+    };
+    store.upsert_watch_task(nt, at).expect("seed task");
+}
+
+fn run_check(store: Arc<dyn TaskStore>, task_id: &str, config: StagnationConfig) -> (i32, Value) {
+    let svc = StagnationService::new(store.as_ref());
+    let mut buf: Vec<u8> = Vec::new();
+    let exit = svc
+        .check(&TaskId::from_raw(task_id), &config, &mut buf)
+        .expect("service check");
+    let json: Value = serde_json::from_slice(&buf).expect("valid JSON output");
+    (exit, json)
+}
+
+fn default_cfg() -> StagnationConfig {
+    StagnationConfig::default()
+}
+
+// ── Scenario 1: no candidates → status=ok, exit 0 ─────────────────────
+
+#[test]
+fn no_candidates_returns_ok() {
+    let store: Arc<dyn TaskStore> = Arc::new(InMemoryTaskStore::new());
+    seed_task(
+        store.as_ref(),
+        "aaaaaaaaaaa1",
+        "introduce middleware",
+        Some(0xDEAD_BEEF_DEAD_BEEF),
+        Some(vec!["src/middleware.rs".into()]),
+        "fp:current",
+        t0(),
+    );
+
+    let (exit, json) = run_check(store, "aaaaaaaaaaa1", default_cfg());
+    assert_eq!(exit, 0, "exit code should be 0 (ok)");
+    assert_eq!(json["status"], "ok");
+    assert_eq!(json["similar_tasks"].as_array().unwrap().len(), 0);
+    assert!(json["recommended_persona"].is_null());
+}
+
+// ── Scenario 2: simhash-only path → status=stagnation, exit 4 ─────────
+
+#[test]
+fn simhash_distance_only_triggers_stagnation() {
+    let store: Arc<dyn TaskStore> = Arc::new(InMemoryTaskStore::new());
+    let base: u64 = 0xA3F2_B81C_4D5E_6F1B;
+    // Three previously-attempted tasks within hamming distance ≤ 3.
+    seed_task(
+        store.as_ref(),
+        "bbbbbbbbbbb1",
+        "prior 1",
+        Some(base ^ 0x01),
+        None, // No paths — only simhash dimension matches.
+        "fp:b1",
+        t0(),
+    );
+    seed_task(
+        store.as_ref(),
+        "bbbbbbbbbbb2",
+        "prior 2",
+        Some(base ^ 0x03),
+        None,
+        "fp:b2",
+        t0(),
+    );
+    seed_task(
+        store.as_ref(),
+        "bbbbbbbbbbb3",
+        "prior 3",
+        Some(base ^ 0x07), // 3 bits flipped → distance 3, still within T=3
+        None,
+        "fp:b3",
+        t0(),
+    );
+    // Current task — same simhash → distance 0/1/2/3 to each prior.
+    seed_task(
+        store.as_ref(),
+        "ccccccccccc1",
+        "current attempt",
+        Some(base),
+        Some(vec!["totally/unrelated.rs".into()]),
+        "fp:cur",
+        t0(),
+    );
+
+    let (exit, json) = run_check(store, "ccccccccccc1", default_cfg());
+    assert_eq!(exit, 4, "exit code should be 4 (stagnation)");
+    assert_eq!(json["status"], "stagnation");
+    assert_eq!(json["similar_tasks"].as_array().unwrap().len(), 3);
+    let simhash = json["current_task"]["simhash"].as_str().unwrap();
+    assert!(
+        simhash.starts_with("0x"),
+        "current_task.simhash hex-formatted: {simhash}"
+    );
+}
+
+// ── Scenario 3: jaccard-only path → status=stagnation, exit 4 ─────────
+
+#[test]
+fn jaccard_only_triggers_stagnation() {
+    let store: Arc<dyn TaskStore> = Arc::new(InMemoryTaskStore::new());
+    let shared: Vec<String> = vec![
+        "src/cmd/task.rs".into(),
+        "src/store/sqlite.rs".into(),
+        "src/ports/task_store.rs".into(),
+    ];
+    // Three tasks share two of three paths → Jaccard ≥ 0.5.
+    let two_of_three = vec![
+        "src/cmd/task.rs".into(),
+        "src/store/sqlite.rs".into(),
+        "tests/extra.rs".into(),
+    ];
+    for (i, id) in ["ddddddddddd1", "ddddddddddd2", "ddddddddddd3"]
+        .iter()
+        .enumerate()
+    {
+        seed_task(
+            store.as_ref(),
+            id,
+            &format!("prior {i}"),
+            // Different simhash → simhash dimension does NOT match.
+            Some(0xFFFF_FFFF_FFFF_FFFF ^ (i as u64)),
+            Some(two_of_three.clone()),
+            &format!("fp:d{i}"),
+            t0(),
+        );
+    }
+    seed_task(
+        store.as_ref(),
+        "eeeeeeeeeee1",
+        "current attempt",
+        Some(0x0000_0000_0000_0000),
+        Some(shared),
+        "fp:cur-e",
+        t0(),
+    );
+
+    let (exit, json) = run_check(store, "eeeeeeeeeee1", default_cfg());
+    assert_eq!(exit, 4, "exit code should be 4 (stagnation)");
+    assert_eq!(json["status"], "stagnation");
+    assert_eq!(json["similar_tasks"].as_array().unwrap().len(), 3);
+    // Pattern.shared_paths surfaces the intersection (2 paths).
+    let shared_paths = json["pattern"]["shared_paths"].as_array().unwrap();
+    assert_eq!(
+        shared_paths.len(),
+        2,
+        "pattern.shared_paths should list the 2 always-present files, got {shared_paths:?}"
+    );
+}
+
+// ── Scenario 4: dedup — both dimensions match same task, counted once ─
+
+#[test]
+fn dedup_when_both_dimensions_match_same_task() {
+    let store: Arc<dyn TaskStore> = Arc::new(InMemoryTaskStore::new());
+    let base: u64 = 0xCAFE_F00D_BABE_5678;
+    let paths: Vec<String> = vec!["src/a.rs".into(), "src/b.rs".into()];
+
+    // Two prior tasks: each matches BOTH dimensions (close simhash AND
+    // overlapping paths). The set must still be 2, not 4.
+    seed_task(
+        store.as_ref(),
+        "fffffffffff1",
+        "prior 1",
+        Some(base ^ 0x01),
+        Some(paths.clone()),
+        "fp:f1",
+        t0(),
+    );
+    seed_task(
+        store.as_ref(),
+        "fffffffffff2",
+        "prior 2",
+        Some(base ^ 0x02),
+        Some(paths.clone()),
+        "fp:f2",
+        t0(),
+    );
+    seed_task(
+        store.as_ref(),
+        "aaaaaaaaa999",
+        "current",
+        Some(base),
+        Some(paths),
+        "fp:cur-dedup",
+        t0(),
+    );
+
+    // Lower n_threshold so 2 is enough to flag stagnation.
+    let cfg = StagnationConfig {
+        n_threshold: 2,
+        ..default_cfg()
+    };
+    let (exit, json) = run_check(store, "aaaaaaaaa999", cfg);
+    assert_eq!(exit, 4);
+    assert_eq!(
+        json["similar_tasks"].as_array().unwrap().len(),
+        2,
+        "task matching both simhash AND paths must be counted once, got {}",
+        json["similar_tasks"]
+    );
+}
+
+// ── Scenario 5: N ≥ n_escalate → status=escalate, exit 5 ──────────────
+
+#[test]
+fn meets_escalate_threshold() {
+    let store: Arc<dyn TaskStore> = Arc::new(InMemoryTaskStore::new());
+    let base: u64 = 0x1111_2222_3333_4444;
+    // 5 similar tasks (default n_escalate = 5).
+    for i in 0..5u64 {
+        seed_task(
+            store.as_ref(),
+            &format!("aaaaaaaaaa{i:02}"),
+            &format!("prior {i}"),
+            Some(base ^ (i & 0x7)),
+            None,
+            &format!("fp:esc-{i}"),
+            t0(),
+        );
+    }
+    seed_task(
+        store.as_ref(),
+        "bbbbbbbbbb99",
+        "current attempt",
+        Some(base),
+        None,
+        "fp:cur-esc",
+        t0(),
+    );
+
+    let (exit, json) = run_check(store, "bbbbbbbbbb99", default_cfg());
+    assert_eq!(exit, 5, "exit code should be 5 (escalate)");
+    assert_eq!(json["status"], "escalate");
+    let count = json["similar_tasks"].as_array().unwrap().len();
+    assert!(
+        count >= 5,
+        "expected ≥5 similar tasks for escalate band, got {count}"
+    );
+}
+
+// ── Scenario 6: persona rotation tracks consecutive_failures ──────────
+
+#[test]
+fn recommended_persona_advances_with_consecutive_failures() {
+    // n=3 → consecutive=4 → idx=2 → "simplifier"
+    // n=5 → consecutive=6 → idx=4 → "contrarian"
+    // (n+1 mirrors `cmd::issue::filter_comments` "this attempt + priors".)
+    let store: Arc<dyn TaskStore> = Arc::new(InMemoryTaskStore::new());
+    let base: u64 = 0xDEAD_BEEF_C0FE_E000;
+    for i in 0..5u64 {
+        seed_task(
+            store.as_ref(),
+            &format!("ccccccccc{i:03}"),
+            &format!("prior {i}"),
+            Some(base ^ (i & 0x3)),
+            None,
+            &format!("fp:p{i}"),
+            t0(),
+        );
+    }
+    seed_task(
+        store.as_ref(),
+        "ddddddddd999",
+        "current attempt",
+        Some(base),
+        None,
+        "fp:cur-p",
+        t0(),
+    );
+
+    // First, run with default thresholds to confirm `escalate` band picks
+    // a late-stage persona (idx ≥ 2).
+    let (_exit, json) = run_check(store.clone(), "ddddddddd999", default_cfg());
+    let persona = json["recommended_persona"].as_str().unwrap();
+    assert!(
+        [
+            "hacker",
+            "researcher",
+            "simplifier",
+            "architect",
+            "contrarian"
+        ]
+        .contains(&persona),
+        "persona should be from the rotation table, got {persona}"
+    );
+    // With 5 priors, consecutive = 6, idx = 4 → "contrarian".
+    assert_eq!(persona, "contrarian", "5 priors should map to PERSONAS[4]");
+}


### PR DESCRIPTION
## Summary

Wires ledger-native stagnation detection per `plans/ledger-stagnation-redesign.md` §3.4/§3.5/§3.9/§3.10. The CLI now exposes `autopilot check stagnation --task <id>` as a deterministic primitive that the upcoming `protect-stagnation.sh` PreToolUse hook (I3) calls before each `task claim`.

- New `TaskRepo::list_similar_tasks` (hybrid OR: simhash hamming distance ≤ T **or** affected-paths Jaccard ≥ J). Implemented in both `InMemoryTaskStore` and `SqliteTaskStore` so the conformance suite stays LSP-sound.
- `StagnationService` emits the §3.10 JSON to stdout and returns 0 / 4 / 5 based on N vs `n_threshold` / `n_escalate`.
- `cmd/check/stagnation.rs` rewritten — old `StagnationAnalysis` (loop-state simhash classifier) is retired since the corresponding flow was already deactivated per `commands/gap-watch.md:233`. `check health` becomes a pure overview (no pattern classification).
- `recommended_persona` follows the same rotation table as `cmd/issue.rs:553` (`hacker → researcher → simplifier → architect → contrarian`), keyed by `consecutive_failures = N+1` capped at the last entry.

## Exit codes

| Code | Status                | Trigger                                  |
|------|-----------------------|------------------------------------------|
| 0    | `ok`                  | `N < n_threshold`                        |
| 4    | `stagnation`          | `n_threshold ≤ N < n_escalate` (default 3 ≤ N < 5) |
| 5    | `escalate`            | `N ≥ n_escalate` (default ≥ 5)           |

`exit_code_for` (validation / runtime) keeps its 1/2/3 semantics.

## Test plan

`cargo fmt --check`, `cargo clippy --tests -- -D warnings`, and `cargo test` all green. New `tests/check_stagnation_tests.rs` covers six black-box scenarios:

- [x] no candidates → `status=ok`, exit 0, `recommended_persona=null`
- [x] simhash distance only (paths absent) → `status=stagnation`, exit 4
- [x] paths Jaccard only (simhash mismatched) → `status=stagnation`, exit 4 + `pattern.shared_paths` populated
- [x] task matching both dimensions → counted **once** (dedup)
- [x] N ≥ `n_escalate` → `status=escalate`, exit 5
- [x] persona rotation tracks `consecutive_failures` (5 priors → `contrarian`)

## Out of scope (deferred)

- Hook script `protect-stagnation.sh` and `commands/setup.md` registration — I3.
- `task add --simhash-input` / `--paths` wiring — handled separately.
- Skill `resilience/SKILL.md` rewrite for ledger input shape — I4 (already merged in #746).

🤖 Generated with [Claude Code](https://claude.com/claude-code)