### PR TITLE
fix(cli): resolve preflight clap arg-id collision with global --config

### DIFF
--- a/plugins/github-autopilot/.claude-plugin/plugin.json
+++ b/plugins/github-autopilot/.claude-plugin/plugin.json
@@ -10,7 +10,8 @@
     "./agents/issue-analyzer.md",
     "./agents/ci-fixer.md",
     "./agents/test-analyzer.md",
-    "./agents/spec-validator.md"
+    "./agents/spec-validator.md",
+    "./agents/stale-task-reviewer.md"
   ],
   "author": {
     "name": "kys0213"
@@ -25,7 +26,9 @@
     "./commands/setup.md",
     "./commands/analyze-issue.md",
     "./commands/ci-fix.md",
-    "./commands/test-watch.md"
+    "./commands/test-watch.md",
+    "./commands/work-ledger.md",
+    "./commands/stale-task-review.md"
   ],
   "description": "CronCreate 기반 자율 개발 루프 - gap 탐지, issue 구현, PR 머지, CI 감시/수정, QA 보강, 테스트 워치",
   "name": "github-autopilot",

--- a/plugins/github-autopilot/cli/Cargo.lock
+++ b/plugins/github-autopilot/cli/Cargo.lock
@@ -111,7 +111,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autopilot"
-version = "0.29.1"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/plugins/github-autopilot/cli/src/cmd/mod.rs
+++ b/plugins/github-autopilot/cli/src/cmd/mod.rs
@@ -334,9 +334,12 @@ pub struct CheckStagnationArgs {
 
 #[derive(Args)]
 pub struct PreflightArgs {
-    /// Path to config file
-    #[arg(long, default_value = "github-autopilot.local.md")]
-    pub config: String,
+    /// Path to the autopilot markdown config (e.g. `github-autopilot.local.md`).
+    /// Renamed from `--config` to avoid clap arg-id collision with the global
+    /// `--config <autopilot.toml>` (different type/default caused a runtime
+    /// downcast TypeId panic — see issue #755).
+    #[arg(long = "autopilot-md", default_value = "github-autopilot.local.md")]
+    pub autopilot_md: String,
     /// Repository root directory
     #[arg(long, default_value = ".")]
     pub repo_root: String,

--- a/plugins/github-autopilot/cli/src/main.rs
+++ b/plugins/github-autopilot/cli/src/main.rs
@@ -171,7 +171,10 @@ fn main() {
                 StatsCommands::Show { command } => svc.show(command.as_deref()),
             }
         }
-        Commands::Preflight(PreflightArgs { config, repo_root }) => {
+        Commands::Preflight(PreflightArgs {
+            autopilot_md,
+            repo_root,
+        }) => {
             let client = gh::real();
             let git_client = git::real();
             let fs_client = fs::real();
@@ -179,7 +182,7 @@ fn main() {
                 client.as_ref(),
                 git_client.as_ref(),
                 fs_client.as_ref(),
-                &config,
+                &autopilot_md,
                 Path::new(&repo_root),
             )
         }

--- a/plugins/github-autopilot/cli/tests/cli_e2e.rs
+++ b/plugins/github-autopilot/cli/tests/cli_e2e.rs
@@ -1231,3 +1231,35 @@ fn json_schema_task_list_header_behavior() {
             "ID            STATUS     ATTEMPTS  TITLE",
         ));
 }
+
+// ---------- Issue #755: preflight clap arg-id collision regression ----------
+//
+// `preflight` used to declare a subcommand-local `--config: String` with a
+// default value, colliding at runtime with the global `--config: Option<PathBuf>`.
+// Any invocation of `autopilot preflight ...` panicked inside clap with a
+// "Mismatch between definition and access of `config`" downcast error before
+// any check ran. The fix renamed the subcommand option to `--autopilot-md`;
+// these tests lock in that the parser no longer panics on `preflight` invocations.
+
+#[test]
+fn e2e_preflight_help_does_not_panic() {
+    let ws = Workspace::new();
+    ws.cmd()
+        .args(["preflight", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--autopilot-md"));
+}
+
+#[test]
+fn e2e_preflight_runs_without_clap_panic() {
+    // Empty workspace: every check FAILs/WARNs, but the binary must reach
+    // the JSON report path and exit 1 — never panic inside clap.
+    let ws = Workspace::new();
+    ws.cmd()
+        .arg("preflight")
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains("CLAUDE.md"))
+        .stderr(predicate::str::contains("TypeId").not());
+}

--- a/plugins/github-autopilot/commands/autopilot.md
+++ b/plugins/github-autopilot/commands/autopilot.md
@@ -54,7 +54,7 @@ test_watch: []
 `autopilot preflight` CLI로 환경을 검증합니다:
 
 ```bash
-autopilot preflight --config github-autopilot.local.md --repo-root .
+autopilot preflight --autopilot-md github-autopilot.local.md --repo-root .
 ```
 
 - Exit 0: 모든 check PASS (WARN 허용) → 계속 진행


### PR DESCRIPTION
## Summary

Fixes issue #755 where the `preflight` subcommand panicked at runtime due to a clap argument ID collision. The subcommand declared a local `--config: String` with a default value that conflicted with the global `--config: Option<PathBuf>`, causing a "Mismatch between definition and access of `config`" downcast error before any checks could run.

## Changes

- **Renamed `--config` to `--autopilot-md`** in `PreflightArgs` to eliminate the collision with the global config option
  - Updated the argument definition with clarifying documentation about the rename reason
  - Changed the struct field from `config: String` to `autopilot_md: String`
  
- **Updated all call sites** to use the new field name:
  - `main.rs`: Updated the pattern match and function call to pass `&autopilot_md`
  - `commands/autopilot.md`: Updated example command in documentation

- **Added regression tests** to lock in the fix:
  - `e2e_preflight_help_does_not_panic()`: Verifies `preflight --help` succeeds and shows the new `--autopilot-md` flag
  - `e2e_preflight_runs_without_clap_panic()`: Ensures `preflight` invocation reaches the JSON report path without panicking, and that stderr does not contain TypeId errors

- **Updated plugin manifest** (`plugin.json`) to register new agents and commands:
  - Added `stale-task-reviewer.md` agent
  - Added `work-ledger.md` and `stale-task-review.md` commands

## Implementation Details

The fix is minimal and surgical: only the argument name and its usages change. The default value (`"github-autopilot.local.md"`) and all behavior remain identical. The new name `--autopilot-md` is more descriptive and avoids the type/default mismatch that triggered clap's runtime validation error.

https://claude.ai/code/session_01X8RNJUY3gVfMpc1NSoTpBM