### PR TITLE
fix(git-core-guard): protect conventional defaults without detection

### DIFF
--- a/plugins/atelier/cli/Cargo.lock
+++ b/plugins/atelier/cli/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "atelier"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/plugins/atelier/cli/src/git/core/guard.rs
+++ b/plugins/atelier/cli/src/git/core/guard.rs
@@ -16,6 +16,22 @@ static GIT_COMMIT_PATTERN: LazyLock<Regex> =
 /// renders it), not the CLI router that merely forwards the flag.
 pub const DEFAULT_CREATE_BRANCH_SCRIPT: &str = "git switch -c";
 
+/// Branch names that are conventional repository defaults across most repos.
+/// These are protected unconditionally — independent of detection and of any
+/// `--default-branch` pin — so a single user-scope guard hook can't leave a
+/// repo's real default unprotected just because the pin was detected in a
+/// different repo (#810). Non-standard defaults (e.g. a custom branch name) are
+/// still covered by per-repo detection and the pin, both unioned in below.
+const CONVENTIONAL_DEFAULTS: &[&str] = &["main", "master", "develop", "trunk"];
+
+/// Appends `branch` to `set` if non-empty and not already present, keeping the
+/// protected set free of duplicates without imposing an ordering.
+fn push_unique(set: &mut Vec<String>, branch: &str) {
+    if !branch.is_empty() && !set.iter().any(|b| b == branch) {
+        set.push(branch.to_string());
+    }
+}
+
 /// Replaces single-/double-quoted segments with a space so quoted text
 /// arguments can't false-positive the commit matcher — on a protected branch,
 /// `gh issue create --body "... git commit ..."` must not be treated as a
@@ -196,30 +212,44 @@ impl GuardService for RealGuardService<'_> {
             return pass(Some("not a git repository"));
         }
 
-        // Resolve default branch. An empty/whitespace value (e.g. a setup that
-        // detected nothing and recorded a bare `--default-branch`) is treated as
-        // absence — not a real branch named "" — so the guard falls back to
-        // detection and still protects the true default instead of silently
-        // protecting nothing.
-        let default_branch = match input.default_branch.as_deref().map(str::trim) {
-            Some(b) if !b.is_empty() => b.to_string(),
-            // Read-only detection — the guard must not mutate repo state
-            // (no `git remote set-head`) on every tool invocation (#779).
-            _ => match self.git.detect_default_branch() {
-                Ok(b) => b,
-                Err(_) => return pass(Some("could not detect default branch")),
-            },
-        };
+        // Resolve the default-branch inputs. An empty/whitespace pin (e.g. a
+        // setup that detected nothing and recorded a bare `--default-branch`) is
+        // treated as absence — not a real branch named "".
+        let pin = input
+            .default_branch
+            .as_deref()
+            .map(str::trim)
+            .filter(|b| !b.is_empty());
+        // Read-only detection — the guard must not mutate repo state (no
+        // `git remote set-head`) on every tool invocation (#779). Detection runs
+        // even when a pin is present so a global hook's pin from one repo can't
+        // suppress another repo's real default (#810); a failure is non-fatal
+        // because the conventional defaults below still cover the common cases.
+        let detected = self.git.detect_default_branch().ok();
 
-        // Protected set: default + develop + extras.
-        let mut protected: Vec<String> = vec![default_branch.clone(), "develop".to_string()];
+        // Protected set: conventional defaults (always) ∪ detected ∪ pin ∪
+        // extras. The union is what makes a single user-scope hook safe across
+        // repos with different defaults (#810).
+        let mut protected: Vec<String> = Vec::new();
+        for name in CONVENTIONAL_DEFAULTS {
+            push_unique(&mut protected, name);
+        }
+        if let Some(b) = &detected {
+            push_unique(&mut protected, b);
+        }
+        if let Some(b) = pin {
+            push_unique(&mut protected, b);
+        }
         if let Some(extras) = &input.protected_branches {
             for b in extras {
-                if !protected.contains(b) {
-                    protected.push(b.clone());
-                }
+                push_unique(&mut protected, b);
             }
         }
+
+        // Default branch reported back (informational): the pin if explicit,
+        // else detection. May be `None` when neither is available yet the guard
+        // still blocks on a conventional default.
+        let default_branch = pin.map(str::to_string).or(detected);
 
         // Guard 2: special state (rebase/merge) → pass. The snapshot also
         // carries the current branch, so guards 2–3 and the branch check cost
@@ -241,7 +271,7 @@ impl GuardService for RealGuardService<'_> {
                 allowed: true,
                 reason: None,
                 current_branch: Some(current_branch),
-                default_branch: Some(default_branch),
+                default_branch,
             };
         }
 
