### PR TITLE
feat(github-autopilot): wire --simhash-input/--paths into task add

### DIFF
--- a/plugins/github-autopilot/cli/src/cmd/mod.rs
+++ b/plugins/github-autopilot/cli/src/cmd/mod.rs
@@ -149,13 +149,35 @@ pub enum TaskCommands {
         /// Origin tag (defaults to `human`)
         #[arg(long, default_value = "human")]
         source: task::TaskSourceArg,
+        /// Override simhash input text. When omitted, derived from
+        /// `title + "\n" + body` and fed into the domain `derive_simhash`
+        /// transform. Used by ledger-based stagnation detection (C10).
+        #[arg(long)]
+        simhash_input: Option<String>,
+        /// Comma-separated affected file paths (top N by line count, descending).
+        /// Stored as JSON-encoded list for the path-set side of hybrid
+        /// stagnation similarity. Empty list (the default) leaves the
+        /// `affected_paths` column NULL.
+        #[arg(long, value_delimiter = ',')]
+        paths: Vec<String>,
     },
-    /// Insert tasks from a JSONL batch file
+    /// Insert tasks from a JSONL batch file. Each line accepts the
+    /// following schema (all fields except `id` and `title` are optional):
+    ///
+    /// ```json
+    /// {"id":"...","title":"...","body":"...","fingerprint":"...",
+    ///  "simhash_input":"...","paths":["p1","p2"],"source":"..."}
+    /// ```
+    ///
+    /// `simhash_input` / `paths` mirror the `task add --simhash-input` /
+    /// `--paths` flags: when present they override the derived defaults,
+    /// when absent the simhash is derived from `title + "\n" + body` and
+    /// `affected_paths` stays NULL.
     AddBatch {
         /// Epic name
         #[arg(long)]
         epic: String,
-        /// JSONL file. Each line: {"id":"...","title":"...","body?":"...","fingerprint?":"...","source?":"..."}
+        /// JSONL file. See command help for the full per-line schema.
         #[arg(long)]
         from: std::path::PathBuf,
     },

