### PR TITLE
refactor(atelier): ship all plugin hooks as plugin-declared, drop setup registration

### DIFF
--- a/.claude/rules/tool-layer-boundary.md
+++ b/.claude/rules/tool-layer-boundary.md
@@ -59,8 +59,9 @@ atelier autopilot check stagnation              # stdin payload 해석
   버전 절대경로로 expand 한다 — 단일 따옴표도 못 막는다. 그래서 setup 이 `.sh` shim 을
   `hook register` 로 등록하면 settings.json 에 버전 절대경로가 박혀 **업데이트마다 frozen**
   된다(0.4.x 잔재의 원인). 반면 `hooks/hooks.json` 의 `${CLAUDE_PLUGIN_ROOT}` 는 Claude Code
-  가 hook **실행 시점**에 활성 버전으로 해석하므로 frozen 이 없다. 차단(exit 2) 여부와 무관하며,
-  모든 세션에 적용돼도 안전하도록 스크립트가 **self-gate**(config 파일 / 명령 패턴 / 워터마크)한다.
+  가 hook **실행 시점**에 활성 버전으로 해석하므로 frozen 이 없다. 모든 세션에 적용되므로 안전이
+  전제다 — 차단(exit 2)형 hook 은 **self-gate**(config 파일 / 명령 패턴)로 비대상 세션에서 no-op 하고,
+  advisory(비차단)형 hook 은 출력만 하므로 게이트 없이 둔다.
 - **예외 — setup 시점 값 주입이 필요한 hook**: git guard 처럼 `--default-branch <감지값>` 등
   프로젝트별 값을 setup 이 1회 감지해 박아야 하는 hook 은 `hook register` 로 등록한다. 단
   이때도 `.sh` 경로가 아니라 **CLI 커맨드 직접**(`atelier git guard ...`) 형태라 PATH 해석으로