@@ -268,7 +298,7 @@ impl GuardService for RealGuardService<'_> {
             allowed: false,
             reason: Some(reason),
             current_branch: Some(current_branch),
-            default_branch: Some(default_branch),
+            default_branch,
         }
     }
 }

--- a/plugins/atelier/cli/src/git/core/guard.rs
+++ b/plugins/atelier/cli/src/git/core/guard.rs
@@ -212,6 +212,19 @@ impl GuardService for RealGuardService<'_> {
             return pass(Some("not a git repository"));
         }
 
+        // Guards 2–3: special git state short-circuits *before* any
+        // default-branch work, so a rebase/merge/detached invocation skips the
+        // detection subprocess and the protected-set allocation entirely. The
+        // snapshot also carries the current branch, so the branch check below
+        // reuses it rather than spawning a second subprocess (#778).
+        let state = self.git.get_special_state();
+        if state.rebase || state.merge {
+            return pass(Some("special git state (rebase/merge)"));
+        }
+        if state.detached() {
+            return pass(Some("detached HEAD"));
+        }
+
         // Resolve the default-branch inputs. An empty/whitespace pin (e.g. a
         // setup that detected nothing and recorded a bare `--default-branch`) is
         // treated as absence — not a real branch named "".
@@ -250,19 +263,6 @@ impl GuardService for RealGuardService<'_> {
         // else detection. May be `None` when neither is available yet the guard
         // still blocks on a conventional default.
         let default_branch = pin.map(str::to_string).or(detected);
-
-        // Guard 2: special state (rebase/merge) → pass. The snapshot also
-        // carries the current branch, so guards 2–3 and the branch check cost
-        // one `get_special_state` round-trip, not a second subprocess (#778).
-        let state = self.git.get_special_state();
-        if state.rebase || state.merge {
-            return pass(Some("special git state (rebase/merge)"));
-        }
-
-        // Guard 3: detached HEAD → pass.
-        if state.detached() {
-            return pass(Some("detached HEAD"));
-        }
 
         let current_branch = state.current_branch;
 

