### PR TITLE
fix(atelier): rename autopilot binary refs to atelier in shim scripts

### DIFF
--- a/plugins/atelier/cli/Cargo.lock
+++ b/plugins/atelier/cli/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "atelier"
-version = "0.4.0"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/plugins/atelier/hooks/check-cli-version.sh
+++ b/plugins/atelier/hooks/check-cli-version.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # check-cli-version.sh — SessionStart hook
-# 세션 시작 시 autopilot CLI 버전이 plugin.json과 일치하는지 확인합니다.
+# 세션 시작 시 atelier CLI 버전이 plugin.json과 일치하는지 확인합니다.
 # 과거 버전이면 업데이트 안내를 출력합니다.
 #
 # 트리거: SessionStart
@@ -37,12 +37,12 @@ if [[ -z "$PLUGIN_VERSION" ]]; then
 fi
 
 # --- 설치된 CLI 버전 확인 ---
-if ! command -v autopilot &> /dev/null; then
-  echo "autopilot CLI가 설치되어 있지 않습니다. /atelier:setup 을 실행하여 설치하세요."
+if ! command -v atelier &> /dev/null; then
+  echo "atelier CLI가 설치되어 있지 않습니다. /atelier:setup 을 실행하여 설치하세요."
   exit 0
 fi
 
-INSTALLED_VERSION=$(autopilot --version 2>/dev/null | awk '{print $NF}' || echo "")
+INSTALLED_VERSION=$(atelier --version 2>/dev/null | awk '{print $NF}' || echo "")
 
 if [[ -z "$INSTALLED_VERSION" ]]; then
   exit 0
@@ -72,7 +72,7 @@ CMP=$?
 set -e
 
 if [[ "$CMP" -eq 2 ]]; then
-  echo "autopilot CLI 업데이트 필요: v${INSTALLED_VERSION} → v${PLUGIN_VERSION}. /atelier:setup 또는 bash ${PLUGIN_ROOT}/scripts/ensure-binary.sh 를 실행하세요."
+  echo "atelier CLI 업데이트 필요: v${INSTALLED_VERSION} → v${PLUGIN_VERSION}. /atelier:setup 또는 bash ${PLUGIN_ROOT}/scripts/ensure-binary.sh 를 실행하세요."
 fi
 
 exit 0

--- a/plugins/atelier/hooks/protect-stagnation.sh
+++ b/plugins/atelier/hooks/protect-stagnation.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # protect-stagnation.sh — PreToolUse hook (Bash matcher)
-# `autopilot task claim` 명령 직전에 `autopilot check stagnation`으로
+# `atelier autopilot task claim` 명령 직전에 `atelier autopilot check stagnation`으로
 # 유사 task 그룹의 반복 실패를 감지하여 redirect 또는 escalate 합니다.
 #
 # 트리거: PreToolUse (Bash matcher)
@@ -9,7 +9,7 @@
 #   - stagnation OK (exit 0) → exit 0
 #   - stagnation detected (exit 4) → exit 2 + stderr redirect prompt
 #   - stagnation escalate (exit 5) → exit 2 + auto-escalate + 사람 개입 안내
-#   - 기타 (autopilot/jq 부재 등) → exit 0 (best-effort 통과)
+#   - 기타 (atelier/jq 부재 등) → exit 0 (best-effort 통과)
 
 set -e
 
@@ -42,14 +42,14 @@ if [ -z "$task_id" ]; then
   exit 0
 fi
 
-# autopilot 부재 시 best-effort 통과
-if ! command -v autopilot >/dev/null 2>&1; then
+# atelier 부재 시 best-effort 통과
+if ! command -v atelier >/dev/null 2>&1; then
   exit 0
 fi
 
 # stagnation 체크
 set +e
-result=$(autopilot check stagnation --task "$task_id" 2>/dev/null)
+result=$(atelier autopilot check stagnation --task "$task_id" 2>/dev/null)
 exit_code=$?
 set -e
 
@@ -78,8 +78,8 @@ case "$exit_code" in
     # Escalate — 자동 escalate 호출 + 사람 개입 prompt
     echo "[STAGNATION ESCALATED] task ${task_id}" >&2
     echo "Stagnation 임계 (N>=5) 도달. 자동 escalate 됩니다." >&2
-    autopilot task escalate "$task_id" --reason "stagnation: auto-escalated by hook (N>=5)" 2>/dev/null \
-      || echo "[WARN] auto-escalate 호출 실패 — 수동으로 'autopilot task escalate $task_id' 실행 필요" >&2
+    atelier autopilot task escalate "$task_id" --reason "stagnation: auto-escalated by hook (N>=5)" 2>/dev/null \
+      || echo "[WARN] auto-escalate 호출 실패 — 수동으로 'atelier autopilot task escalate $task_id' 실행 필요" >&2
     echo "이 영역은 자동 retry 한도를 넘었습니다. 사람의 검토가 필요합니다." >&2
     exit 2
     ;;

