### PR TITLE
docs(atelier): add dispatch-time worktree creation guard

### DIFF
--- a/plugins/atelier/skills/orchestrator/references/autonomous-driving.md
+++ b/plugins/atelier/skills/orchestrator/references/autonomous-driving.md
@@ -64,6 +64,9 @@ while not satisfied(contract.done_when) and loop_count < contract.max_loops:
              isolation=("worktree" if heavy else None),  #   무거운: base = epic 브랜치, 편집은 격리 subagent
              run_in_background=true,                     #   경량: 격리할 tracked 쓰기가 없다.
              model=main_allocates_per_task)              #         대신 산출 경로 계약을 prompt에 싣는다
+                                                      # 무거운 경로의 worktree dispatch는 직렬로 —
+                                                      # 매 dispatch 직후 assert_worktree_created()
+                                                      # (worktree-lifecycle.md §dispatch 생성 가드)
     log_decision("병렬/순차 + 위임 형태(subagent/team) + 모델 배분", ...)
     results = await_completion_notifications()        # 모니터 (sleep/poll 금지)
     if heavy: assert_topology()                       # 가드: branch == epic + status clean (아래)
@@ -226,7 +229,7 @@ HITL(opt-out) 모드에서 금지된 행위가 자율 모드(기본)에서는 **
 
 ### 토폴로지 가드 (assert_topology)
 
-자율 모드는 보고 없이 연속 진행하므로, sub-agent의 격리 이탈로 메인 working tree가 오염되면 그것이 후속 dispatch/머지로 전파되기 전에 잡아야 한다. **매 sub-agent 완료 알림 수신 직후 + 매 머지 직후** 실행한다 — 가드 명령과 복구 절차는 `merge-coordinator.md §토폴로지 가드`가 단일 출처다.
+자율 모드는 보고 없이 연속 진행하므로, sub-agent의 격리 이탈로 메인 working tree가 오염되면 그것이 후속 dispatch/머지로 전파되기 전에 잡아야 한다. **매 sub-agent 완료 알림 수신 직후 + 매 머지 직후** 실행한다 — 가드 명령과 복구 절차는 `merge-coordinator.md §토폴로지 가드`가 단일 출처다. 여기에 더해 **매 worktree dispatch 직후**에는 생성 가드(worktree 등장 + 메인 clean + cwd)를 실행한다 — 동일 batch 다중 dispatch race로 worktree를 못 받은 agent가 메인 트리에서 편집하는 유출은 완료 알림 시점 가드로는 늦게 잡히기 때문이다. 절차는 `worktree-lifecycle.md §dispatch 생성 가드`가 단일 출처다.
 
 **적용 범위: 무거운 경로** (판정: `SKILL.md` §경로 판정 게이트). 경량에서 tracked 편집이 필요해지면 가드를 되살리는 것은 `delegation-patterns.md §경로 전환`의 5단계다.
 
