### PR TITLE
feat(atelier): add pr target to unified git guard

### DIFF
--- a/.claude/rules/tool-layer-boundary.md
+++ b/.claude/rules/tool-layer-boundary.md
@@ -23,7 +23,7 @@ paths:
 **모두 `atelier` 바이너리의 서브커맨드**로 구현한다.
 
 ```
-atelier git guard --target <write|commit|pr>   # PreToolUse 가드 판단
+atelier git guard <write|commit|pr>             # PreToolUse 가드 판단
 atelier git hook <register|unregister|list>     # settings.json 편집
 atelier autopilot check stagnation              # stdin payload 해석
 ```
@@ -43,7 +43,7 @@ atelier autopilot check stagnation              # stdin payload 해석
 
   ```jsonc
   // ✅ 버전 비의존 — 바이너리가 PATH/등록 경로에서 해석됨
-  { "command": "atelier git guard --target commit" }
+  { "command": "atelier git guard commit" }
 
   // ✅ shim 경유가 필요하면 리터럴 ${CLAUDE_PLUGIN_ROOT} 보존 (expand 금지)
   { "command": "${CLAUDE_PLUGIN_ROOT}/hooks/check-cli-version.sh" }

--- a/plugins/atelier/README.md
+++ b/plugins/atelier/README.md
@@ -78,5 +78,5 @@ atelier setup <module>
 > Fat Controller 14개가 관심사 skill(`spec`/`autopilot`/`git`) + `references/` 로 해체되었습니다.
 > 슬래시 표면은 capability 35개 → 관심사 단위로 수렴, 흡수 6개 plugin 은 snapshot freeze 보존.
 >
-> ⚠️ `gh` CLI 의존 git 명령(pr create, reviews, pr-guard)은 mock 단위 테스트만 완료 —
+> ⚠️ `gh` CLI 의존 git 명령(pr create, reviews, guard pr)은 mock 단위 테스트만 완료 —
 > 실제 `gh`/네트워크 라이브 검증은 정식 릴리스 전 별도 수행이 필요합니다.

--- a/plugins/atelier/cli/Cargo.lock
+++ b/plugins/atelier/cli/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "atelier"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/plugins/atelier/cli/src/git/commands/guard.rs
+++ b/plugins/atelier/cli/src/git/commands/guard.rs
@@ -26,30 +26,25 @@ pub struct GuardCommandInput {
 pub fn run(deps: &GuardCommandDeps, input: &GuardCommandInput) -> GuardDecision {
     match &input.target {
         GuardCommandTarget::Pr { command } => check_pr(deps.pr_guard, command.clone()),
-        GuardCommandTarget::Branch(target) => {
-            let out = deps.branch_guard.check(&GuardInput {
+        GuardCommandTarget::Branch(target) => deps
+            .branch_guard
+            .check(&GuardInput {
                 target: target.clone(),
                 project_dir: input.project_dir.clone(),
                 create_branch_script: input.create_branch_script.clone(),
                 default_branch: input.default_branch.clone(),
                 protected_branches: input.protected_branches.clone(),
-            });
-            GuardDecision {
-                allowed: out.allowed,
-                reason: out.reason,
-            }
-        }
+            })
+            .into(),
     }
 }
 
 /// PR-guard check without branch configuration — shared by the `guard pr`
 /// dispatch above and the legacy `pr-guard` alias.
 pub fn check_pr(pr_guard: &dyn PrGuardService, command: Option<String>) -> GuardDecision {
-    let out = pr_guard.check(&PrGuardInput {
-        tool_command: command,
-    });
-    GuardDecision {
-        allowed: out.allowed,
-        reason: out.reason,
-    }
+    pr_guard
+        .check(&PrGuardInput {
+            tool_command: command,
+        })
+        .into()
 }

--- a/plugins/atelier/cli/src/git/commands/guard.rs
+++ b/plugins/atelier/cli/src/git/commands/guard.rs
@@ -1,16 +1,55 @@
-//! `guard` command glue — port of `git-utils/src/commands/guard.ts`. The TS
-//! module only re-declares types; the decision logic lives in
-//! `core::guard::GuardService`. This thin wrapper runs a guard check so the
-//! CLI layer stays declarative.
+//! `guard` command — the single dispatch point for all guard targets (#777).
+//! Branch targets (write/commit) route to `core::guard::GuardService`, the
+//! `pr` target routes to `core::pr_guard::PrGuardService`. Both collapse into
+//! a `GuardDecision` so the CLI layer only maps allow/block to exit codes.
 
 use crate::git::core::guard::GuardService;
-use crate::git::types::{GuardInput, GuardOutput};
+use crate::git::core::pr_guard::PrGuardService;
+use crate::git::types::{GuardCommandTarget, GuardDecision, GuardInput, PrGuardInput};
 
 pub struct GuardCommandDeps<'a> {
-    pub guard: &'a dyn GuardService,
+    pub branch_guard: &'a dyn GuardService,
+    pub pr_guard: &'a dyn PrGuardService,
 }
 
-/// Runs the guard check.
-pub fn run(deps: &GuardCommandDeps, input: &GuardInput) -> GuardOutput {
-    deps.guard.check(input)
+/// Guard request as parsed by the CLI: the target (with its tool payload) plus
+/// the branch-guard configuration, which only branch targets consume.
+pub struct GuardCommandInput {
+    pub target: GuardCommandTarget,
+    pub project_dir: String,
+    pub create_branch_script: String,
+    pub default_branch: Option<String>,
+    pub protected_branches: Option<Vec<String>>,
+}
+
+/// Routes the target to its guard service and returns the unified decision.
+pub fn run(deps: &GuardCommandDeps, input: &GuardCommandInput) -> GuardDecision {
+    match &input.target {
+        GuardCommandTarget::Pr { command } => check_pr(deps.pr_guard, command.clone()),
+        GuardCommandTarget::Branch(target) => {
+            let out = deps.branch_guard.check(&GuardInput {
+                target: target.clone(),
+                project_dir: input.project_dir.clone(),
+                create_branch_script: input.create_branch_script.clone(),
+                default_branch: input.default_branch.clone(),
+                protected_branches: input.protected_branches.clone(),
+            });
+            GuardDecision {
+                allowed: out.allowed,
+                reason: out.reason,
+            }
+        }
+    }
+}
+
+/// PR-guard check without branch configuration — shared by the `guard pr`
+/// dispatch above and the legacy `pr-guard` alias.
+pub fn check_pr(pr_guard: &dyn PrGuardService, command: Option<String>) -> GuardDecision {
+    let out = pr_guard.check(&PrGuardInput {
+        tool_command: command,
+    });
+    GuardDecision {
+        allowed: out.allowed,
+        reason: out.reason,
+    }
 }

--- a/plugins/atelier/cli/src/git/core/github.rs
+++ b/plugins/atelier/cli/src/git/core/github.rs
@@ -72,24 +72,30 @@ fn load_gh_host() -> Option<String> {
 
 pub struct RealGitHubService {
     cwd: Option<String>,
-    gh_host: Option<String>,
+    // Lazy: the env-file read only happens on the first gh invocation, so
+    // constructing the service (e.g. for a guard target that never consults
+    // gh) costs no I/O.
+    gh_host: std::cell::OnceCell<Option<String>>,
 }
 
 /// Constructs the real GitHub service bound to an optional working directory.
 pub fn create_github_service(cwd: Option<String>) -> RealGitHubService {
     RealGitHubService {
         cwd,
-        gh_host: load_gh_host(),
+        gh_host: std::cell::OnceCell::new(),
     }
 }
 
 impl RealGitHubService {
+    fn gh_host(&self) -> &Option<String> {
+        self.gh_host.get_or_init(load_gh_host)
+    }
     fn opts(&self) -> Option<ExecOptions> {
-        if self.cwd.is_none() && self.gh_host.is_none() {
+        let gh_host = self.gh_host();
+        if self.cwd.is_none() && gh_host.is_none() {
             return None;
         }
-        let env = self
-            .gh_host
+        let env = gh_host
             .as_ref()
             .map(|host| HashMap::from([("GH_HOST".to_string(), host.clone())]));
         Some(ExecOptions {

--- a/plugins/atelier/cli/src/git/core/github.rs
+++ b/plugins/atelier/cli/src/git/core/github.rs
@@ -56,10 +56,11 @@ query($owner: String!, $repo: String!, $number: Int!) {
 "#;
 
 /// Matches `export GH_HOST="<value>"` with flexible inter-token whitespace,
-/// mirroring the TS `loadGhHost` regex `^export\s+GH_HOST="(.+)"` (multiline,
-/// greedy value).
+/// after the TS `loadGhHost` regex — but with `[^"]+` instead of the TS
+/// greedy `.+`, which would capture up to the LAST quote on the line (e.g.
+/// a trailing `# see "docs"` comment would corrupt the host).
 static GH_HOST_PATTERN: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r#"(?m)^export\s+GH_HOST="(.+)""#).unwrap());
+    LazyLock::new(|| Regex::new(r#"(?m)^export\s+GH_HOST="([^"]+)""#).unwrap());
 
 /// Reads `GH_HOST` from `~/.git-workflow-env` (matching the TS loadGhHost).
 fn load_gh_host() -> Option<String> {
@@ -74,15 +75,15 @@ pub struct RealGitHubService {
     cwd: Option<String>,
     // Lazy: the env-file read only happens on the first gh invocation, so
     // constructing the service (e.g. for a guard target that never consults
-    // gh) costs no I/O.
-    gh_host: std::cell::OnceCell<Option<String>>,
+    // gh) costs no I/O. OnceLock (not cell::OnceCell) keeps the service Sync.
+    gh_host: std::sync::OnceLock<Option<String>>,
 }
 
 /// Constructs the real GitHub service bound to an optional working directory.
 pub fn create_github_service(cwd: Option<String>) -> RealGitHubService {
     RealGitHubService {
         cwd,
-        gh_host: std::cell::OnceCell::new(),
+        gh_host: std::sync::OnceLock::new(),
     }
 }
 
@@ -232,6 +233,16 @@ mod tests {
         assert_eq!(
             parse(r#"export GH_HOST="github.example.com""#),
             Some("github.example.com")
+        );
+    }
+
+    #[test]
+    fn trailing_quoted_text_does_not_extend_capture() {
+        // Greedy `.+` would capture up to the last quote on the line; the
+        // value must stop at the closing quote of the assignment.
+        assert_eq!(
+            parse(r#"export GH_HOST="ghe.corp.com" # see "docs""#),
+            Some("ghe.corp.com")
         );
     }
 

--- a/plugins/atelier/cli/src/git/core/guard.rs
+++ b/plugins/atelier/cli/src/git/core/guard.rs
@@ -118,19 +118,18 @@ impl GuardService for RealGuardService<'_> {
         // Target-specific prefilters; the payload lives on the variant (#777).
         match &input.target {
             // write guard: file outside the project directory.
-            GuardTarget::Write {
-                file_path: Some(file_path),
-            } => {
-                // Resolve project_dir once for both path checks (one
-                // current_dir() syscall instead of two per tool invocation).
-                let project = resolve_project_dir(&input.project_dir);
-                if !inside_project_dir(&project, file_path)
-                    && !inside_any_git_repo(&project, file_path)
-                {
-                    return pass(Some("file is outside any git repository"));
+            GuardTarget::Write { file_path } => {
+                if let Some(file_path) = file_path {
+                    // Resolve project_dir once for both path checks (one
+                    // current_dir() syscall instead of two per tool invocation).
+                    let project = resolve_project_dir(&input.project_dir);
+                    if !inside_project_dir(&project, file_path)
+                        && !inside_any_git_repo(&project, file_path)
+                    {
+                        return pass(Some("file is outside any git repository"));
+                    }
                 }
             }
-            GuardTarget::Write { file_path: None } => {}
             // commit guard: not a git commit command → pass.
             GuardTarget::Commit { command } => {
                 let is_commit = command

--- a/plugins/atelier/cli/src/git/core/guard.rs
+++ b/plugins/atelier/cli/src/git/core/guard.rs
@@ -115,9 +115,12 @@ impl GuardService for RealGuardService<'_> {
             default_branch: None,
         };
 
-        // write guard: file outside the project directory.
-        if input.target == GuardTarget::Write {
-            if let Some(file_path) = &input.tool_file_path {
+        // Target-specific prefilters; the payload lives on the variant (#777).
+        match &input.target {
+            // write guard: file outside the project directory.
+            GuardTarget::Write {
+                file_path: Some(file_path),
+            } => {
                 // Resolve project_dir once for both path checks (one
                 // current_dir() syscall instead of two per tool invocation).
                 let project = resolve_project_dir(&input.project_dir);
@@ -127,17 +130,16 @@ impl GuardService for RealGuardService<'_> {
                     return pass(Some("file is outside any git repository"));
                 }
             }
-        }
-
-        // commit guard: not a git commit command → pass.
-        if input.target == GuardTarget::Commit {
-            let is_commit = input
-                .tool_command
-                .as_ref()
-                .map(|c| !c.is_empty() && GIT_COMMIT_PATTERN.is_match(c))
-                .unwrap_or(false);
-            if !is_commit {
-                return pass(Some("not a git commit command"));
+            GuardTarget::Write { file_path: None } => {}
+            // commit guard: not a git commit command → pass.
+            GuardTarget::Commit { command } => {
+                let is_commit = command
+                    .as_ref()
+                    .map(|c| !c.is_empty() && GIT_COMMIT_PATTERN.is_match(c))
+                    .unwrap_or(false);
+                if !is_commit {
+                    return pass(Some("not a git commit command"));
+                }
             }
         }
 
@@ -190,7 +192,7 @@ impl GuardService for RealGuardService<'_> {
         }
 
         // On a protected branch → block.
-        let action = if input.target == GuardTarget::Commit {
+        let action = if matches!(input.target, GuardTarget::Commit { .. }) {
             "커밋할 수 없습니다"
         } else {
             "파일을 수정하려 합니다"

--- a/plugins/atelier/cli/src/git/mod.rs
+++ b/plugins/atelier/cli/src/git/mod.rs
@@ -257,17 +257,28 @@ pub fn run(cli: Cli) -> i32 {
             default_branch,
             protected_branches,
         } => {
-            let (tool_command, tool_file_path) = read_hook_stdin();
+            // Validate the target before touching stdin: an invalid target
+            // must print usage immediately (not block on a missing pipe) and
+            // must not consume the stream.
             let target = match target.as_deref() {
-                Some("write") => GuardCommandTarget::Branch(GuardTarget::Write {
-                    file_path: tool_file_path,
-                }),
-                Some("commit") => GuardCommandTarget::Branch(GuardTarget::Commit {
-                    command: tool_command,
-                }),
-                Some("pr") => GuardCommandTarget::Pr {
-                    command: tool_command,
-                },
+                Some("write") => {
+                    let (_, tool_file_path) = read_hook_stdin();
+                    GuardCommandTarget::Branch(GuardTarget::Write {
+                        file_path: tool_file_path,
+                    })
+                }
+                Some("commit") => {
+                    let (tool_command, _) = read_hook_stdin();
+                    GuardCommandTarget::Branch(GuardTarget::Commit {
+                        command: tool_command,
+                    })
+                }
+                Some("pr") => {
+                    let (tool_command, _) = read_hook_stdin();
+                    GuardCommandTarget::Pr {
+                        command: tool_command,
+                    }
+                }
                 _ => {
                     eprintln!("Usage: atelier git guard <write|commit|pr> --project-dir=<p> --create-branch-script=<s>");
                     return 1;

--- a/plugins/atelier/cli/src/git/mod.rs
+++ b/plugins/atelier/cli/src/git/mod.rs
@@ -18,8 +18,8 @@ use crate::git::core::guard::create_guard_service;
 use crate::git::core::jira::create_jira_service;
 use crate::git::core::pr_guard::create_pr_guard_service;
 use crate::git::types::{
-    BranchInput, CmdResult, CommitInput, GuardInput, GuardTarget, HookListInput, HookRegisterInput,
-    HookUnregisterInput, PrGuardInput, PrInput, ReviewsInput,
+    BranchInput, CmdResult, CommitInput, GuardCommandTarget, GuardDecision, GuardTarget,
+    HookListInput, HookRegisterInput, HookUnregisterInput, PrInput, ReviewsInput,
 };
 use clap::{Parser, Subcommand};
 use serde::Serialize;
@@ -67,9 +67,9 @@ pub enum Commands {
     },
     /// Query unresolved PR review threads
     Reviews { pr_number: Option<i64> },
-    /// Default branch guard (Claude hook)
+    /// Tool guard (Claude hook): branch protection or PR duplicate check
     Guard {
-        /// write | commit
+        /// write | commit | pr
         target: Option<String>,
         #[arg(long = "project-dir")]
         project_dir: Option<String>,
@@ -80,7 +80,7 @@ pub enum Commands {
         #[arg(long = "protected-branches")]
         protected_branches: Option<String>,
     },
-    /// PR duplicate creation guard (Claude hook)
+    /// Deprecated alias of `guard pr`
     #[command(name = "pr-guard")]
     PrGuard,
     /// Manage Claude Code hooks in settings.json
@@ -131,6 +131,18 @@ fn read_hook_stdin() -> (Option<String>, Option<String>) {
         }
         Err(_) => (None, None),
     }
+}
+
+/// Maps a guard decision to the hook exit contract: allow → 0, block → reason
+/// on stderr + exit 2 (PreToolUse deny signal).
+fn guard_exit(decision: GuardDecision) -> i32 {
+    if decision.allowed {
+        return 0;
+    }
+    if let Some(reason) = decision.reason {
+        eprintln!("{reason}");
+    }
+    2
 }
 
 /// Prints a successful command result as pretty JSON (exit 0) or an error to
@@ -245,15 +257,22 @@ pub fn run(cli: Cli) -> i32 {
             default_branch,
             protected_branches,
         } => {
+            let (tool_command, tool_file_path) = read_hook_stdin();
             let target = match target.as_deref() {
-                Some("write") => GuardTarget::Write,
-                Some("commit") => GuardTarget::Commit,
+                Some("write") => GuardCommandTarget::Branch(GuardTarget::Write {
+                    file_path: tool_file_path,
+                }),
+                Some("commit") => GuardCommandTarget::Branch(GuardTarget::Commit {
+                    command: tool_command,
+                }),
+                Some("pr") => GuardCommandTarget::Pr {
+                    command: tool_command,
+                },
                 _ => {
-                    eprintln!("Usage: atelier git guard <write|commit> --project-dir=<p> --create-branch-script=<s>");
+                    eprintln!("Usage: atelier git guard <write|commit|pr> --project-dir=<p> --create-branch-script=<s>");
                     return 1;
                 }
             };
-            let (tool_command, tool_file_path) = read_hook_stdin();
             let protected = protected_branches.map(|raw| {
                 raw.split(',')
                     .map(|b| b.trim().to_string())
@@ -271,39 +290,29 @@ pub fn run(cli: Cli) -> i32 {
             // default-branch detection reflect the project, not the hook's
             // process cwd (worktree / subagent contexts) — see #780.
             let git = create_git_service(Some(project_dir.clone()));
-            let guard = create_guard_service(&git);
-            let deps = commands::guard::GuardCommandDeps { guard: &guard };
-            let input = GuardInput {
+            let branch_guard = create_guard_service(&git);
+            let github = create_github_service(None);
+            let pr_guard = create_pr_guard_service(&github);
+            let deps = commands::guard::GuardCommandDeps {
+                branch_guard: &branch_guard,
+                pr_guard: &pr_guard,
+            };
+            let input = commands::guard::GuardCommandInput {
                 target,
                 project_dir,
                 create_branch_script,
                 default_branch,
                 protected_branches: protected,
-                tool_command,
-                tool_file_path,
             };
-            let result = commands::guard::run(&deps, &input);
-            if !result.allowed {
-                if let Some(reason) = result.reason {
-                    eprintln!("{reason}");
-                }
-                return 2;
-            }
-            0
+            guard_exit(commands::guard::run(&deps, &input))
         }
         Commands::PrGuard => {
+            // Legacy alias of `guard pr` — kept so hooks registered before
+            // the unified `guard` surface (#777) keep working.
             let github = create_github_service(None);
-            let guard = create_pr_guard_service(&github);
+            let pr_guard = create_pr_guard_service(&github);
             let (tool_command, _) = read_hook_stdin();
-            let input = PrGuardInput { tool_command };
-            let result = crate::git::core::pr_guard::PrGuardService::check(&guard, &input);
-            if !result.allowed {
-                if let Some(reason) = result.reason {
-                    eprintln!("{reason}");
-                }
-                return 2;
-            }
-            0
+            guard_exit(commands::guard::check_pr(&pr_guard, tool_command))
         }
         Commands::Hook {
             sub,

--- a/plugins/atelier/cli/src/git/types.rs
+++ b/plugins/atelier/cli/src/git/types.rs
@@ -167,6 +167,24 @@ pub struct GuardDecision {
     pub reason: Option<String>,
 }
 
+impl From<GuardOutput> for GuardDecision {
+    fn from(out: GuardOutput) -> Self {
+        GuardDecision {
+            allowed: out.allowed,
+            reason: out.reason,
+        }
+    }
+}
+
+impl From<PrGuardOutput> for GuardDecision {
+    fn from(out: PrGuardOutput) -> Self {
+        GuardDecision {
+            allowed: out.allowed,
+            reason: out.reason,
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Hook
 // ---------------------------------------------------------------------------

--- a/plugins/atelier/cli/src/git/types.rs
+++ b/plugins/atelier/cli/src/git/types.rs
@@ -124,10 +124,22 @@ pub struct ReviewsOutput {
 // Guard
 // ---------------------------------------------------------------------------
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Branch-guard target as a data-bearing enum: each variant carries exactly
+/// the tool payload its check consumes, so invalid combinations (e.g. a write
+/// guard with a tool command) are unrepresentable (#777).
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GuardTarget {
-    Write,
-    Commit,
+    Write { file_path: Option<String> },
+    Commit { command: Option<String> },
+}
+
+/// Full guard surface the CLI dispatches on. Branch targets route to the
+/// branch guard (`GuardService`), `Pr` routes to the PR duplicate guard
+/// (`PrGuardService`) — the branch guard never sees a `Pr` target by type.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GuardCommandTarget {
+    Branch(GuardTarget),
+    Pr { command: Option<String> },
 }
 
 #[derive(Debug, Clone)]
@@ -137,8 +149,6 @@ pub struct GuardInput {
     pub create_branch_script: String,
     pub default_branch: Option<String>,
     pub protected_branches: Option<Vec<String>>,
-    pub tool_command: Option<String>,
-    pub tool_file_path: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -147,6 +157,14 @@ pub struct GuardOutput {
     pub reason: Option<String>,
     pub current_branch: Option<String>,
     pub default_branch: Option<String>,
+}
+
+/// Unified allow/block decision returned by the guard command after routing
+/// a target to its service — the only contract the CLI exit mapping needs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GuardDecision {
+    pub allowed: bool,
+    pub reason: Option<String>,
 }
 
 // ---------------------------------------------------------------------------

--- a/plugins/atelier/cli/tests/git_cli.rs
+++ b/plugins/atelier/cli/tests/git_cli.rs
@@ -71,7 +71,30 @@ fn git_guard_missing_target_usage() {
         .write_stdin("{}")
         .assert()
         .code(1)
-        .stderr(predicate::str::contains("Usage"));
+        .stderr(predicate::str::contains("Usage"))
+        .stderr(predicate::str::contains("pr"));
+}
+
+#[test]
+fn git_guard_pr_non_matching_command_passes() {
+    // A non-`gh pr create` command passes the PR guard before any gh lookup,
+    // so this is deterministic without a gh binary or network.
+    atelier()
+        .args(["git", "guard", "pr"])
+        .write_stdin(r#"{"tool_input":{"command":"echo hello"}}"#)
+        .assert()
+        .code(0);
+}
+
+#[test]
+fn git_pr_guard_alias_non_matching_command_passes() {
+    // Legacy alias of `guard pr` — must keep the same contract for hooks
+    // registered before the unified guard surface.
+    atelier()
+        .args(["git", "pr-guard"])
+        .write_stdin(r#"{"tool_input":{"command":"echo hello"}}"#)
+        .assert()
+        .code(0);
 }
 
 #[test]

--- a/plugins/atelier/cli/tests/git_commands_guard.rs
+++ b/plugins/atelier/cli/tests/git_commands_guard.rs
@@ -1,0 +1,111 @@
+//! Dispatch tests for the unified `guard` command (#777): branch targets must
+//! route to the branch guard, the pr target to the PR guard — verified through
+//! the public command API with stub services.
+
+use atelier::git::commands::guard::{check_pr, run, GuardCommandDeps, GuardCommandInput};
+use atelier::git::core::guard::GuardService;
+use atelier::git::core::pr_guard::PrGuardService;
+use atelier::git::types::{
+    GuardCommandTarget, GuardInput, GuardOutput, GuardTarget, PrGuardInput, PrGuardOutput,
+};
+
+/// Branch guard stub: blocks, echoing the received target in the reason so
+/// tests can assert what reached the service.
+struct StubBranchGuard;
+
+impl GuardService for StubBranchGuard {
+    fn check(&self, input: &GuardInput) -> GuardOutput {
+        GuardOutput {
+            allowed: false,
+            reason: Some(format!("branch-guard: {:?}", input.target)),
+            current_branch: None,
+            default_branch: None,
+        }
+    }
+}
+
+/// PR guard stub: blocks, echoing the received command.
+struct StubPrGuard;
+
+impl PrGuardService for StubPrGuard {
+    fn check(&self, input: &PrGuardInput) -> PrGuardOutput {
+        PrGuardOutput {
+            allowed: false,
+            reason: Some(format!("pr-guard: {:?}", input.tool_command)),
+            pr_number: Some(7),
+        }
+    }
+}
+
+fn deps<'a>(branch: &'a StubBranchGuard, pr: &'a StubPrGuard) -> GuardCommandDeps<'a> {
+    GuardCommandDeps {
+        branch_guard: branch,
+        pr_guard: pr,
+    }
+}
+
+fn input_with(target: GuardCommandTarget) -> GuardCommandInput {
+    GuardCommandInput {
+        target,
+        project_dir: "/tmp/test".to_string(),
+        create_branch_script: "atelier git branch".to_string(),
+        default_branch: None,
+        protected_branches: None,
+    }
+}
+
+#[test]
+fn write_target_routes_to_branch_guard() {
+    let branch = StubBranchGuard;
+    let pr = StubPrGuard;
+    let decision = run(
+        &deps(&branch, &pr),
+        &input_with(GuardCommandTarget::Branch(GuardTarget::Write {
+            file_path: Some("src/main.rs".to_string()),
+        })),
+    );
+    assert!(!decision.allowed);
+    let reason = decision.reason.unwrap();
+    assert!(reason.starts_with("branch-guard:"));
+    assert!(reason.contains("src/main.rs"));
+}
+
+#[test]
+fn commit_target_routes_to_branch_guard() {
+    let branch = StubBranchGuard;
+    let pr = StubPrGuard;
+    let decision = run(
+        &deps(&branch, &pr),
+        &input_with(GuardCommandTarget::Branch(GuardTarget::Commit {
+            command: Some("git commit -m x".to_string()),
+        })),
+    );
+    assert!(!decision.allowed);
+    let reason = decision.reason.unwrap();
+    assert!(reason.starts_with("branch-guard:"));
+    assert!(reason.contains("git commit -m x"));
+}
+
+#[test]
+fn pr_target_routes_to_pr_guard() {
+    let branch = StubBranchGuard;
+    let pr = StubPrGuard;
+    let decision = run(
+        &deps(&branch, &pr),
+        &input_with(GuardCommandTarget::Pr {
+            command: Some("gh pr create --title x".to_string()),
+        }),
+    );
+    assert!(!decision.allowed);
+    let reason = decision.reason.unwrap();
+    assert!(reason.starts_with("pr-guard:"));
+    assert!(reason.contains("gh pr create --title x"));
+}
+
+#[test]
+fn check_pr_maps_output_to_decision() {
+    let pr = StubPrGuard;
+    let decision = check_pr(&pr, None);
+    assert!(!decision.allowed);
+    assert!(decision.reason.unwrap().starts_with("pr-guard:"));
+}

--- a/plugins/atelier/cli/tests/git_core_guard.rs
+++ b/plugins/atelier/cli/tests/git_core_guard.rs
@@ -12,13 +12,11 @@ use git_mocks::MockGit;
 
 fn base_input() -> GuardInput {
     GuardInput {
-        target: GuardTarget::Write,
+        target: GuardTarget::Write { file_path: None },
         project_dir: "/tmp/test".to_string(),
         create_branch_script: "./create-branch.sh".to_string(),
         default_branch: None,
         protected_branches: None,
-        tool_command: None,
-        tool_file_path: None,
     }
 }
 
@@ -157,47 +155,52 @@ fn write_block_reason_mentions_action_and_script() {
 #[test]
 fn commit_target_not_git_commit_passes() {
     let mut input = base_input();
-    input.target = GuardTarget::Commit;
-    input.tool_command = Some("git push origin main".to_string());
+    input.target = GuardTarget::Commit {
+        command: Some("git push origin main".to_string()),
+    };
     assert!(check(MockGit::default(), &input).allowed);
 }
 
 #[test]
 fn commit_target_git_commit_on_default_blocked() {
     let mut input = base_input();
-    input.target = GuardTarget::Commit;
-    input.tool_command = Some("git commit -m \"test\"".to_string());
+    input.target = GuardTarget::Commit {
+        command: Some("git commit -m \"test\"".to_string()),
+    };
     assert!(!check(MockGit::default(), &input).allowed);
 }
 
 #[test]
 fn commit_target_compound_command_blocked() {
     let mut input = base_input();
-    input.target = GuardTarget::Commit;
-    input.tool_command = Some("git add . && git commit -m \"test\"".to_string());
+    input.target = GuardTarget::Commit {
+        command: Some("git add . && git commit -m \"test\"".to_string()),
+    };
     assert!(!check(MockGit::default(), &input).allowed);
 }
 
 #[test]
 fn commit_target_git_log_passes() {
     let mut input = base_input();
-    input.target = GuardTarget::Commit;
-    input.tool_command = Some("git log --oneline".to_string());
+    input.target = GuardTarget::Commit {
+        command: Some("git log --oneline".to_string()),
+    };
     assert!(check(MockGit::default(), &input).allowed);
 }
 
 #[test]
 fn commit_target_empty_command_passes() {
     let mut input = base_input();
-    input.target = GuardTarget::Commit;
-    input.tool_command = Some(String::new());
+    input.target = GuardTarget::Commit {
+        command: Some(String::new()),
+    };
     assert!(check(MockGit::default(), &input).allowed);
 }
 
 #[test]
 fn commit_target_no_command_passes() {
     let mut input = base_input();
-    input.target = GuardTarget::Commit;
+    input.target = GuardTarget::Commit { command: None };
     assert!(check(MockGit::default(), &input).allowed);
 }
 
@@ -214,7 +217,9 @@ fn block_reason_contains_branch_name() {
 fn outside_project_and_outside_git_repo_passes() {
     let mut input = base_input();
     input.project_dir = "/home/user/my-project".to_string();
-    input.tool_file_path = Some("/home/user/.claude/settings.json".to_string());
+    input.target = GuardTarget::Write {
+        file_path: Some("/home/user/.claude/settings.json".to_string()),
+    };
     let out = check(MockGit::default(), &input);
     assert!(out.allowed);
     assert_eq!(
@@ -230,12 +235,14 @@ fn outside_project_but_inside_other_git_repo_blocked() {
     let this_project = std::env::current_dir().unwrap();
     let mut input = base_input();
     input.project_dir = "/some/other/project".to_string();
-    input.tool_file_path = Some(
-        this_project
-            .join("Cargo.toml")
-            .to_string_lossy()
-            .to_string(),
-    );
+    input.target = GuardTarget::Write {
+        file_path: Some(
+            this_project
+                .join("Cargo.toml")
+                .to_string_lossy()
+                .to_string(),
+        ),
+    };
     assert!(!check(MockGit::default(), &input).allowed);
 }
 
@@ -243,7 +250,9 @@ fn outside_project_but_inside_other_git_repo_blocked() {
 fn inside_project_on_default_blocked() {
     let mut input = base_input();
     input.project_dir = "/home/user/my-project".to_string();
-    input.tool_file_path = Some("/home/user/my-project/src/index.ts".to_string());
+    input.target = GuardTarget::Write {
+        file_path: Some("/home/user/my-project/src/index.ts".to_string()),
+    };
     assert!(!check(MockGit::default(), &input).allowed);
 }
 
@@ -253,22 +262,15 @@ fn inside_project_on_feature_passes() {
     git.get_current_branch = Box::new(|| "feat/something".to_string());
     let mut input = base_input();
     input.project_dir = "/home/user/my-project".to_string();
-    input.tool_file_path = Some("/home/user/my-project/src/index.ts".to_string());
+    input.target = GuardTarget::Write {
+        file_path: Some("/home/user/my-project/src/index.ts".to_string()),
+    };
     assert!(check(git, &input).allowed);
 }
 
 #[test]
 fn no_tool_file_path_runs_default_guard() {
     assert!(!check(MockGit::default(), &base_input()).allowed);
-}
-
-#[test]
-fn commit_target_ignores_tool_file_path() {
-    let mut input = base_input();
-    input.target = GuardTarget::Commit;
-    input.tool_file_path = Some("/external/path/file.txt".to_string());
-    input.tool_command = Some("git commit -m \"test\"".to_string());
-    assert!(!check(MockGit::default(), &input).allowed);
 }
 
 // ---- path helpers ----
@@ -357,6 +359,8 @@ fn relative_file_path_outside_project_on_default_blocks() {
     // is_inside_project_dir must be true so we fall through to the branch guard.
     let mut input = base_input();
     input.project_dir = "/home/user/my-project".to_string();
-    input.tool_file_path = Some("src/index.ts".to_string());
+    input.target = GuardTarget::Write {
+        file_path: Some("src/index.ts".to_string()),
+    };
     assert!(!check(MockGit::default(), &input).allowed);
 }

--- a/plugins/atelier/commands/git/hook-config.md
+++ b/plugins/atelier/commands/git/hook-config.md
@@ -50,7 +50,7 @@ hook이 두 범위에서 발견되었습니다.
 
 - `atelier git guard write` 포함 hook → Write/Edit Guard 활성화
 - `atelier git guard commit` 포함 hook → Commit Guard 활성화
-- `atelier git pr-guard` 포함 hook → PR Guard 활성화
+- `atelier git guard pr` 또는 `atelier git pr-guard`(legacy alias) 포함 hook → PR Guard 활성화
 - 프로젝트 범위 vs 사용자 범위는 `--project-dir` 유무로 판별
 
 ## Step 3: 관리할 hook 선택
@@ -130,15 +130,15 @@ atelier git hook unregister PreToolUse \
 
 ```bash
 atelier git hook unregister PreToolUse \
-  "atelier git pr-guard"
+  "atelier git guard pr"   # legacy 설치는 "atelier git pr-guard" — Step 2에서 찾은 문자열 사용
 ```
 
 **사용자 범위:**
 
 ```bash
 atelier git hook unregister PreToolUse \
-  "atelier git pr-guard" \
-  --project-dir="$HOME"
+  "atelier git guard pr" \
+  --project-dir="$HOME"   # legacy 설치는 "atelier git pr-guard" — Step 2에서 찾은 문자열 사용
 ```
 
 완료 메시지:
@@ -203,7 +203,7 @@ atelier git hook register PreToolUse "Bash" \
 
 ```bash
 atelier git hook register PreToolUse "Bash" \
-  "atelier git pr-guard" \
+  "atelier git guard pr" \
   --timeout=10
 ```
 
@@ -211,7 +211,7 @@ atelier git hook register PreToolUse "Bash" \
 
 ```bash
 atelier git hook register PreToolUse "Bash" \
-  "atelier git pr-guard" \
+  "atelier git guard pr" \
   --timeout=10 \
   --project-dir="$HOME"
 ```

--- a/plugins/atelier/skills/git/SKILL.md
+++ b/plugins/atelier/skills/git/SKILL.md
@@ -118,13 +118,14 @@ atelier git reviews [pr-number]
 
 **출력 (JSON):** PR 제목, URL, 리뷰 쓰레드 목록
 
-### 5. Default Branch Guard
+### 5. Tool Guard (branch 보호 · PR 중복)
 
 ```bash
-atelier git guard <write|commit> --project-dir=<p> --create-branch-script=<s> [--default-branch=<b>]
+atelier git guard <write|commit|pr> --project-dir=<p> --create-branch-script=<s> [--default-branch=<b>]
 ```
 
-- 기본 브랜치에서 차단 시 exit 2, 통과 시 exit 0
+- `write`/`commit`: 기본 브랜치(보호 브랜치)에서 차단 시 exit 2, 통과 시 exit 0
+- `pr`: 현재 브랜치에 열린 PR이 있으면 `gh pr create` 차단 (exit 2). branch 옵션 불필요. legacy alias: `atelier git pr-guard`
 
 ### 6. Hook 관리
 


### PR DESCRIPTION
## Summary

#777 해결 — guard 표면을 일반화하여 무효 입력 조합을 타입으로 차단하고, PR 가드를 통합 `guard` 디스패치에 배선합니다.

### 변경 내용

- **`GuardTarget` 데이터 enum 일반화**: `Write { file_path }` / `Commit { command }` — 각 variant가 자신의 check가 소비하는 payload만 보유. `GuardInput`의 sibling `tool_command`/`tool_file_path` Option 제거 → 무효 조합(Write+command 등)이 표현 불가
- **`GuardCommandTarget` (`Branch(_)` | `Pr { command }`)**: command 레이어의 단일 디스패치 — branch target은 `GuardService`, pr은 `PrGuardService`로 라우팅하고 `GuardDecision`으로 수렴. branch guard core는 타입상 `Pr`을 받을 수 없음 (rust-core "타입으로 제약 표현")
- **`atelier git guard pr` 배선** → PR 중복 생성 가드. 기존 `pr-guard`는 이미 등록된 hook 호환을 위해 legacy alias로 유지
- **hook-config.md** 등록/해제 예시와 감지 로직을 canonical `guard pr`로 갱신

### /simplify 후속 (fb9247b)

- `RealGitHubService`의 `~/.git-workflow-env` 로딩을 lazy로 — write/commit guard 경로에서 PreToolUse마다 발생하던 불필요한 파일 I/O 제거
- `GuardOutput`/`PrGuardOutput` → `GuardDecision` 변환을 `From` impl로
- 빈 `Write { file_path: None }` match arm 제거

### /code-review 후속 (f3e374a)

- target 검증을 stdin 읽기보다 앞으로 — 무효/누락 target이 stdin EOF를 기다리며 블로킹하던 회귀 수정
- lazy gh_host를 `sync::OnceLock`으로 — 서비스의 `Sync` 유지
- `GH_HOST_PATTERN` 캡처를 greedy `.+` → `[^"]+`로 tighten (+회귀 테스트)
- git skill 문서에 `pr` target 반영, tool-layer-boundary 규칙 예시를 positional 문법으로 정정

### 테스트

- 기존 `git_core_guard.rs` 블랙박스 테스트를 새 타입으로 이행 (무효 조합 테스트는 타입이 보장하게 되어 제거)
- 신규 `git_commands_guard.rs`: stub 서비스로 타입 라우팅 검증 4건
- `git_cli.rs` e2e: `guard pr` / `pr-guard` alias 모두 비매칭 명령에 exit 0 (gh 바이너리 없이 결정적)
- `cargo fmt --check` / `cargo clippy --all-targets -- -D warnings` / `cargo test` (36 스위트) 전부 통과

Resolves #777

https://claude.ai/code/session_01953WETiyt3SWt8AorYUUKA