--- a/plugins/github-autopilot/cli/src/cmd/task.rs
+++ b/plugins/github-autopilot/cli/src/cmd/task.rs
@@ -166,6 +166,12 @@ impl<'a> TaskService<'a> {
     /// Auto-derives a fingerprint from `title + body` when `fingerprint` is
     /// `None`, so callers don't need to mirror the simhash recipe.
     ///
+    /// `simhash_input` overrides the text fed into `domain::simhash::derive_simhash`
+    /// (default: `title + "\n" + body`) so callers can pin the stagnation
+    /// signature to a stable canonical form. `paths` is the affected-paths list
+    /// for the path-set side of hybrid stagnation similarity — empty leaves
+    /// the column NULL.
+    ///
     /// Validates `task_id` via [`TaskId::parse`] before any store mutation
     /// so a typoed id is rejected as a `UserInputError` (exit code 1) rather
     /// than silently inserting a row whose id will never match the
@@ -181,6 +187,8 @@ impl<'a> TaskService<'a> {
         body: Option<&str>,
         fingerprint: Option<&str>,
         source: TaskSourceArg,
+        simhash_input: Option<&str>,
+        paths: &[String],
         out: &mut dyn Write,
     ) -> Result<i32> {
         let id = TaskId::parse(task_id)
@@ -189,6 +197,12 @@ impl<'a> TaskService<'a> {
         let fp = fingerprint
             .map(str::to_string)
             .unwrap_or_else(|| derive_fingerprint(title, body));
+        let simhash_value = derive_task_simhash(simhash_input, title, body);
+        let affected_paths = if paths.is_empty() {
+            None
+        } else {
+            Some(paths.to_vec())
+        };
         let nt = NewWatchTask {
             id,
             epic_name: epic.to_string(),
@@ -196,8 +210,8 @@ impl<'a> TaskService<'a> {
             fingerprint: fp,
             title: title.to_string(),
             body: body.map(str::to_string),
-            simhash: None,
-            affected_paths: None,
+            simhash: Some(simhash_value),
+            affected_paths,
         };
         match self.store.upsert_watch_task(nt, now) {
             Ok(UpsertOutcome::Inserted(id)) => {
@@ -254,6 +268,11 @@ impl<'a> TaskService<'a> {
             let fp = parsed
                 .fingerprint
                 .unwrap_or_else(|| derive_fingerprint(&title, body.as_deref()));
+            let simhash_value =
+                derive_task_simhash(parsed.simhash_input.as_deref(), &title, body.as_deref());
+            let affected_paths = parsed
+                .paths
+                .and_then(|p| if p.is_empty() { None } else { Some(p) });
             let nt = NewWatchTask {
                 id,
                 epic_name: epic.to_string(),
@@ -261,8 +280,8 @@ impl<'a> TaskService<'a> {
                 fingerprint: fp,
                 title,
                 body,
-                simhash: None,
-                affected_paths: None,
+                simhash: Some(simhash_value),
+                affected_paths,
             };
             match self
                 .store
@@ -473,6 +492,15 @@ struct BatchLine {
     fingerprint: Option<String>,
     #[serde(default)]
     source: Option<String>,
+    /// Optional override text for the simhash signature (mirrors
+    /// `task add --simhash-input`). Falls back to `title + "\n" + body`
+    /// when omitted.
+    #[serde(default)]
+    simhash_input: Option<String>,
+    /// Optional affected-paths list for ledger-based stagnation similarity
+    /// (mirrors `task add --paths`). Empty/missing leaves the column NULL.
+    #[serde(default)]
+    paths: Option<Vec<String>>,
     // Unknown fields (e.g. section/requirement on watch payloads) are silently
     // accepted by serde, keeping the JSONL contract forward-compatible.
 }
@@ -581,6 +609,25 @@ fn derive_fingerprint(title: &str, body: Option<&str>) -> String {
     simhash::format_simhash(simhash::weighted_simhash(&simhash::tokenize_weighted(
         &composite,
     )))
+}
+
+/// Resolve the simhash signature for a watch-style task.
+///
+/// Priority order matches the CLI contract for `task add` /
+/// `task add-batch`:
+/// 1. If `simhash_input` is `Some`, hash that text verbatim — caller has
+///    pinned the canonical form.
+/// 2. Otherwise hash `title + "\n" + body`, mirroring [`derive_fingerprint`].
+///
+/// Always returns a value (never `None`) so the ledger column is filled
+/// for every newly-inserted watch task; pre-V3 NULL rows continue to bypass
+/// stagnation comparison via the store-side filter.
+fn derive_task_simhash(simhash_input: Option<&str>, title: &str, body: Option<&str>) -> u64 {
+    use crate::domain::simhash::derive_simhash;
+    match simhash_input {
+        Some(text) => derive_simhash(text),
+        None => derive_simhash(&format!("{title}\n{}", body.unwrap_or(""))),
+    }
 }
 
 fn print_task_human(t: &Task, out: &mut dyn Write) -> Result<()> {

--- a/plugins/github-autopilot/cli/src/main.rs
+++ b/plugins/github-autopilot/cli/src/main.rs
@@ -210,6 +210,8 @@ fn main() {
                     body,
                     fingerprint,
                     source,
+                    simhash_input,
+                    paths,
                 } => svc.add(
                     &epic,
                     &task_id,
@@ -217,6 +219,8 @@ fn main() {
                     body.as_deref(),
                     fingerprint.as_deref(),
                     source,
+                    simhash_input.as_deref(),
+                    &paths,
                     &mut out,
                 ),
                 TaskCommands::AddBatch { epic, from } => svc.add_batch(&epic, &from, &mut out),

--- a/plugins/github-autopilot/cli/tests/task_tests.rs
+++ b/plugins/github-autopilot/cli/tests/task_tests.rs
@@ -70,6 +70,8 @@ fn seed_via_add(svc: &TaskService<'_>, id: &str, fingerprint: &str) {
         None,
         Some(fingerprint),
         TaskSourceArg::Human,
+        None,
+        &[],
         &mut buf,
     )
     .expect("seed_via_add");
@@ -145,6 +147,8 @@ fn add_with_explicit_fingerprint_persists_task_and_emits_event() {
             Some("body"),
             Some("0xDEADBEEF"),
             TaskSourceArg::Human,
+            None,
+            &[],
             w,
         )
     });
@@ -185,6 +189,8 @@ fn add_auto_derives_fingerprint_from_title_and_body() {
             Some("add interceptor for throttling"),
             None,
             TaskSourceArg::Human,
+            None,
+            &[],
             w,
         )
     });
@@ -213,6 +219,8 @@ fn add_detects_duplicate_fingerprint_and_returns_same_id() {
             None,
             Some("0xDEADBEEF"),
             TaskSourceArg::Human,
+            None,
+            &[],
             w,
         )
     });
@@ -224,6 +232,8 @@ fn add_detects_duplicate_fingerprint_and_returns_same_id() {
             None,
             Some("0xDEADBEEF"),
             TaskSourceArg::Human,
+            None,
+            &[],
             w,
         )
     });
@@ -266,6 +276,8 @@ fn add_rejects_invalid_task_id_before_store_mutation() {
             None,
             Some("0xDEADBEEF"),
             TaskSourceArg::Human,
+            None,
+            &[],
             &mut buf,
         )
         .unwrap_err();
@@ -283,6 +295,8 @@ fn add_rejects_invalid_task_id_before_store_mutation() {
             None,
             Some("0xDEADBEEF"),
             TaskSourceArg::Human,
+            None,
+            &[],
             &mut buf,
         )
         .unwrap_err();
@@ -291,6 +305,135 @@ fn add_rejects_invalid_task_id_before_store_mutation() {
 
     // Store stayed clean across both rejections.
     assert!(store.list_tasks_by_epic("e", None).unwrap().is_empty());
+}
+
+#[test]
+fn add_default_derives_nonzero_simhash_and_leaves_paths_null() {
+    // C10-I1b lock: when neither `--simhash-input` nor `--paths` is
+    // supplied, `task add` derives the simhash from `title + "\n" + body`
+    // (so stagnation detection has a stable signature for every newly-
+    // inserted watch task) and leaves `affected_paths` NULL.
+    let (store, clock) = fixture();
+    let svc = TaskService::new(store.as_ref(), &clock);
+    capture(|w| {
+        svc.add(
+            "e",
+            "aaaaaaaaaaaa",
+            "rate limiter middleware",
+            Some("interceptor for throttling"),
+            None,
+            TaskSourceArg::Human,
+            None,
+            &[],
+            w,
+        )
+    });
+    let task = store
+        .get_task(&TaskId::from_raw("aaaaaaaaaaaa"))
+        .unwrap()
+        .unwrap();
+    assert!(
+        task.simhash.is_some(),
+        "default simhash should be derived, got {:?}",
+        task.simhash
+    );
+    assert_ne!(
+        task.simhash.unwrap(),
+        0,
+        "non-trivial title/body must hash to non-zero simhash"
+    );
+    assert!(
+        task.affected_paths.is_none(),
+        "no --paths => affected_paths NULL, got {:?}",
+        task.affected_paths
+    );
+}
+
+#[test]
+fn add_with_explicit_simhash_input_and_paths_persists_them() {
+    // C10-I1b lock: explicit `--simhash-input <text>` overrides the
+    // derived signature (caller pinned the canonical form), and
+    // `--paths a.rs,b.rs` lands as the affected-paths list verbatim.
+    use autopilot::domain::simhash::derive_simhash;
+    let (store, clock) = fixture();
+    let svc = TaskService::new(store.as_ref(), &clock);
+    let custom = "canonical stagnation signature payload";
+    let paths: Vec<String> = vec!["src/a.rs".into(), "src/b.rs".into()];
+    capture(|w| {
+        svc.add(
+            "e",
+            "aaaaaaaaaaaa",
+            "title that would otherwise drive simhash",
+            Some("body that would otherwise drive simhash"),
+            None,
+            TaskSourceArg::Human,
+            Some(custom),
+            &paths,
+            w,
+        )
+    });
+    let task = store
+        .get_task(&TaskId::from_raw("aaaaaaaaaaaa"))
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        task.simhash,
+        Some(derive_simhash(custom)),
+        "explicit --simhash-input must win over derived default"
+    );
+    assert_eq!(task.affected_paths.as_deref(), Some(paths.as_slice()));
+}
+
+#[test]
+fn add_simhash_is_deterministic_for_same_title_body() {
+    // C10-I1b lock: `derive_simhash(title\nbody)` is a pure function, so
+    // two distinct task ids with identical title+body+no override must
+    // share the simhash signature. Stagnation detection relies on this
+    // deterministic property.
+    let (store, clock) = fixture();
+    let svc = TaskService::new(store.as_ref(), &clock);
+    capture(|w| {
+        svc.add(
+            "e",
+            "aaaaaaaaaaaa",
+            "rate limiter",
+            Some("identical body"),
+            // Distinct fingerprints prevent the second insert from being
+            // treated as a duplicate of the first; we want both rows to
+            // land so we can compare their simhash values.
+            Some("0xAAAA"),
+            TaskSourceArg::Human,
+            None,
+            &[],
+            w,
+        )
+    });
+    capture(|w| {
+        svc.add(
+            "e",
+            "bbbbbbbbbbbb",
+            "rate limiter",
+            Some("identical body"),
+            Some("0xBBBB"),
+            TaskSourceArg::Human,
+            None,
+            &[],
+            w,
+        )
+    });
+    let a = store
+        .get_task(&TaskId::from_raw("aaaaaaaaaaaa"))
+        .unwrap()
+        .unwrap();
+    let b = store
+        .get_task(&TaskId::from_raw("bbbbbbbbbbbb"))
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        a.simhash, b.simhash,
+        "identical title+body must yield identical simhash"
+    );
+    assert!(a.simhash.is_some());
 }
 
 // ---------- add-batch ----------