--- a/plugins/atelier/scripts/ensure-binary.sh
+++ b/plugins/atelier/scripts/ensure-binary.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# ensure-binary.sh — autopilot CLI 바이너리 버전 확인 및 조건부 빌드/설치
+# ensure-binary.sh — atelier CLI 바이너리 버전 확인 및 조건부 빌드/설치
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -7,7 +7,7 @@ PLUGIN_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 CLI_DIR="$PLUGIN_DIR/cli"
 PLUGIN_JSON="$PLUGIN_DIR/.claude-plugin/plugin.json"
 INSTALL_DIR="$HOME/.local/bin"
-BINARY_NAME="autopilot"
+BINARY_NAME="atelier"
 BINARY_PATH="$INSTALL_DIR/$BINARY_NAME"
 
 # --- Helper: SemVer 비교 ---
@@ -54,7 +54,7 @@ fi
 ACTION=""
 if [ -z "$INSTALLED_VERSION" ]; then
   ACTION="install"
-  echo "autopilot CLI not found. Installing v${PLUGIN_VERSION}..."
+  echo "atelier CLI not found. Installing v${PLUGIN_VERSION}..."
 else
   set +e
   compare_semver "$INSTALLED_VERSION" "$PLUGIN_VERSION"
@@ -63,9 +63,9 @@ else
 
   if [ "$CMP" -eq 2 ]; then
     ACTION="update"
-    echo "autopilot CLI outdated: v${INSTALLED_VERSION} → v${PLUGIN_VERSION}. Rebuilding..."
+    echo "atelier CLI outdated: v${INSTALLED_VERSION} → v${PLUGIN_VERSION}. Rebuilding..."
   else
-    echo "autopilot CLI is up to date (v${INSTALLED_VERSION})."
+    echo "atelier CLI is up to date (v${INSTALLED_VERSION})."
     exit 0
   fi
 fi
@@ -78,21 +78,21 @@ if ! command -v cargo &> /dev/null; then
 fi
 
 # --- 5. 빌드 ---
-echo "Building autopilot CLI..."
+echo "Building atelier CLI..."
 cargo build --release --manifest-path "$CLI_DIR/Cargo.toml"
 
 # --- 6. 설치 ---
 mkdir -p "$INSTALL_DIR"
-cp "$CLI_DIR/target/release/autopilot" "$BINARY_PATH"
+cp "$CLI_DIR/target/release/$BINARY_NAME" "$BINARY_PATH"
 chmod +x "$BINARY_PATH"
 
 # --- 7. 설치 확인 ---
 if "$BINARY_PATH" --version &> /dev/null; then
   NEW_VERSION=$("$BINARY_PATH" --version 2>/dev/null | awk '{print $NF}')
   if [ "$ACTION" = "install" ]; then
-    echo "autopilot CLI installed successfully (v${NEW_VERSION})."
+    echo "atelier CLI installed successfully (v${NEW_VERSION})."
   else
-    echo "autopilot CLI updated successfully: v${INSTALLED_VERSION} → v${NEW_VERSION}."
+    echo "atelier CLI updated successfully: v${INSTALLED_VERSION} → v${NEW_VERSION}."
   fi
 else
   echo "ERROR: Installation verification failed." >&2


### PR DESCRIPTION
## 요약

`autopilot` → `atelier` 바이너리 리네임이 셸 스크립트 3곳에 반영되지 않아, 깨끗한 환경에서 CLI 설치가 실패하고 세션마다 false-nag가 출력되던 문제를 수정합니다.

## 변경

| 파일 | 수정 |
|---|---|
| `scripts/ensure-binary.sh` | `BINARY_NAME=atelier`, `cp .../release/$BINARY_NAME` (존재하지 않던 `release/autopilot` → 설치 실패 해소), 메시지 |
| `hooks/check-cli-version.sh` | `command -v atelier`, `atelier --version` (세션 false-nag 해소), 메시지 |
| `hooks/protect-stagnation.sh` | `command -v atelier`, `atelier autopilot check stagnation`, `atelier autopilot task escalate` |
| `cli/Cargo.lock` | atelier 패키지 버전 0.4.0 → 0.4.3 동기화 (Cargo.toml 일치) |

## 검증

- `cargo build --release` → `target/release/atelier` 생성 확인 (cp 소스 경로 정상)
- 3개 스크립트 `bash -n` 문법 통과
- `atelier --version` → `atelier 0.4.3`

## 범위 메모

- `protect-stagnation.sh`의 prefilter grep(`autopilot task claim` 부분 문자열)은 `atelier autopilot task claim`도 매칭하므로 그대로 유지
- 해당 hook 로직의 CLI 이전은 #776에서 별도 진행

Closes #792