### PR TITLE
fix(atelier): make branch guard read-only and worktree-safe

### DIFF
--- a/.claude/rules/tool-layer-boundary.md
+++ b/.claude/rules/tool-layer-boundary.md
@@ -1,0 +1,75 @@
+---
+paths:
+  - "**/hooks/**"
+  - "**/cli/src/git/commands/hook.rs"
+  - "**/cli/src/git/commands/guard.rs"
+  - "**/scripts/*-hook.sh"
+---
+
+# Tool Layer Boundary — 훅 로직은 CLI, 등록은 thin shim
+
+> CLAUDE.md "책임 경계 (CLI vs Skill/Agent)" 절의 hook/CLI 적용 규칙.
+> 설계 근거: `plans/atelier/02-architecture.md` §3(setup), §4(CLI 통합).
+
+훅(hook)·셸 스크립트와 CLI 서브커맨드 사이의 책임을 고정한다. 경계가 흐려지면
+결정적 로직이 테스트 불가능한 bash에 흩어지고, 설치 시점에 절대경로가 박혀
+플러그인 버전 업데이트마다 깨진다.
+
+## 원칙
+
+### 결정적 로직은 CLI 서브커맨드에 둔다
+
+훅이 수행하는 판단(브랜치 보호 여부, PR 중복 차단, stagnation 카운트 해석 등)은
+**모두 `atelier` 바이너리의 서브커맨드**로 구현한다.
+
+```
+atelier git guard --target <write|commit|pr>   # PreToolUse 가드 판단
+atelier git hook <register|unregister|list>     # settings.json 편집
+atelier autopilot check stagnation              # stdin payload 해석
+```
+
+- 동일 입력 → 동일 출력. 단위 테스트로 동작을 고정한다 (`tests/git_core_guard.rs` 등).
+- 입력은 **args / env / stdin** 으로만 받는다. "지금 상황을 보고 추측"하지 않는다.
+- PreToolUse 페이로드(JSON)는 stdin 으로 받고, 차단은 exit code(2)로 신호한다.
+
+### 등록 진입점은 thin shim 또는 `hook register`
+
+훅을 settings.json 에 등록할 때 **`.sh` 파일 경로나 버전 절대경로를 박지 않는다.**
+
+- shim 셸 스크립트의 책임은 **부트스트랩뿐**이다: 바이너리 존재 보장
+  (`ensure-binary.sh`), 버전 확인(`check-cli-version.sh`) 후 CLI 로 위임.
+  로직(파싱·분기·판단)을 shim 에 두지 않는다.
+- 가능하면 settings.json 에는 shim 대신 **CLI 커맨드를 직접** 기록한다:
+
+  ```jsonc
+  // ✅ 버전 비의존 — 바이너리가 PATH/등록 경로에서 해석됨
+  { "command": "atelier git guard --target commit" }
+
+  // ✅ shim 경유가 필요하면 리터럴 ${CLAUDE_PLUGIN_ROOT} 보존 (expand 금지)
+  { "command": "${CLAUDE_PLUGIN_ROOT}/hooks/check-cli-version.sh" }
+
+  // ❌ 실행 시점 절대경로로 expand — 버전 업데이트 시 깨짐
+  { "command": "bash /Users/me/.claude/plugins/cache/.../0.30.0/hooks/guard.sh" }
+  ```
+
+- 등록 자체도 결정적 변환이므로 `atelier git hook register <type> <matcher> <command>`
+  로 수행한다. LLM 이 `Write` 로 settings.json 을 직접 편집하지 않는다 (#762).
+
+## 판단 기준
+
+| 대상 | 위치 | 이유 |
+|---|---|---|
+| 가드/카운트/파싱/포맷 | CLI 서브커맨드 | 동일 입력 → 동일 출력, 테스트 가능 |
+| 바이너리 보장·버전 확인 | shim (`.sh`) | 부트스트랩은 CLI 가 없을 때 동작해야 함 |
+| settings.json 편집 | `hook register` (CLI) | 결정적 변환, 경로 하드코딩 방지 |
+
+헷갈리면 "두 번 호출해서 결과가 항상 같아야 하나?"를 묻는다. 같아야 하면 CLI,
+부트스트랩(바이너리가 아직 없을 수 있음)이면 shim.
+
+## 안티패턴
+
+- ❌ bash 가 config 를 파싱하고 PR base 를 검증해 차단 (`guard-pr-base.sh`) — 로직을
+  `atelier ... guard` 로 올린다 (#776).
+- ❌ setup 이 `bash <version-path>/hooks/x.sh` 를 settings.json 에 기록 — `hook register`
+  로 `atelier ...` 또는 리터럴 `${CLAUDE_PLUGIN_ROOT}` 를 기록한다 (#762, #772).
+- ✅ shim 은 바이너리 보장 후 `exec atelier ...`, 로직은 CLI, 등록은 `hook register`.

--- a/plugins/atelier/cli/Cargo.lock
+++ b/plugins/atelier/cli/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "atelier"
-version = "0.1.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/plugins/atelier/cli/src/git/core/git.rs
+++ b/plugins/atelier/cli/src/git/core/git.rs
@@ -22,6 +22,11 @@ pub struct PushOptions {
 
 pub trait GitService {
     fn detect_default_branch(&self) -> Result<String, String>;
+    /// Like `detect_default_branch` but never mutates repo state. Skips the
+    /// `git remote set-head` step (Method 2) so it is safe to call from a
+    /// PreToolUse guard on every tool invocation. Used by the branch guard;
+    /// `detect_default_branch` keeps the writing fallback for branch/PR flows.
+    fn detect_default_branch_readonly(&self) -> Result<String, String>;
     fn get_current_branch(&self) -> String;
     fn branch_exists(&self, name: &str, location: BranchLocation) -> bool;
     fn is_inside_work_tree(&self) -> bool;
@@ -74,27 +79,20 @@ impl RealGitService {
         let r = exec(&full, self.opts().as_ref());
         (r.stdout, r.exit_code)
     }
-}
 
-impl GitService for RealGitService {
-    fn detect_default_branch(&self) -> Result<String, String> {
-        // Method 1: cached origin/HEAD
-        let (head, head_exit) = self.git_safe(&["symbolic-ref", "refs/remotes/origin/HEAD"]);
-        if head_exit == 0 && !head.is_empty() {
-            return Ok(head.replace("refs/remotes/origin/", ""));
+    /// Method 1: read the cached `refs/remotes/origin/HEAD` symbolic ref.
+    /// Pure read — never mutates repo state.
+    fn read_origin_head(&self) -> Option<String> {
+        let (head, exit) = self.git_safe(&["symbolic-ref", "refs/remotes/origin/HEAD"]);
+        if exit == 0 && !head.is_empty() {
+            Some(head.replace("refs/remotes/origin/", ""))
+        } else {
+            None
         }
+    }
 
-        // Method 2: auto-detect from remote
-        let _ = exec(
-            &["git", "remote", "set-head", "origin", "--auto"],
-            self.opts().as_ref(),
-        );
-        let (head2, head_exit2) = self.git_safe(&["symbolic-ref", "refs/remotes/origin/HEAD"]);
-        if head_exit2 == 0 && !head2.is_empty() {
-            return Ok(head2.replace("refs/remotes/origin/", ""));
-        }
-
-        // Method 3: fallback to common names
+    /// Method 3: probe common default-branch names on the remote. Pure read.
+    fn probe_common_default(&self) -> Option<String> {
         for name in ["main", "develop", "master"] {
             let (_, exit) = self.git_safe(&[
                 "show-ref",
@@ -103,11 +101,42 @@ impl GitService for RealGitService {
                 &format!("refs/remotes/origin/{name}"),
             ]);
             if exit == 0 {
-                return Ok(name.to_string());
+                return Some(name.to_string());
             }
         }
+        None
+    }
+}
 
-        Err("Could not detect default branch. Make sure you have a remote configured.".to_string())
+const NO_DEFAULT_BRANCH: &str =
+    "Could not detect default branch. Make sure you have a remote configured.";
+
+impl GitService for RealGitService {
+    fn detect_default_branch(&self) -> Result<String, String> {
+        // Method 1: cached origin/HEAD
+        if let Some(branch) = self.read_origin_head() {
+            return Ok(branch);
+        }
+
+        // Method 2: auto-detect from remote (mutates refs/remotes/origin/HEAD)
+        let _ = exec(
+            &["git", "remote", "set-head", "origin", "--auto"],
+            self.opts().as_ref(),
+        );
+        if let Some(branch) = self.read_origin_head() {
+            return Ok(branch);
+        }
+
+        // Method 3: fallback to common names
+        self.probe_common_default()
+            .ok_or_else(|| NO_DEFAULT_BRANCH.to_string())
+    }
+
+    fn detect_default_branch_readonly(&self) -> Result<String, String> {
+        // Method 1 + Method 3 only — no `set-head` write (see #779).
+        self.read_origin_head()
+            .or_else(|| self.probe_common_default())
+            .ok_or_else(|| NO_DEFAULT_BRANCH.to_string())
     }
 
     fn get_current_branch(&self) -> String {

--- a/plugins/atelier/cli/src/git/core/guard.rs
+++ b/plugins/atelier/cli/src/git/core/guard.rs
@@ -11,33 +11,43 @@ use std::sync::LazyLock;
 static GIT_COMMIT_PATTERN: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"\bgit\b.*\bcommit\b").unwrap());
 
-/// Normalizes a path the way Node's `path.resolve` does for the comparison:
-/// makes it absolute against cwd if relative, then lexically collapses
-/// `.`/`..` without touching the filesystem.
-fn resolve_lexical(p: &str) -> PathBuf {
-    let path = Path::new(p);
-    let mut base = if path.is_absolute() {
+/// Lexically collapses `.`/`..` in `path` (relative to `base`) without touching
+/// the filesystem. A relative `path` is anchored at `base` rather than the
+/// process cwd — the guard runs as a PreToolUse hook whose cwd may differ from
+/// the project (worktree / subagent contexts), so resolving against cwd
+/// mis-judges relative `file_path`s (#780).
+fn resolve_against(base: &Path, path: &str) -> PathBuf {
+    let path = Path::new(path);
+    let mut out = if path.is_absolute() {
         PathBuf::new()
     } else {
-        std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/"))
+        base.to_path_buf()
     };
     for comp in path.components() {
         match comp {
             Component::ParentDir => {
-                base.pop();
+                out.pop();
             }
             Component::CurDir => {}
-            other => base.push(other.as_os_str()),
+            other => out.push(other.as_os_str()),
         }
     }
-    base
+    out
+}
+
+/// Resolves `project_dir` itself, anchoring a relative project dir at the
+/// process cwd (the project dir is the anchor, so there is no better base).
+fn resolve_project_dir(project_dir: &str) -> PathBuf {
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/"));
+    resolve_against(&cwd, project_dir)
 }
 
 /// Port of TS `isInsideProjectDir`: true when `file_path` is the project dir
 /// itself or strictly inside it (no `..` escape, not a sibling prefix match).
+/// Relative `file_path`s are resolved against `project_dir` (#780).
 pub fn is_inside_project_dir(file_path: &str, project_dir: &str) -> bool {
-    let project = resolve_lexical(project_dir);
-    let file = resolve_lexical(file_path);
+    let project = resolve_project_dir(project_dir);
+    let file = resolve_against(&project, file_path);
     match file.strip_prefix(&project) {
         Ok(rel) => {
             // rel == '' (same dir) or a normal relative descendant.
@@ -49,8 +59,10 @@ pub fn is_inside_project_dir(file_path: &str, project_dir: &str) -> bool {
 
 /// Port of TS `isInsideAnyGitRepo`: walks up from the file's directory looking
 /// for a `.git` entry, skipping non-existent leading directories first.
-pub fn is_inside_any_git_repo(file_path: &str) -> bool {
-    let resolved = resolve_lexical(file_path);
+/// Relative `file_path`s are resolved against `project_dir`, not the process
+/// cwd, so the walk starts inside the project (#780).
+pub fn is_inside_any_git_repo(file_path: &str, project_dir: &str) -> bool {
+    let resolved = resolve_against(&resolve_project_dir(project_dir), file_path);
     let mut dir = resolved.parent().map(PathBuf::from).unwrap_or(resolved);
     let root = PathBuf::from("/");
 
@@ -100,7 +112,7 @@ impl GuardService for RealGuardService<'_> {
         if input.target == GuardTarget::Write {
             if let Some(file_path) = &input.tool_file_path {
                 if !is_inside_project_dir(file_path, &input.project_dir)
-                    && !is_inside_any_git_repo(file_path)
+                    && !is_inside_any_git_repo(file_path, &input.project_dir)
                 {
                     return pass(Some("file is outside any git repository"));
                 }
@@ -127,7 +139,9 @@ impl GuardService for RealGuardService<'_> {
         // Resolve default branch.
         let default_branch = match &input.default_branch {
             Some(b) => b.clone(),
-            None => match self.git.detect_default_branch() {
+            // Read-only detection — the guard must not mutate repo state
+            // (no `git remote set-head`) on every tool invocation (#779).
+            None => match self.git.detect_default_branch_readonly() {
                 Ok(b) => b,
                 Err(_) => return pass(Some("could not detect default branch")),
             },

--- a/plugins/atelier/cli/src/git/core/guard.rs
+++ b/plugins/atelier/cli/src/git/core/guard.rs
@@ -46,9 +46,12 @@ fn resolve_project_dir(project_dir: &str) -> PathBuf {
 /// itself or strictly inside it (no `..` escape, not a sibling prefix match).
 /// Relative `file_path`s are resolved against `project_dir` (#780).
 pub fn is_inside_project_dir(file_path: &str, project_dir: &str) -> bool {
-    let project = resolve_project_dir(project_dir);
-    let file = resolve_against(&project, file_path);
-    match file.strip_prefix(&project) {
+    inside_project_dir(&resolve_project_dir(project_dir), file_path)
+}
+
+fn inside_project_dir(project: &Path, file_path: &str) -> bool {
+    let file = resolve_against(project, file_path);
+    match file.strip_prefix(project) {
         Ok(rel) => {
             // rel == '' (same dir) or a normal relative descendant.
             rel.as_os_str().is_empty() || !rel.starts_with("..")
@@ -62,7 +65,11 @@ pub fn is_inside_project_dir(file_path: &str, project_dir: &str) -> bool {
 /// Relative `file_path`s are resolved against `project_dir`, not the process
 /// cwd, so the walk starts inside the project (#780).
 pub fn is_inside_any_git_repo(file_path: &str, project_dir: &str) -> bool {
-    let resolved = resolve_against(&resolve_project_dir(project_dir), file_path);
+    inside_any_git_repo(&resolve_project_dir(project_dir), file_path)
+}
+
+fn inside_any_git_repo(project: &Path, file_path: &str) -> bool {
+    let resolved = resolve_against(project, file_path);
     let mut dir = resolved.parent().map(PathBuf::from).unwrap_or(resolved);
     let root = PathBuf::from("/");
 
@@ -111,8 +118,11 @@ impl GuardService for RealGuardService<'_> {
         // write guard: file outside the project directory.
         if input.target == GuardTarget::Write {
             if let Some(file_path) = &input.tool_file_path {
-                if !is_inside_project_dir(file_path, &input.project_dir)
-                    && !is_inside_any_git_repo(file_path, &input.project_dir)
+                // Resolve project_dir once for both path checks (one
+                // current_dir() syscall instead of two per tool invocation).
+                let project = resolve_project_dir(&input.project_dir);
+                if !inside_project_dir(&project, file_path)
+                    && !inside_any_git_repo(&project, file_path)
                 {
                     return pass(Some("file is outside any git repository"));
                 }

--- a/plugins/atelier/cli/src/git/mod.rs
+++ b/plugins/atelier/cli/src/git/mod.rs
@@ -267,7 +267,10 @@ pub fn run(cli: Cli) -> i32 {
             });
             let create_branch_script =
                 create_branch_script.unwrap_or_else(|| "atelier git branch".to_string());
-            let git = create_git_service(None);
+            // Pin the git service to project_dir so branch / special-state /
+            // default-branch detection reflect the project, not the hook's
+            // process cwd (worktree / subagent contexts) — see #780.
+            let git = create_git_service(Some(project_dir.clone()));
             let guard = create_guard_service(&git);
             let deps = commands::guard::GuardCommandDeps { guard: &guard };
             let input = GuardInput {

--- a/plugins/atelier/cli/tests/git_core_git.rs
+++ b/plugins/atelier/cli/tests/git_core_git.rs
@@ -142,6 +142,49 @@ fn detect_default_branch_develop() {
 }
 
 #[test]
+fn detect_default_branch_readonly_uses_cached_head() {
+    let (_r, local) = setup();
+    assert_eq!(
+        svc(local.path()).detect_default_branch_readonly().unwrap(),
+        "main"
+    );
+}
+
+#[test]
+fn detect_default_branch_readonly_does_not_write_origin_head() {
+    let (_r, local) = setup();
+    // Remove the cached symbolic ref so Method 1 misses; readonly must fall
+    // back to Method 3 (probe common names) WITHOUT running `set-head`.
+    sh(
+        &[
+            "git",
+            "symbolic-ref",
+            "--delete",
+            "refs/remotes/origin/HEAD",
+        ],
+        local.path(),
+    );
+
+    assert_eq!(
+        svc(local.path()).detect_default_branch_readonly().unwrap(),
+        "main"
+    );
+
+    // The ref must still be absent — readonly detection has no side effects.
+    let head_present = Command::new("git")
+        .args(["symbolic-ref", "refs/remotes/origin/HEAD"])
+        .current_dir(local.path())
+        .output()
+        .unwrap()
+        .status
+        .success();
+    assert!(
+        !head_present,
+        "detect_default_branch_readonly must not recreate refs/remotes/origin/HEAD"
+    );
+}
+
+#[test]
 fn detect_default_branch_no_remote_errors() {
     let local = TempDir::new().unwrap();
     sh(&["git", "init"], local.path());

--- a/plugins/atelier/cli/tests/git_core_guard.rs
+++ b/plugins/atelier/cli/tests/git_core_guard.rs
@@ -83,7 +83,7 @@ fn default_branch_main_blocked() {
 fn default_branch_master_blocked() {
     let mut git = MockGit::default();
     git.get_current_branch = Box::new(|| "master".to_string());
-    git.detect_default_branch = Box::new(|| Ok("master".to_string()));
+    git.detect_default_branch_readonly = Box::new(|| Ok("master".to_string()));
     assert!(!check(git, &base_input()).allowed);
 }
 
@@ -91,7 +91,7 @@ fn default_branch_master_blocked() {
 fn default_branch_develop_blocked() {
     let mut git = MockGit::default();
     git.get_current_branch = Box::new(|| "develop".to_string());
-    git.detect_default_branch = Box::new(|| Ok("develop".to_string()));
+    git.detect_default_branch_readonly = Box::new(|| Ok("develop".to_string()));
     assert!(!check(git, &base_input()).allowed);
 }
 
@@ -99,7 +99,7 @@ fn default_branch_develop_blocked() {
 fn develop_protected_even_when_default_is_main() {
     let mut git = MockGit::default();
     git.get_current_branch = Box::new(|| "develop".to_string());
-    git.detect_default_branch = Box::new(|| Ok("main".to_string()));
+    git.detect_default_branch_readonly = Box::new(|| Ok("main".to_string()));
     let out = check(git, &base_input());
     assert!(!out.allowed);
     assert_eq!(out.current_branch.as_deref(), Some("develop"));
@@ -110,7 +110,7 @@ fn develop_protected_even_when_default_is_main() {
 fn extra_protected_branches_blocked() {
     let mut git = MockGit::default();
     git.get_current_branch = Box::new(|| "staging".to_string());
-    git.detect_default_branch = Box::new(|| Ok("main".to_string()));
+    git.detect_default_branch_readonly = Box::new(|| Ok("main".to_string()));
     let mut input = base_input();
     input.protected_branches = Some(vec!["staging".to_string(), "release".to_string()]);
     let out = check(git, &input);
@@ -122,7 +122,7 @@ fn extra_protected_branches_blocked() {
 fn branch_not_in_protected_passes() {
     let mut git = MockGit::default();
     git.get_current_branch = Box::new(|| "feat/something".to_string());
-    git.detect_default_branch = Box::new(|| Ok("main".to_string()));
+    git.detect_default_branch_readonly = Box::new(|| Ok("main".to_string()));
     let mut input = base_input();
     input.protected_branches = Some(vec!["staging".to_string()]);
     assert!(check(git, &input).allowed);
@@ -142,7 +142,7 @@ fn explicit_default_branch_used() {
 #[test]
 fn detect_failure_passes_safe_mode() {
     let mut git = MockGit::default();
-    git.detect_default_branch = Box::new(|| Err("no remote".to_string()));
+    git.detect_default_branch_readonly = Box::new(|| Err("no remote".to_string()));
     assert!(check(git, &base_input()).allowed);
 }
 
@@ -300,11 +300,63 @@ fn is_inside_project_dir_cases() {
 #[test]
 fn is_inside_any_git_repo_cases() {
     let cwd = std::env::current_dir().unwrap();
+    let cwd_str = cwd.to_str().unwrap();
     let file = cwd.join("Cargo.toml");
-    assert!(is_inside_any_git_repo(file.to_str().unwrap()));
+    // Absolute file_path: project_dir is irrelevant to the walk.
+    assert!(is_inside_any_git_repo(
+        file.to_str().unwrap(),
+        "/nonexistent"
+    ));
 
     let deep = cwd.join("some/deep/nonexistent/file.ts");
-    assert!(is_inside_any_git_repo(deep.to_str().unwrap()));
+    assert!(is_inside_any_git_repo(
+        deep.to_str().unwrap(),
+        "/nonexistent"
+    ));
 
-    assert!(!is_inside_any_git_repo("/tmp/random-file.txt"));
+    assert!(!is_inside_any_git_repo("/tmp/random-file.txt", cwd_str));
+}
+
+// ---- #780: relative file_path is anchored at project_dir, not process cwd ----
+
+#[test]
+fn relative_file_path_resolved_against_project_dir() {
+    // A relative path belongs to the project regardless of the process cwd,
+    // which (in this test binary) is the atelier/cli dir — not the project_dir.
+    assert!(is_inside_project_dir(
+        "src/index.ts",
+        "/home/user/my-project"
+    ));
+    assert!(is_inside_project_dir(
+        "./src/index.ts",
+        "/home/user/my-project"
+    ));
+    assert!(is_inside_project_dir(".", "/home/user/my-project"));
+    // `..` still escapes the project.
+    assert!(!is_inside_project_dir(
+        "../other/file.ts",
+        "/home/user/my-project"
+    ));
+}
+
+#[test]
+fn relative_file_path_inside_repo_anchored_at_project_dir() {
+    // project_dir is this checkout (a git repo); a relative file_path must
+    // resolve under it, so the .git walk finds the repo.
+    let cwd = std::env::current_dir().unwrap();
+    let cwd_str = cwd.to_str().unwrap();
+    assert!(is_inside_any_git_repo("src/main.rs", cwd_str));
+    // Relative path under a non-repo project_dir is outside any git repo.
+    assert!(!is_inside_any_git_repo("src/main.rs", "/tmp"));
+}
+
+#[test]
+fn relative_file_path_outside_project_on_default_blocks() {
+    // Relative file_path under project_dir, on a protected branch → blocked.
+    // Proves the path was resolved into project_dir (not the process cwd):
+    // is_inside_project_dir must be true so we fall through to the branch guard.
+    let mut input = base_input();
+    input.project_dir = "/home/user/my-project".to_string();
+    input.tool_file_path = Some("src/index.ts".to_string());
+    assert!(!check(MockGit::default(), &input).allowed);
 }

--- a/plugins/atelier/cli/tests/git_mocks.rs
+++ b/plugins/atelier/cli/tests/git_mocks.rs
@@ -23,6 +23,7 @@ pub struct MockGit {
     pub is_inside_work_tree: Box<dyn Fn() -> bool>,
     pub get_current_branch: Box<dyn Fn() -> String>,
     pub detect_default_branch: Box<dyn Fn() -> R<String>>,
+    pub detect_default_branch_readonly: Box<dyn Fn() -> R<String>>,
     pub get_special_state: Box<dyn Fn() -> GitSpecialState>,
     pub branch_exists: Box<dyn Fn(&str, BranchLocation) -> bool>,
     pub has_uncommitted_changes: Box<dyn Fn() -> bool>,
@@ -40,6 +41,7 @@ impl Default for MockGit {
             is_inside_work_tree: Box::new(|| true),
             get_current_branch: Box::new(|| "main".to_string()),
             detect_default_branch: Box::new(|| Ok("main".to_string())),
+            detect_default_branch_readonly: Box::new(|| Ok("main".to_string())),
             get_special_state: Box::new(|| GitSpecialState {
                 rebase: false,
                 merge: false,
@@ -60,6 +62,9 @@ impl Default for MockGit {
 impl GitService for MockGit {
     fn detect_default_branch(&self) -> R<String> {
         (self.detect_default_branch)()
+    }
+    fn detect_default_branch_readonly(&self) -> R<String> {
+        (self.detect_default_branch_readonly)()
     }
     fn get_current_branch(&self) -> String {
         (self.get_current_branch)()


### PR DESCRIPTION
## 요약

atelier 가드 정합성의 "마무리" 묶음입니다. git-utils 평행 포팅(#768/#770) 과정에서 닫힌 PR #771의 델타가 일부 누락됐고, 그로 인한 가드 버그 2건과 참조 끊긴 규칙 문서 1건을 함께 정리합니다.

## 변경 내역

### #780 — worktree false-positive (상대경로 cwd 오해석)
- guard가 상대 `file_path`를 hook 프로세스 cwd 기준으로 절대화해, cwd ≠ project_dir인 worktree/서브에이전트 컨텍스트에서 "project 밖 / git repo 밖"으로 오판 (#754 핵심 원인).
- `core/guard.rs`: 상대 경로를 `--project-dir` 기준으로 정규화(`resolve_against`). `is_inside_project_dir` / `is_inside_any_git_repo` 둘 다 project_dir 앵커.
- `git/mod.rs`: guard의 git 서비스를 `create_git_service(Some(project_dir))`로 핀 고정 → 브랜치·special-state·기본브랜치 감지가 프로세스 cwd가 아닌 프로젝트 기준으로 동작.

### #779 — guard가 repo config를 쓰던 부수효과 제거
- 기존 `detect_default_branch`는 Method 2에서 `git remote set-head origin --auto`를 실행 → PreToolUse 가드가 매 tool 호출마다 `refs/remotes/origin/HEAD`(로컬 config)를 **씀**.
- read-only 변형 `detect_default_branch_readonly`(Method 1 + 3, set-head 미실행) 추가, guard가 이를 호출. `detect_default_branch`(set-head 폴백 포함)는 branch/PR 흐름용으로 유지.

### #781 — `.claude/rules/tool-layer-boundary.md` 신설
- #772·#776이 근거로 인용하나 main에 부재하던 규칙 문서. CLAUDE.md "책임 경계(CLI vs Skill/Agent)" + `plans/atelier/02-architecture.md` §3과 정합: 결정적 로직은 CLI 서브커맨드, 등록은 thin shim 또는 `hook register`, 경로 하드코딩 금지.

## 테스트
- 신규 5건: 상대경로 앵커링(helper + guard 레벨), read-only 감지가 `origin/HEAD`를 건드리지 않음 검증.
- `cargo test` **592 passed, 0 failed** · `cargo fmt --check` 클린 · `cargo clippy --all-targets -D warnings` 클린.

Closes #779
Closes #780
Closes #781

https://claude.ai/code/session_01ViuiNQyXPGGY6NVsBhovfD

---
_Generated by [Claude Code](https://claude.ai/code/session_01ViuiNQyXPGGY6NVsBhovfD)_