@@ -797,6 +940,8 @@ fn add_with_existing_id_and_different_body_returns_friendly_error() {
             Some("body one"),
             None,
             TaskSourceArg::Human,
+            None,
+            &[],
             w,
         )
     });
@@ -808,6 +953,8 @@ fn add_with_existing_id_and_different_body_returns_friendly_error() {
             Some("body two — different content => different fingerprint"),
             None,
             TaskSourceArg::Human,
+            None,
+            &[],
             w,
         )
     });


### PR DESCRIPTION
## Summary

I1 (#747) 누락 보완 — `task add` / `task add-batch` 명령에 `--simhash-input` / `--paths` 인자를 추가하고, 미지정 시 `title + body` 기반으로 simhash 를 자동 derive.

## 변경

- `cli/src/cmd/mod.rs` — clap 인자 추가
- `cli/src/cmd/task.rs::add` / `add_batch` — 명시 값 우선, 미지정 시 fallback derive
- `cli/src/main.rs` — 새 인자 dispatch
- `cli/tests/task_tests.rs` — derive / 명시 / deterministic 시나리오

## Acceptance

- [x] `task add` (default) 시 simhash 자동 채워짐, paths None
- [x] `--simhash-input "..."` 명시 시 그 텍스트로 simhash 계산
- [x] `--paths "a.rs,b.rs"` 명시 시 그대로 저장
- [x] 같은 title+body → 같은 simhash (deterministic)
- [x] cargo fmt / clippy --tests -D warnings / test 모두 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)