@@ -441,7 +444,7 @@ worktree sub-agent는 인프라 의존 환경(내부 자격증명, live DB, 외�
 4. **opt-out 무시**: 사용자가 HITL을 명시했는데 자율로 밀어붙임 → 자율은 기본이지만 opt-out은 존중한다. 자동 개입을 멈추고 보고 후 결정을 받는다.
 5. **sleep / poll**: 자율 루프에서도 완료 알림을 사용. `Bash sleep` 루프 금지.
 6. **결정 기록 누락 / 로그 커밋**: 근거 없이 자율 주행하면 사후에 "왜"를 복원 불가. 반대로 휘발성 로그를 epic 브랜치에 커밋하면 repo 오염. 분기 결정은 참고 소스와 함께 `log_dir`에 기록하되 `.orchestrator/`는 gitignore, 완료 시 요약으로만 공유.
-7. **토폴로지 가드 생략** (무거운 경로): 완료 알림/머지 후 메인 branch 확인 없이 연속 진행 → 오염된 HEAD 위에서 다음 dispatch의 worktree base가 잘못 잡힘. 경량 경로에서의 생략은 판정 결과이므로 이 안티패턴이 아니다 — 대신 판정 자체를 빠뜨리는 것이 `SKILL.md §안티패턴 15`다.
+7. **토폴로지 가드 생략** (무거운 경로): 완료 알림/머지/dispatch 직후 확인 없이 연속 진행 → 오염된 HEAD 위에서 다음 dispatch의 worktree base가 잘못 잡히거나, worktree를 못 받은 agent의 유출을 커밋된 뒤에야 발견. 같은 batch에 worktree dispatch를 2개 이상 싣는 것 자체가 이 유출의 알려진 원인이다 (`worktree-lifecycle.md §dispatch 생성 가드`). 경량 경로에서의 생략은 판정 결과이므로 이 안티패턴이 아니다 — 대신 판정 자체를 빠뜨리는 것이 `SKILL.md §안티패턴 15`다.
 8. **인프라 의존 테스트를 worktree 검증에 포함**: sub-agent가 접근 불가한 환경 의존 테스트를 worktree에서 실행 → 환경 실패 noise로 검증 신뢰도 저하. 계약의 `integration_verify`로 분리해 메인이 실행.
 9. **게이트 무력화**: 구현 sub-agent의 자기 보고만 믿고 머지하거나, 구현한 agent가 자기 결과를 검토/QA → 자기 검증 편향으로 결함 통과. 게이트 에이전트는 항상 구현자와 다른 sub-agent다.
 10. **검증 테스트·DBA 게이트 생략**: 구현만 머지하고 검증 테스트를 안 만들면 회귀를 잡을 그물이 없다(spec 유무와 무관). DB 접촉 판정에 걸렸는데 reviewer/QA만으로 통과시키면 락·하위 호환·인덱스 누락 같은 DB 특유 위험이 그대로 들어간다.
@@ -476,6 +479,7 @@ worktree sub-agent는 인프라 의존 환경(내부 자격증명, live DB, 외�
 - [ ] 각 작업을 머지 전 **검토 + QA (+ DB 접촉 시 DBA)** 게이트로, 구현자와 다른 agent가 검증하고 전부 pass(AND)여야 머지하는가? (QA가 추가한 검증 테스트 green 포함)
 - [ ] 재위임·게이트 거부·충돌 해결이 `max_redispatch_per_task` 예산을 소모하며 카운트되는가?
 - [ ] (무거운 경로) 같은 파일의 충돌 횟수를 task 예산과 **별개로** 세고 있는가? (`branch-strategy.md §충돌 반복`)
+- [ ] (무거운 경로) worktree dispatch를 한 메시지에 하나씩 직렬화하고, 매 dispatch 직후 생성 가드를 실행하는가? (`worktree-lifecycle.md §dispatch 생성 가드`)
 - [ ] (무거운 경로) 매 sub-agent 완료 직후 + 매 머지 직후 토폴로지 가드를 실행하는가? (`merge-coordinator.md §토폴로지 가드`)
 - [ ] 자율 계약에 경로 판정(경량/무거운)과 그 근거를 실었는가? (`SKILL.md §경로 판정 게이트`)
 - [ ] 계약의 integration_verify를 run_at 시점에 메인이 직접 실행하는가?

--- a/plugins/atelier/skills/orchestrator/references/merge-coordinator.md
+++ b/plugins/atelier/skills/orchestrator/references/merge-coordinator.md
@@ -100,7 +100,7 @@ worktree 브랜치는 PR을 생성하지 않고 epic 브랜치로 수렴 후 삭
 
 ## 토폴로지 가드 (명령·복구 절차 단일 출처)
 
-메인은 항상 epic 브랜치의 메인 working tree에 있어야 한다. 머지 명령이나 sub-agent의 격리 이탈로 메인의 current branch가 sub-agent 브랜치로 switch되면, 오염된 HEAD 위에서 후속 dispatch의 worktree base가 잘못 잡히고 머지 경로가 어긋난다. 가드 명령과 복구 절차는 이 절이 단일 출처이며, **언제 실행하는가**는 각 단계 문서가 정한다 — 매 sub-agent 완료 알림 직후(`worktree-lifecycle.md`), 매 머지 직후(위 §표준 절차 5 머지 직후 가드), 자율 루프의 `assert_topology()`(`autonomous-driving.md`).
+메인은 항상 epic 브랜치의 메인 working tree에 있어야 한다. 머지 명령이나 sub-agent의 격리 이탈로 메인의 current branch가 sub-agent 브랜치로 switch되면, 오염된 HEAD 위에서 후속 dispatch의 worktree base가 잘못 잡히고 머지 경로가 어긋난다. 가드 명령과 복구 절차는 이 절이 단일 출처이며, **언제 실행하는가**는 각 단계 문서가 정한다 — 매 sub-agent 완료 알림 직후(`worktree-lifecycle.md`), 매 머지 직후(위 §표준 절차 5 머지 직후 가드), 자율 루프의 `assert_topology()`(`autonomous-driving.md`). 매 worktree dispatch 직후에는 **생성 검증이 추가된** 별도 가드가 돈다 — 검사 항목과 절차는 `worktree-lifecycle.md §dispatch 생성 가드`가 단일 출처이고, 거기서 오염이 발견되면 복구는 이 절을 따른다.
 
 ```bash
 git branch --show-current    # epic/<name> 이어야 함

--- a/plugins/atelier/skills/orchestrator/references/worktree-lifecycle.md
+++ b/plugins/atelier/skills/orchestrator/references/worktree-lifecycle.md
@@ -54,15 +54,46 @@ S = files_A ∩ files_B
 if S and not all_hot_spot(S):     # S 가 전부 hot-spot 이면 병렬 유지 +
     → 순차로 전환 (worktree 병렬 X)  #   통합 task 분리 (branch-strategy.md §hot-spot 파일)
 
-# Dispatch (worktree base는 자동 보장되지 않음 — prompt에 base 확인·동기화 지시 포함)
+# Dispatch — 직렬로, 한 메시지에 하나씩 (같은 tool-call batch에 worktree dispatch를
+# 2개 이상 싣지 않는다 — 아래 §dispatch 생성 가드. base는 자동 보장되지 않음 —
+# prompt에 base 확인·동기화 지시 포함)
+before = snapshot(`git worktree list --porcelain`)
 Agent({description: "task A", isolation: "worktree", run_in_background: true,
        prompt: "<자기완결, epic 브랜치 이름 포함>"})
+assert_worktree_created(before)   # 생성 확인 후에야 다음 dispatch
+
+before = snapshot(`git worktree list --porcelain`)
 Agent({description: "task B", isolation: "worktree", run_in_background: true,
        prompt: "<자기완결, epic 브랜치 이름 포함>"})
+assert_worktree_created(before)
 
 # 메인은 epic 브랜치에서 다른 일 진행 또는 사용자 응대
+# (직렬화되는 것은 dispatch 행위뿐이다 — agent들은 background에서 여전히 병렬로 돈다)
 # 완료 알림 자동 도착 — sleep/poll 금지
 ```
+
+---
+
+## dispatch 생성 가드 (assert_worktree_created — 단일 출처)
+
+동일 tool-call batch에서 worktree-isolated agent를 2개 이상 동시 생성하면, worktree 생성이 직렬화되지 않아 한쪽이 누락되는 race가 알려져 있다. worktree를 받지 못한 agent는 **메인 working tree에서 직접 편집·커밋**해 격리 계약이 깨지고, 메인 shell cwd가 다른 agent의 worktree로 drift하는 부수효과도 관찰됐다. 완료 알림 시점의 토폴로지 가드로는 늦다 — 유출이 이미 커밋된 뒤다. 그래서 dispatch 시점에 두 가지를 지킨다:
+
+1. **직렬화**: worktree dispatch는 **한 메시지에 하나씩**. 이전 dispatch의 worktree 생성을 확인한 뒤에야 다음을 dispatch한다. 병렬성은 잃지 않는다 — `run_in_background: true` agent는 dispatch가 직렬이어도 실행은 병렬이다.
+2. **생성 검증**: 매 dispatch 직후 메인이 직접 Bash로 확인한다:
+
+```bash
+git worktree list --porcelain   # dispatch 전 스냅샷 대비 새 worktree가 실제 추가됐는가
+git status --short              # 메인 working tree가 여전히 clean인가
+git rev-parse --show-toplevel   # 메인 shell cwd가 메인 working tree인가 (worktree로 drift 감지)
+```
+
+위반 시 처리 (셋 중 하나라도):
+
+- **새 worktree 미등장** → 해당 agent가 격리 없이 돌고 있을 수 있다. **후속 dispatch를 중단**하고 해당 agent를 정지시킨 뒤 메인 working tree 오염 여부를 확인한다. 자율 모드면 hard stop이다 (`autonomous-driving.md §에스컬레이션` 조건 2와 동급 — 토폴로지 위반).
+- **메인 not clean** → 유출이 이미 시작된 것. 즉시 위와 동일하게 중단하고, 변경은 버리지 않고 보존한다 — 복구 절차는 `merge-coordinator.md §토폴로지 가드`가 단일 출처다.
+- **cwd drift** → 메인 working tree로 복귀 후 재검증한다 (오염 검사를 worktree 안에서 하면 결과가 그 worktree 것으로 바뀌어 가드 자체가 무의미해진다).
+
+주의: 검증 기준은 **worktree 등장 + 메인 clean + cwd**다. 규약 브랜치(`epic/<name>/t*`)는 agent가 작업 시작 후 스스로 전환하므로 dispatch 직후에는 아직 없을 수 있다 — 브랜치 존재를 생성 검증 기준으로 삼지 않는다.
 
 ---
 
@@ -110,6 +141,7 @@ Agent({description: "task B", isolation: "worktree", run_in_background: true,
 4. **worktree 누수**: 결과를 받은 뒤 머지/폐기 결정을 안 하고 방치 → 디스크/git 상태 오염.
 5. **epic 브랜치 아닌 곳에서 dispatch**: main이나 임의 feature 브랜치에서 worktree sub-agent 호출 → worktree base가 epic이 아니게 되어 결과 머지 경로가 어긋남.
 6. **완료 알림 후 가드 생략**: sub-agent 완료 직후 메인 branch/status 확인 없이 다음 단계 진행 → sub-agent의 격리 이탈(Edit 절대경로 트랩 등)로 변형된 메인 state 위에서 후속 작업이 진행됨.
+7. **단일 batch 다중 worktree dispatch**: 한 메시지(tool-call batch)에 worktree-isolated dispatch를 2개 이상 → 생성 race로 한쪽 worktree가 누락되고 그 agent의 편집이 메인 트리로 유출. 직렬 dispatch + 생성 가드 필수 (§dispatch 생성 가드).
 
 ---
 
@@ -123,9 +155,11 @@ Agent({description: "task B", isolation: "worktree", run_in_background: true,
 - [ ] disjoint가 명확한가? (의심스러우면 순차)
 - [ ] 각 sub-agent prompt가 자기완결적이며 epic 브랜치 이름과 `epic/<name>/t<task-id>-<slug>` 전환 지시를 포함하는가?
 - [ ] `isolation: "worktree"`와 `run_in_background: true`를 켰는가?
+- [ ] worktree dispatch를 한 메시지에 하나씩 싣고 있는가? (같은 batch 다중 dispatch 금지 — §dispatch 생성 가드)
 
 dispatch 후:
 
+- [ ] 매 dispatch 직후 생성 가드를 실행했는가? (worktree 등장 + 메인 clean + cwd — §dispatch 생성 가드)
 - [ ] 완료 알림을 기다리는 중에 sleep/poll을 하고 있지 않은가?
 - [ ] 완료 알림 수신 직후 토폴로지 가드를 실행했는가? (`merge-coordinator.md §토폴로지 가드`)
 - [ ] 각 결과의 worktree 상태(변경 유무)를 파악했는가?


### PR DESCRIPTION
## 배경

#808 — autonomous 모드에서 동일 tool-call batch에 `isolation:"worktree"` agent를 2개 이상 동시 dispatch하면 worktree 생성 race로 한쪽 worktree가 누락되고, 그 agent의 편집이 메인 working tree로 유출되는 사고. 기존 토폴로지 가드(완료 알림 직후 + 머지 직후)로는 유출이 커밋된 뒤에야 잡힌다.

## 변경 내용

이슈의 제안 4건을 모두 오케스트레이터 지침 레벨에서 반영:

- **`worktree-lifecycle.md`**: `§dispatch 생성 가드` 신설 (단일 출처)
  - worktree dispatch **직렬화** — 한 메시지에 하나씩, 이전 dispatch의 생성 확인 후 다음 진행 (background 실행은 여전히 병렬)
  - 매 dispatch 직후 **생성 검증** — `git worktree list --porcelain` 스냅샷 대조 + 메인 clean + cwd drift 확인. 위반 시 후속 dispatch 중단, 자율 모드면 hard stop
  - 규약 브랜치는 dispatch 직후 아직 없을 수 있으므로 검증 기준에서 제외 (오탐 방지)
  - 병렬 dispatch 예시 갱신 + 안티패턴 7번(단일 batch 다중 worktree dispatch) + 체크리스트 항목 추가
- **`autonomous-driving.md`**: 자율 루프 의사코드·토폴로지 가드 절·안티패턴 7번·체크리스트에 dispatch-직후 시점 반영
- **`merge-coordinator.md`**: `§토폴로지 가드` 실행 시점 목록에 dispatch-직후 가드 참조 추가 (검사 절차는 worktree-lifecycle, 오염 복구는 기존대로 이 문서가 단일 출처)

## 검증

- `make validate-ci` 통과 — 162 passed, 실패 0 (경고 1건은 본 변경과 무관한 `git/SKILL.md` 기존 경고)

Closes #808

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwssWqSQZ6NtBcfJF7HrhG)_