### PR TITLE
fix(atelier): add autonomous-mode triggers to orchestrator

### DIFF
--- a/plugins/atelier/skills/orchestrator/SKILL.md
+++ b/plugins/atelier/skills/orchestrator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: orchestrator
-description: Use this skill for any multi-unit work delegated to sub-agents, agent-teams, or worktrees — parallel fan-out, sequential pipelines, long-running agent teams, document deliverables (writing reports, specs, or write-up docs is also delegated Write work), multi-branch research and investigation (codebase surveys, side-effect analysis, comparing options — read-only work counts too), or any moment the main agent is about to use Edit/Write directly (delegate instead). Scope is set by scale, not by kind. Triggers include "여러 작업 병렬로", "동시에 처리", "에이전트 나눠서", "worktree로 분리", "위임해서", "팀으로 작업", "리포트 작성", "보고서로 정리", "스펙 문서 작성", "분석 결과 문서화", "조사해줘", "리서치", "코드베이스 파악", "영향 범위 분석", "사이드이펙트 조사", "여러 방안 비교", "delegate", "parallel agents", "fan-out", "agent team", "sub-agent", "dispatch multiple", "split into tasks", "run in parallel", "write a report", "draft a spec", "write up findings", "research", "investigate", "survey the codebase", "analyze impact", "compare approaches".
+description: Use this skill for any multi-unit work delegated to sub-agents, agent-teams, or worktrees — parallel fan-out, sequential pipelines, long-running agent teams, autonomous self-driving runs (decompose→dispatch→merge without human intervention), document deliverables (writing reports, specs, or write-up docs is also delegated Write work), multi-branch research and investigation (codebase surveys, side-effect analysis, comparing options — read-only work counts too), or any moment the main agent is about to use Edit/Write directly (delegate instead). Scope is set by scale, not by kind. Triggers include "자율주행", "자율주행모드", "자율 모드", "자율 주행으로", "알아서 끝까지", "여러 작업 병렬로", "동시에 처리", "에이전트 나눠서", "worktree로 분리", "위임해서", "팀으로 작업", "리포트 작성", "보고서로 정리", "스펙 문서 작성", "분석 결과 문서화", "조사해줘", "리서치", "코드베이스 파악", "영향 범위 분석", "사이드이펙트 조사", "여러 방안 비교", "autonomous mode", "self-driving", "hands-off run", "delegate", "parallel agents", "fan-out", "agent team", "sub-agent", "dispatch multiple", "split into tasks", "run in parallel", "write a report", "draft a spec", "write up findings", "research", "investigate", "survey the codebase", "analyze impact", "compare approaches".
 version: 0.1.0
 ---
 
@@ -10,6 +10,7 @@ version: 0.1.0
 
 이 스킬을 트리거해야 하는 상황:
 
+- 사용자가 **자율주행 모드를 언급** ("자율주행모드로", "자율 주행으로 진행해", "알아서 끝까지 해줘", "autonomous mode") — 자율 루프(분해→위임→머지 self-drive)는 오케스트레이터의 기본 동작이므로 이 스킬로 진입한다 (`references/autonomous-driving.md`)
 - 사용자가 **2개 이상의 독립 작업**을 한 번에 요청 ("A랑 B랑 C 같이 해줘", "동시에 처리해줘")
 - **병렬 fan-out**이 가능해 보일 때 ("여러 파일 동시에", "병렬로", "parallel", "in parallel")
 - **sub-agent / agent-team / worktree 위임**을 명시적으로 요청 ("나눠서", "팀으로", "에이전트 여러 개", "delegate", "dispatch")


### PR DESCRIPTION
## 문제

오케스트레이터 스킬이 "자율주행모드" 언급에 발동하지 않는다. 스킬 발동을 결정하는 frontmatter `description`에 자율주행 계열 키워드가 처음부터 한 번도 들어간 적이 없었다 — 본문은 "기본적으로 자율 주행한다"고 선언하고 `references/autonomous-driving.md`까지 두고 있지만, 본문은 트리거 판정에 쓰이지 않는다.

## 변경 내용

`plugins/atelier/skills/orchestrator/SKILL.md`:

- `description`에 자율주행 트리거 문구 추가: "자율주행", "자율주행모드", "자율 모드", "자율 주행으로", "알아서 끝까지", "autonomous mode", "self-driving", "hands-off run" + 스킬 범위 서술에 "autonomous self-driving runs (decompose→dispatch→merge without human intervention)" 명시
- 본문 "When to use (트리거 케이스)" 목록 맨 앞에 자율주행 모드 언급 케이스 추가, `references/autonomous-driving.md`로 연결

## 검증

- `make validate-ci` 통과 (Passed 162 / Failed 0 — 경고 1건은 git 스킬의 기존 건으로 이번 변경과 무관)
- SKILL.md 436줄로 validate의 500줄 상한 이내

---
_Generated by [Claude Code](https://claude.ai/code/session_01QxHPqDf2r2uC5dv7VmNuK5)_