### PR TITLE
docs(atelier): adopt upstream-style trigger descriptions for grill/brainstorm

### DIFF
--- a/plugins/atelier/skills/brainstorm/SKILL.md
+++ b/plugins/atelier/skills/brainstorm/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: brainstorm
-description: 막연한 아이디어에서 출발해 대화로 완전한 설계와 스펙을 만들어내는 brainstorm 스킬. "같이 brainstorm 하자 / 설계 같이 잡자 / 막연한데 방향 잡아줘 / 무에서 시작하자 / 뭘 만들지부터 정하자" 처럼 아직 구체안이 없을 때 사용합니다. 슬래시로 직접 호출하거나 모델이 모호한 출발점을 감지하면 제안합니다. 이미 있는 계획·설계를 심문·검증하는 요청은 `grill` 스킬을 씁니다.
+description: You MUST use this before any creative work - creating features, building components, adding functionality, or modifying behavior. Explores user intent, requirements and design before implementation.
 version: 1.0.0
 ---
 

--- a/plugins/atelier/skills/grill/SKILL.md
+++ b/plugins/atelier/skills/grill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: grill
-description: 이미 있는 계획·설계·접근안의 빈틈을 대화로 찾아내는 심문 스킬. "이 계획 심문해줘 / grill me / 스트레스 테스트 해줘 / 이 설계 도전해줘 / 빈틈 찾아줘 / 가정 깨봐" 처럼 검토할 구체안이 이미 있을 때 사용합니다. 슬래시로 직접 호출하거나 모델이 미검증 계획을 감지하면 제안합니다. 아직 구체안이 없어 무에서 설계를 시작하는 요청은 `brainstorm` 스킬을 씁니다.
+description: Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions "grill me".
 version: 1.0.0
 ---
 


### PR DESCRIPTION
## Summary

grill·brainstorm 의 `description` frontmatter 를 포팅 원본인 [obra/superpowers](https://github.com/obra/superpowers) 의 phrasing 으로 교체합니다.

- **brainstorm**: `You MUST use this before any creative work - ...` — 모델이 구현 전 설계 단계를 선제적으로 제안하도록 imperative 톤.
- **grill**: plan/design stress-test 트리거를 직접 서술 ("grill me").

## Trade-off (검토됨)

기존 한국어 description 에 있던 상호 disambiguation 문장("이미 있는 계획은 grill / 무에서는 brainstorm")은 빠집니다. grill 의 "stress-test a plan / get grilled" 와 brainstorm 의 "before any creative work" 가 역할을 충분히 가르므로 의도된 단순화입니다.

## Verification

- `make validate-ci` → 0 failed (frontmatter·길이·민감데이터 검증 통과)

🤖 Generated with [Claude Code](https://claude.com/claude-code)