--- a/.claude/rules/tool-layer-boundary.md
+++ b/.claude/rules/tool-layer-boundary.md
@@ -54,12 +54,17 @@ atelier autopilot check stagnation              # stdin payload 해석
 
 - 등록 자체도 결정적 변환이므로 `atelier git hook register <type> <matcher> <command>`
   로 수행한다. LLM 이 `Write` 로 settings.json 을 직접 편집하지 않는다 (#762).
-- **plugin-declared hook**: setup·프로젝트 설정과 무관하게 플러그인 활성화만으로 모든
-  세션에 적용돼야 하는 config-free·non-blocking hook(예: `check-cli-version`)은
-  플러그인 루트의 `hooks/hooks.json` 에 리터럴 `${CLAUDE_PLUGIN_ROOT}` 로 선언한다.
-  이는 settings.json 편집이 아니므로 `hook register` 가 필요 없고, 활성 플러그인 버전
-  경로로 해석돼 frozen 이 없다. 반대로 프로젝트별 설정이나 차단(exit 2)이 필요한 hook
-  (guard 류)은 opt-in 이라 `hook register` 로 settings.json 에 등록한다.
+- **플러그인 번들 `.sh` hook 은 `hooks/hooks.json` 으로 선언한다 (setup-register 금지).**
+  슬래시 커맨드(`/atelier:setup`)는 로드 시점에 본문의 `${CLAUDE_PLUGIN_ROOT}` 를 *그때의*
+  버전 절대경로로 expand 한다 — 단일 따옴표도 못 막는다. 그래서 setup 이 `.sh` shim 을
+  `hook register` 로 등록하면 settings.json 에 버전 절대경로가 박혀 **업데이트마다 frozen**
+  된다(0.4.x 잔재의 원인). 반면 `hooks/hooks.json` 의 `${CLAUDE_PLUGIN_ROOT}` 는 Claude Code
+  가 hook **실행 시점**에 활성 버전으로 해석하므로 frozen 이 없다. 차단(exit 2) 여부와 무관하며,
+  모든 세션에 적용돼도 안전하도록 스크립트가 **self-gate**(config 파일 / 명령 패턴 / 워터마크)한다.
+- **예외 — setup 시점 값 주입이 필요한 hook**: git guard 처럼 `--default-branch <감지값>` 등
+  프로젝트별 값을 setup 이 1회 감지해 박아야 하는 hook 은 `hook register` 로 등록한다. 단
+  이때도 `.sh` 경로가 아니라 **CLI 커맨드 직접**(`atelier git guard ...`) 형태라 PATH 해석으로
+  버전 비의존이다.
 
 ## 판단 기준
 
@@ -67,7 +72,8 @@ atelier autopilot check stagnation              # stdin payload 해석
 |---|---|---|
 | 가드/카운트/파싱/포맷 | CLI 서브커맨드 | 동일 입력 → 동일 출력, 테스트 가능 |
 | 바이너리 보장·버전 확인 | shim (`.sh`) | 부트스트랩은 CLI 가 없을 때 동작해야 함 |
-| settings.json 편집 | `hook register` (CLI) | 결정적 변환, 경로 하드코딩 방지 |
+| 플러그인 번들 `.sh` hook 등록 | `hooks/hooks.json` (plugin-declared) | 실행 시점 `${CLAUDE_PLUGIN_ROOT}` 해석 → frozen 없음 |
+| setup 시점 값 주입 hook 등록 | `hook register` (CLI 커맨드 직접) | 프로젝트별 값 주입 필요, PATH 해석으로 버전 비의존 |
 
 헷갈리면 "두 번 호출해서 결과가 항상 같아야 하나?"를 묻는다. 같아야 하면 CLI,
 부트스트랩(바이너리가 아직 없을 수 있음)이면 shim.

--- a/plugins/atelier/commands/setup.md
+++ b/plugins/atelier/commands/setup.md
@@ -119,6 +119,7 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/ensure-binary.sh"
      .*/plugins/(github-autopilot|coding-style)/hooks/(<file>)\.sh
      .*/plugins/git-utils/scripts/(default-branch-guard.*)\.sh
      .*/plugins/atelier/scripts/(default-branch-guard.*)\.sh   # 구버전 atelier setup 잔재
+     .*/atelier/[^/]*/hooks/(check-cli-version|guard-pr-base|protect-stagnation|suggest-simplify)\.sh   # 구버전 atelier setup 이 frozen 버전경로로 박은 .sh shim (이제 plugin-declared → "제거만")
 3. 변경 전 ~/.claude/settings.json 을 settings.json.bak-<timestamp> 로 백업 (cp)
 4. 사용자에게 치환 목록을 보여주고 AskUserQuestion 으로 확인
 5. 매칭 entry 마다: atelier git hook unregister <type> <old-command> --project-dir "$HOME"

--- a/plugins/atelier/commands/setup.md
+++ b/plugins/atelier/commands/setup.md
@@ -13,10 +13,9 @@ allowed-tools: ["Bash", "Read", "Write", "Edit", "AskUserQuestion"]
 > 등록은 LLM 이 settings.json 을 직접 편집하지 않고 **`atelier git hook register` CLI** 로 수행합니다
 > (`.claude/rules/tool-layer-boundary.md`). `--project-dir "$HOME"` 을 주면 `~/.claude/settings.json` 에 기록됩니다.
 
-등록되는 command 는 두 형태뿐입니다:
+setup 이 settings.json 에 등록하는 hook 은 **CLI 직접 호출 형태뿐**입니다 (`atelier git guard write ...` — 바이너리가 PATH 에서 해석되므로 버전 비의존). 이는 setup 시점에 프로젝트별 값(예: `--default-branch <감지값>`)을 주입해야 하기 때문입니다.
 
-- **CLI 직접 호출** (결정적 로직이 CLI 에 있는 hook): `atelier git guard write ...` — 바이너리가 PATH 에서 해석되므로 버전 비의존
-- **`${CLAUDE_PLUGIN_ROOT}` 리터럴 shim** (#776 에서 CLI 이전 예정인 `.sh` hook): 절대경로로 expand 하지 않고 리터럴 그대로 기록
+> 플러그인에 번들된 `.sh` hook(`check-cli-version`·`guard-pr-base`·`protect-stagnation`·`suggest-simplify`)은 setup 이 등록하지 않습니다 — 플러그인이 `hooks/hooks.json` 으로 직접 선언하고, 각 스크립트가 내부에서 self-gate(autopilot config / 명령 패턴 / style 워터마크)합니다. `${CLAUDE_PLUGIN_ROOT}` 가 hook 실행 시점에 활성 버전으로 해석돼 frozen 이 없습니다 (`.claude/rules/tool-layer-boundary.md`).
 
 ## Step 0 — atelier CLI 보장 (공통 선행)
 
@@ -29,9 +28,8 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/ensure-binary.sh"
 - plugin.json 버전과 설치된 `atelier --version` 을 SemVer 비교해 필요 시 빌드/설치합니다 (`~/.local/bin/atelier`)
 - 실패하면(cargo 부재 등) 이후 Step 을 진행하지 말고 에러를 안내합니다
 
-> CLI 버전 드리프트 알림(SessionStart)은 setup 이 등록하지 않습니다 — 플러그인이 `hooks/hooks.json` 으로
-> 직접 선언해 활성화 시 자동 적용됩니다(`${CLAUDE_PLUGIN_ROOT}` 해석으로 버전 frozen 없음). Step 0 이
-> *setup 시점* 바이너리를 보장하면, 그 hook 이 *이후 드리프트*를 알리는 한 쌍입니다.
+> Step 0 은 *setup 시점* 바이너리를 보장하고, plugin-declared SessionStart hook(`check-cli-version`)이
+> *이후 버전 드리프트*를 알립니다 — 둘이 한 쌍입니다.
 
 ## Step 1 — 설치 모듈 선택
 
@@ -90,17 +88,9 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/ensure-binary.sh"
 ## Step 2b — autopilot 모듈
 
 1. 프로젝트 설정 파일 `github-autopilot.local.md` 생성 (기존 스키마/경로 동일 — 호환).
-2. autopilot hook 2종 등록 — 로직이 아직 `.sh` 에 있으므로(#776 에서 CLI 이전 예정) `${CLAUDE_PLUGIN_ROOT}` 리터럴 shim 으로 기록 (버전 드리프트 알림 hook 은 setup 이 등록하지 않음 — Step 0 안내 참조, 플러그인이 `hooks/hooks.json` 으로 직접 선언):
-   ```bash
-   atelier git hook register PreToolUse "Bash" \
-     '${CLAUDE_PLUGIN_ROOT}/hooks/guard-pr-base.sh' --project-dir "$HOME"
 
-   atelier git hook register PreToolUse "Bash" \
-     '${CLAUDE_PLUGIN_ROOT}/hooks/protect-stagnation.sh' --project-dir "$HOME"
-   ```
-   > `PreToolUse`/`Bash` matcher 는 git 모듈의 commit guard 와 공유됩니다 — `hook register` 는 같은 matcher
-   > 그룹에 command 를 append 하므로 서로 덮어쓰지 않습니다.
-
+> autopilot hook(`guard-pr-base`·`protect-stagnation`)은 setup 이 등록하지 않습니다 — 플러그인이 `hooks/hooks.json` 으로 직접 선언하고, 두 스크립트가 `github-autopilot.local.md` 존재로 self-gate 합니다. 따라서 위 1번(config 파일 생성)만으로 활성화됩니다.
+>
 > autopilot SQLite store(ledger/task DB)는 기존 스키마/경로를 계승하므로 마이그레이션 불필요.
 
 ## Step 2c — workflow 모듈
@@ -114,11 +104,8 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/ensure-binary.sh"
 
 1. `~/.claude/CLAUDE.md` 에 코딩 원칙 템플릿 병합 (워터마크 기반 중복 확인 — 기존 coding-style 로직 동일):
    - 템플릿 원본: `${CLAUDE_PLUGIN_ROOT}/templates/claude-md/CLAUDE.md`
-2. Stop hook 등록:
-   ```bash
-   atelier git hook register Stop "*" \
-     '${CLAUDE_PLUGIN_ROOT}/hooks/suggest-simplify.sh' --project-dir "$HOME"
-   ```
+
+> `/simplify` 제안 Stop hook(`suggest-simplify`)은 setup 이 등록하지 않습니다 — 플러그인이 `hooks/hooks.json` 으로 직접 선언하고, 스크립트가 `~/.claude/CLAUDE.md` 의 `[coding-style:begin]` 워터마크로 self-gate 합니다. 따라서 위 1번(템플릿 병합)만으로 활성화됩니다.
 
 ## Step 3 — 기존 hook 마이그레이션 (frozen → atelier)
 
@@ -147,9 +134,9 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/ensure-binary.sh"
 | frozen 경로 | atelier 등록 command |
 |---|---|
 | `github-autopilot/hooks/check-cli-version.sh` | **제거만** (재등록 안 함) — 플러그인이 `hooks/hooks.json` 으로 직접 선언 |
-| `github-autopilot/hooks/guard-pr-base.sh` | `${CLAUDE_PLUGIN_ROOT}/hooks/guard-pr-base.sh` (리터럴) |
-| `github-autopilot/hooks/protect-stagnation.sh` | `${CLAUDE_PLUGIN_ROOT}/hooks/protect-stagnation.sh` (리터럴) |
-| `coding-style/hooks/suggest-simplify.sh` | `${CLAUDE_PLUGIN_ROOT}/hooks/suggest-simplify.sh` (리터럴) |
+| `github-autopilot/hooks/guard-pr-base.sh` | **제거만** (재등록 안 함) — 플러그인이 `hooks/hooks.json` 으로 직접 선언 |
+| `github-autopilot/hooks/protect-stagnation.sh` | **제거만** (재등록 안 함) — 플러그인이 `hooks/hooks.json` 으로 직접 선언 |
+| `coding-style/hooks/suggest-simplify.sh` | **제거만** (재등록 안 함) — 플러그인이 `hooks/hooks.json` 으로 직접 선언 |
 | `git-utils/scripts/default-branch-guard-hook.sh` (또는 구버전 atelier 동명 스크립트) | `atelier git guard write ...` (§"git 모듈" 등록 형식) |
 | `git-utils/scripts/default-branch-guard-commit-hook.sh` (또는 구버전 atelier 동명 스크립트) | `atelier git guard commit ...` (§"git 모듈" 등록 형식) |
 

--- a/plugins/atelier/commands/setup.md
+++ b/plugins/atelier/commands/setup.md
@@ -15,7 +15,7 @@ allowed-tools: ["Bash", "Read", "Write", "Edit", "AskUserQuestion"]
 
 setup 이 settings.json 에 등록하는 hook 은 **CLI 직접 호출 형태뿐**입니다 (`atelier git guard write ...` — 바이너리가 PATH 에서 해석되므로 버전 비의존). 이는 setup 시점에 프로젝트별 값(예: `--default-branch <감지값>`)을 주입해야 하기 때문입니다.
 
-> 플러그인에 번들된 `.sh` hook(`check-cli-version`·`guard-pr-base`·`protect-stagnation`·`suggest-simplify`)은 setup 이 등록하지 않습니다 — 플러그인이 `hooks/hooks.json` 으로 직접 선언하고, 각 스크립트가 내부에서 self-gate(autopilot config / 명령 패턴 / style 워터마크)합니다. `${CLAUDE_PLUGIN_ROOT}` 가 hook 실행 시점에 활성 버전으로 해석돼 frozen 이 없습니다 (`.claude/rules/tool-layer-boundary.md`).
+> 플러그인에 번들된 `.sh` hook(`check-cli-version`·`guard-pr-base`·`protect-stagnation`·`suggest-simplify`)은 플러그인이 `hooks/hooks.json` 으로 직접 선언합니다. 차단형(`guard-pr-base`·`protect-stagnation`)은 autopilot config·명령 패턴으로 self-gate 해 비대상 세션에서 no-op 이고, advisory형(`check-cli-version`·`suggest-simplify`)은 비차단이라 모든 세션에 적용돼도 안전합니다. `${CLAUDE_PLUGIN_ROOT}` 가 hook 실행 시점에 활성 버전으로 해석돼 frozen 이 없습니다 (`.claude/rules/tool-layer-boundary.md`).
 
 ## Step 0 — atelier CLI 보장 (공통 선행)
 
@@ -39,7 +39,7 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/ensure-binary.sh"
 |---|---|---|
 | `git` | GitHub 인증 확인 + `~/.git-workflow-env` 생성 + Default Branch Guard hook | git-utils setup |
 | `autopilot` | `github-autopilot.local.md` 생성 (autopilot hook 은 plugin-declared, config 로 self-gate) | github-autopilot setup |
-| `style` | `~/.claude/CLAUDE.md` 코딩 원칙 병합 (Stop hook 은 plugin-declared, 워터마크로 self-gate) | coding-style setup |
+| `style` | `~/.claude/CLAUDE.md` 코딩 원칙 병합 | coding-style setup |
 | `workflow` | `.claude/rules/agent-design-principles.md` 룰 설치 | workflow-guide install |
 | `all` | 위 네 가지 전부 | 신규 |
 
@@ -87,10 +87,8 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/ensure-binary.sh"
 
 ## Step 2b — autopilot 모듈
 
-프로젝트 설정 파일 `github-autopilot.local.md` 를 생성합니다 (기존 스키마/경로 동일 — 호환).
+프로젝트 설정 파일 `github-autopilot.local.md` 를 생성합니다 (기존 스키마/경로 동일 — 호환). autopilot hook 은 이 config 존재로 self-gate 하므로 생성만으로 활성화됩니다.
 
-> autopilot hook(`guard-pr-base`·`protect-stagnation`)은 setup 이 등록하지 않습니다 — 플러그인이 `hooks/hooks.json` 으로 직접 선언하고, 두 스크립트가 `github-autopilot.local.md` 존재로 self-gate 합니다. 따라서 config 파일 생성만으로 활성화됩니다.
->
 > autopilot SQLite store(ledger/task DB)는 기존 스키마/경로를 계승하므로 마이그레이션 불필요.
 
 ## Step 2c — workflow 모듈
@@ -102,11 +100,9 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/ensure-binary.sh"
 
 ## Step 2d — style 모듈
 
-`~/.claude/CLAUDE.md` 에 코딩 원칙 템플릿을 병합합니다 (워터마크 기반 중복 확인 — 기존 coding-style 로직 동일):
+`~/.claude/CLAUDE.md` 에 코딩 원칙 템플릿을 병합합니다 (워터마크 기반 중복 확인 — 기존 coding-style 로직 동일).
 
 - 템플릿 원본: `${CLAUDE_PLUGIN_ROOT}/templates/claude-md/CLAUDE.md`
-
-> `/simplify` 제안 Stop hook(`suggest-simplify`)은 setup 이 등록하지 않습니다 — 플러그인이 `hooks/hooks.json` 으로 직접 선언하고, 스크립트가 `~/.claude/CLAUDE.md` 의 `[coding-style:begin]` 워터마크로 self-gate 합니다. 따라서 템플릿 병합만으로 활성화됩니다.
 
 ## Step 3 — 기존 hook 마이그레이션 (frozen → atelier)
 

--- a/plugins/atelier/commands/setup.md
+++ b/plugins/atelier/commands/setup.md
@@ -38,8 +38,8 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/ensure-binary.sh"
 | 선택 | 수행 동작 | 출처 |
 |---|---|---|
 | `git` | GitHub 인증 확인 + `~/.git-workflow-env` 생성 + Default Branch Guard hook | git-utils setup |
-| `autopilot` | `github-autopilot.local.md` 생성 + autopilot hook 3개 등록 | github-autopilot setup |
-| `style` | `~/.claude/CLAUDE.md` 코딩 원칙 + Stop hook 등록 | coding-style setup |
+| `autopilot` | `github-autopilot.local.md` 생성 (autopilot hook 은 plugin-declared, config 로 self-gate) | github-autopilot setup |
+| `style` | `~/.claude/CLAUDE.md` 코딩 원칙 병합 (Stop hook 은 plugin-declared, 워터마크로 self-gate) | coding-style setup |
 | `workflow` | `.claude/rules/agent-design-principles.md` 룰 설치 | workflow-guide install |
 | `all` | 위 네 가지 전부 | 신규 |
 
@@ -87,9 +87,9 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/ensure-binary.sh"
 
 ## Step 2b — autopilot 모듈
 
-1. 프로젝트 설정 파일 `github-autopilot.local.md` 생성 (기존 스키마/경로 동일 — 호환).
+프로젝트 설정 파일 `github-autopilot.local.md` 를 생성합니다 (기존 스키마/경로 동일 — 호환).
 
-> autopilot hook(`guard-pr-base`·`protect-stagnation`)은 setup 이 등록하지 않습니다 — 플러그인이 `hooks/hooks.json` 으로 직접 선언하고, 두 스크립트가 `github-autopilot.local.md` 존재로 self-gate 합니다. 따라서 위 1번(config 파일 생성)만으로 활성화됩니다.
+> autopilot hook(`guard-pr-base`·`protect-stagnation`)은 setup 이 등록하지 않습니다 — 플러그인이 `hooks/hooks.json` 으로 직접 선언하고, 두 스크립트가 `github-autopilot.local.md` 존재로 self-gate 합니다. 따라서 config 파일 생성만으로 활성화됩니다.
 >
 > autopilot SQLite store(ledger/task DB)는 기존 스키마/경로를 계승하므로 마이그레이션 불필요.
 
@@ -102,10 +102,11 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/ensure-binary.sh"
 
 ## Step 2d — style 모듈
 
-1. `~/.claude/CLAUDE.md` 에 코딩 원칙 템플릿 병합 (워터마크 기반 중복 확인 — 기존 coding-style 로직 동일):
-   - 템플릿 원본: `${CLAUDE_PLUGIN_ROOT}/templates/claude-md/CLAUDE.md`
+`~/.claude/CLAUDE.md` 에 코딩 원칙 템플릿을 병합합니다 (워터마크 기반 중복 확인 — 기존 coding-style 로직 동일):
 
-> `/simplify` 제안 Stop hook(`suggest-simplify`)은 setup 이 등록하지 않습니다 — 플러그인이 `hooks/hooks.json` 으로 직접 선언하고, 스크립트가 `~/.claude/CLAUDE.md` 의 `[coding-style:begin]` 워터마크로 self-gate 합니다. 따라서 위 1번(템플릿 병합)만으로 활성화됩니다.
+- 템플릿 원본: `${CLAUDE_PLUGIN_ROOT}/templates/claude-md/CLAUDE.md`
+
+> `/simplify` 제안 Stop hook(`suggest-simplify`)은 setup 이 등록하지 않습니다 — 플러그인이 `hooks/hooks.json` 으로 직접 선언하고, 스크립트가 `~/.claude/CLAUDE.md` 의 `[coding-style:begin]` 워터마크로 self-gate 합니다. 따라서 템플릿 병합만으로 활성화됩니다.
 
 ## Step 3 — 기존 hook 마이그레이션 (frozen → atelier)
 

--- a/plugins/atelier/hooks/hooks.json
+++ b/plugins/atelier/hooks/hooks.json
@@ -10,6 +10,32 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/guard-pr-base.sh"
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/protect-stagnation.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/suggest-simplify.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/plugins/atelier/hooks/protect-stagnation.sh
+++ b/plugins/atelier/hooks/protect-stagnation.sh
@@ -13,6 +13,10 @@
 
 set -e
 
+# plugin-declared 라 모든 Bash 호출에서 실행된다. autopilot 프로젝트가 아니면
+# stdin·jq·정규식 전부 건너뛰고 즉시 종료 (stagnation 체크는 autopilot ledger 가 전제).
+[ -f "${CLAUDE_PROJECT_DIR:-.}/github-autopilot.local.md" ] || exit 0
+
 input=$(cat)
 
 # jq 부재 시 best-effort 통과 (가드가 머지 자체를 막지 않게)

--- a/plugins/atelier/hooks/suggest-simplify.sh
+++ b/plugins/atelier/hooks/suggest-simplify.sh
@@ -2,9 +2,14 @@
 # Stop hook: 코드/문서 변경이 있으면 /simplify 검토를 제안합니다.
 #
 # 동작:
+#   0. style 모듈 opt-in 확인 (~/.claude/CLAUDE.md 워터마크) — 없으면 종료
 #   1. git status --porcelain으로 작업 트리 변경사항 확인
 #   2. 변경된 파일이 있으면 /simplify 추천 메시지 출력
 #   3. 변경이 없으면 무출력 (exit 0)
+
+# plugin-declared 라 모든 세션에서 실행된다. style 모듈을 설치한 사용자
+# (~/.claude/CLAUDE.md 에 coding-style 워터마크가 병합됨)에게만 제안한다.
+grep -q '\[coding-style:begin\]' "${HOME}/.claude/CLAUDE.md" 2>/dev/null || exit 0
 
 # git repo가 아니면 종료
 git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0

--- a/plugins/atelier/hooks/suggest-simplify.sh
+++ b/plugins/atelier/hooks/suggest-simplify.sh
@@ -2,14 +2,9 @@
 # Stop hook: 코드/문서 변경이 있으면 /simplify 검토를 제안합니다.
 #
 # 동작:
-#   0. style 모듈 opt-in 확인 (~/.claude/CLAUDE.md 워터마크) — 없으면 종료
 #   1. git status --porcelain으로 작업 트리 변경사항 확인
 #   2. 변경된 파일이 있으면 /simplify 추천 메시지 출력
 #   3. 변경이 없으면 무출력 (exit 0)
-
-# plugin-declared 라 모든 세션에서 실행된다. style 모듈을 설치한 사용자
-# (~/.claude/CLAUDE.md 에 coding-style 워터마크가 병합됨)에게만 제안한다.
-grep -q '\[coding-style:begin\]' "${HOME}/.claude/CLAUDE.md" 2>/dev/null || exit 0
 
 # git repo가 아니면 종료
 git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0


### PR DESCRIPTION
## 왜

플러그인 번들 `.sh` hook 들이 `~/.claude/settings.json` 에 **버전 절대경로로 frozen** 되는 문제의 근본 원인을 찾았어요.

슬래시 커맨드(`/atelier:setup`)는 **로드 시점에 본문의 `${CLAUDE_PLUGIN_ROOT}` 를 그때의 버전 절대경로로 expand** 합니다 (단일 따옴표도 못 막아요 — 셸 파싱보다 먼저 일어남). 그래서 setup 이 `.sh` shim 을 `hook register` 로 등록하면 settings.json 에 `.../atelier/0.4.3/hooks/...` 같은 경로가 박히고, 플러그인이 업데이트돼도 그 경로에 묶여요. (사용자 settings 가 0.4.3 에 frozen 됐던 정확한 원인)

직전 PR(#799)에서 `check-cli-version` 만 plugin-declared 로 옮겨 면역시켰는데, 같은 병을 가진 나머지 3종도 옮겨 **setup 의 `.sh` hook 등록을 전면 제거**합니다.

## 무엇을

`hooks/hooks.json` 의 `${CLAUDE_PLUGIN_ROOT}` 는 Claude Code 가 hook **실행 시점**에 활성 버전으로 해석하므로 frozen 이 없어요. 모든 번들 `.sh` hook 을 이 방식으로 통일하고, 항상 켜져도 안전하도록 각 스크립트가 **self-gate** 하게 했어요.

## 어떻게

- **`hooks/hooks.json`**: `PreToolUse "Bash"`(guard-pr-base + protect-stagnation), `Stop "*"`(suggest-simplify) 선언 추가.
- **`protect-stagnation.sh`**: early `github-autopilot.local.md` 게이트 추가 — 모든 Bash 호출에서 실행되므로 비 autopilot 프로젝트는 stdin·jq·정규식 전에 즉시 종료(전역 오버헤드 0, stagnation 은 autopilot ledger 가 전제).
- **`suggest-simplify.sh`**: `~/.claude/CLAUDE.md` 의 `[coding-style:begin]` 워터마크 게이트 추가 — **style 모듈 opt-in 보존**(설치 안 한 사용자에겐 무음).
- **`guard-pr-base.sh`**: 변경 없음 (이미 `github-autopilot.local.md` 로 self-gate).
- **`commands/setup.md`**: Step 2b(autopilot)·2d(style)의 hook 등록 제거 → 모듈은 config 파일 생성/템플릿 병합만 하고 self-gate 가 활성화. Step 3 마이그레이션 표 3행 모두 "제거만". intro/Step 0 갱신.
- **`tool-layer-boundary.md`**: 직전 PR 에서 제가 적은 "차단(exit 2) hook 은 setup-register" 노트를 교정 — 진짜 기준은 **setup 시점 값 주입 필요 여부**(git guard `--default-branch`). 번들 `.sh` 는 차단 여부와 무관하게 plugin-declared + self-gate.

## 확인 방법

self-gate 수동 검증:
- **protect-stagnation**: autopilot config 없는 dir + `autopilot task claim` 명령 → 즉시 exit 0 (jq spawn 안 함) ✅
- **suggest-simplify**: 워터마크 없는 `$HOME` → 무음 exit 0 / 워터마크 있고 변경 있음 → 제안 출력 ✅
- `make validate-ci` → 0 failed (645 passed)

## 결과

setup 은 이제 settings.json 에 **CLI 직접 호출 hook(git guard)만** 등록합니다 — `--default-branch <감지값>` 주입이 필요해서요. 그 외 모든 번들 `.sh` hook 은 plugin-declared 라 frozen 이 구조적으로 불가능해졌어요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)