--- a/plugins/atelier/cli/tests/git_core_guard.rs
+++ b/plugins/atelier/cli/tests/git_core_guard.rs
@@ -141,9 +141,63 @@ fn explicit_default_branch_used() {
 
 #[test]
 fn detect_failure_passes_safe_mode() {
+    // Detection failed AND the current branch is not a conventional default:
+    // the guard can't prove this is a protected branch, so it allows (safe
+    // mode). Conventional names are handled separately (see below).
     let mut git = MockGit::default();
+    git.current_branch = Box::new(|| "wip".to_string());
     git.detect_default_branch = Box::new(|| Err("no remote".to_string()));
     assert!(check(git, &base_input()).allowed);
+}
+
+#[test]
+fn conventional_default_blocked_without_detection() {
+    // #810: a conventional default name must be protected even when detection
+    // fails and no pin is supplied — a branch literally named "main" is almost
+    // certainly the default regardless of remote state.
+    let mut git = MockGit::default();
+    git.current_branch = Box::new(|| "main".to_string());
+    git.detect_default_branch = Box::new(|| Err("no remote".to_string()));
+    assert!(!check(git, &base_input()).allowed);
+}
+
+#[test]
+fn trunk_protected_as_conventional() {
+    // `trunk` is a conventional default; protected without pin or extras.
+    let mut git = MockGit::default();
+    git.current_branch = Box::new(|| "trunk".to_string());
+    git.detect_default_branch = Box::new(|| Ok("main".to_string()));
+    assert!(!check(git, &base_input()).allowed);
+}
+
+#[test]
+fn foreign_pin_does_not_unprotect_local_default() {
+    // #810 core: a user-scope hook pins `--default-branch develop` (detected in
+    // another repo), but this repo's default is `master`. The pin must not
+    // suppress protection of this repo's real default — being on `master` is
+    // still blocked because (a) master is conventional and (b) detection runs
+    // even with a pin and is unioned in.
+    let mut git = MockGit::default();
+    git.current_branch = Box::new(|| "master".to_string());
+    git.detect_default_branch = Box::new(|| Ok("master".to_string()));
+    let mut input = base_input();
+    input.default_branch = Some("develop".to_string());
+    assert!(
+        !check(git, &input).allowed,
+        "a pin from another repo must not unprotect this repo's default branch"
+    );
+}
+
+#[test]
+fn pin_supplements_non_conventional_default() {
+    // A pin for a non-conventional default (e.g. a repo whose default is a
+    // custom name) is still honored on top of conventional + detected.
+    let mut git = MockGit::default();
+    git.current_branch = Box::new(|| "release-train".to_string());
+    git.detect_default_branch = Box::new(|| Ok("main".to_string()));
+    let mut input = base_input();
+    input.default_branch = Some("release-train".to_string());
+    assert!(!check(git, &input).allowed);
 }
 
 #[test]

--- a/plugins/atelier/commands/setup.md
+++ b/plugins/atelier/commands/setup.md
@@ -70,6 +70,7 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/ensure-binary.sh"
    DEFAULT_BRANCH=$( (cd "$PROJECT_DIR" && gh repo view --json defaultBranchRef -q .defaultBranchRef.name) 2>/dev/null || true )
    ```
    gh 조회가 실패해 `--default-branch` 를 **생략**해도, (a) 의 warm-up 덕분에 guard 의 런타임 readonly 감지(`origin/HEAD` → main/develop/master)가 기본 브랜치를 해결한다.
+   > `--default-branch` pin 은 **대체가 아니라 보강**이다 (#810). guard 는 pin 유무와 무관하게 관례 기본값(`main/master/develop/trunk`)과 런타임 readonly 감지 결과를 항상 보호 대상에 합집합으로 포함하므로, 한 repo 에서 감지한 pin 이 user scope hook 에 박혀도 다른 repo 의 기본 브랜치 보호를 막지 않는다. pin 은 비표준 기본 브랜치(예: 커스텀 이름)를 추가 보강하는 힌트일 뿐이다.
 4. Default Branch Guard hook 2종 등록 — `.sh` 경로가 아니라 **CLI 커맨드를 직접** 기록합니다.
    감지값이 비어있으면 `--default-branch` 플래그 자체를 빼야 합니다 (빈 플래그를 박으면 hook 실행 시 clap 이
    값 누락으로 exit 2 → 모든 편집 차단되거나, 빈 브랜치로 guard 가 무력화됨):
@@ -187,7 +188,7 @@ alias git-utils='atelier git'
 - 이후 Step 을 중단하고 Rust toolchain 설치를 안내합니다 (`rustup`)
 
 **기본 브랜치 감지 실패 (remote 미설정):**
-- `--default-branch` 없이 guard 를 등록하고, 비표준 기본 브랜치 repo 에서는 보호가 제한될 수 있음을 안내합니다
+- `--default-branch` 없이 guard 를 등록합니다. 관례 기본값(`main/master/develop/trunk`)은 감지 없이도 항상 보호되므로(#810), 비표준 기본 브랜치(예: 커스텀 이름) repo 에서만 보호가 제한될 수 있음을 안내합니다
 
 **settings.json 이 깨진 JSON 인 경우:**
 - `hook register` 가 덮어쓰기를 거부하고 에러를 반환합니다 — 사용자에게 파일 상태를 보여주고 수동 복구를 안내합니다


### PR DESCRIPTION
## Summary

Fix issue #810 where a user-scope guard hook with a `--default-branch` pin from one repository could inadvertently leave another repository's default branch unprotected. The guard now unconditionally protects conventional default branch names (`main`, `master`, `develop`, `trunk`) regardless of detection success or pin configuration.

## Key Changes

- **Unconditional conventional defaults protection**: Added `CONVENTIONAL_DEFAULTS` constant containing standard branch names that are always protected, independent of detection or pin configuration
- **Union-based protected set**: Changed from a single resolved default branch to a union of:
  - Conventional defaults (always included)
  - Detected default (if detection succeeds)
  - Pinned default (if explicitly configured)
  - Extra protected branches (from config)
- **Decoupled pin from default reporting**: The `--default-branch` pin now supplements rather than replaces detection. The reported default branch is the pin if explicit, otherwise the detected value
- **Helper function**: Added `push_unique()` to maintain a duplicate-free protected set without imposing ordering constraints
- **Test coverage**: Added four new test cases covering:
  - Conventional defaults blocked even when detection fails
  - `trunk` protected as a conventional default
  - Foreign pins not suppressing local defaults (#810 core scenario)
  - Non-conventional custom defaults still honored via pin
- **Documentation**: Updated setup guide to clarify that `--default-branch` is a supplement, not a replacement, and explain the union behavior for cross-repo safety

## Implementation Details

The core fix ensures that a single user-scope hook can safely operate across repositories with different default branches. Previously, if a hook was configured with `--default-branch develop` (detected in repo A), it would only protect `develop` and `master` in repo B, leaving repo B's actual default unprotected if it was neither of those. Now, repo B's actual default (whether `main`, `master`, or detected at runtime) is always protected because conventional names are always in the protected set and detection runs independently of the pin.

https://claude.ai/code/session_019xPoMfGpK8628tfQoScYq2